### PR TITLE
feat(theme): add light and dark mode tokens, CSS variables, and spec

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { WalletProvider } from './context/WalletContext'
+import { ThemeProvider } from './context/ThemeContext'
 import Layout from './components/Layout'
 import Home from './pages/Home'
 import Vaults from './pages/Vaults'
@@ -7,16 +8,18 @@ import CreateVault from './pages/CreateVault'
 
 export default function App() {
   return (
-    <WalletProvider>
-      <BrowserRouter>
-        <Layout>
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/vaults" element={<Vaults />} />
-            <Route path="/vaults/create" element={<CreateVault />} />
-          </Routes>
-        </Layout>
-      </BrowserRouter>
-    </WalletProvider>
+    <ThemeProvider>
+      <WalletProvider>
+        <BrowserRouter>
+          <Layout>
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/vaults" element={<Vaults />} />
+              <Route path="/vaults/create" element={<CreateVault />} />
+            </Routes>
+          </Layout>
+        </BrowserRouter>
+      </WalletProvider>
+    </ThemeProvider>
   )
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from 'react-router-dom'
 import { WalletConnectButton } from './Wallet/WalletConnectButton'
+import ThemeToggle from './ThemeToggle'
 
 interface LayoutProps {
   children: React.ReactNode
@@ -51,6 +52,7 @@ export default function Layout({ children }: LayoutProps) {
             >
               Create Vault
             </Link>
+            <ThemeToggle />
             <WalletConnectButton />
           </div>
         </nav>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,71 @@
+import { useTheme } from '../context/ThemeContext';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+      style={{
+        background: 'transparent',
+        border: '1px solid var(--border)',
+        borderRadius: '9999px',
+        width: '2.5rem',
+        height: '2.5rem',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: 'pointer',
+        color: 'var(--text)',
+        transition: 'all 0.2s ease',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.background = 'var(--hover)';
+        e.currentTarget.style.borderColor = 'var(--accent)';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = 'transparent';
+        e.currentTarget.style.borderColor = 'var(--border)';
+      }}
+    >
+      {theme === 'light' ? (
+        // Moon icon for dark mode
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      ) : (
+        // Sun icon for light mode
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="5" />
+          <line x1="12" y1="1" x2="12" y2="3" />
+          <line x1="12" y1="21" x2="12" y2="23" />
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+          <line x1="1" y1="12" x2="3" y2="12" />
+          <line x1="21" y1="12" x2="23" y2="12" />
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,72 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const THEME_STORAGE_KEY = 'disciplr-theme';
+
+function getSystemTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function getStoredTheme(): Theme | null {
+  if (typeof window === 'undefined') return null;
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  return stored === 'light' || stored === 'dark' ? stored : null;
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const stored = getStoredTheme();
+    if (stored) return stored;
+    return getSystemTheme();
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.setAttribute('data-theme', theme);
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }, [theme]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (e: MediaQueryListEvent) => {
+      // Only auto‑switch if user hasn't manually selected a theme
+      if (!getStoredTheme()) {
+        setThemeState(e.matches ? 'dark' : 'light');
+      }
+    };
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  const toggleTheme = () => {
+    setThemeState((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  const setTheme = (newTheme: Theme) => {
+    setThemeState(newTheme);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,14 +1,77 @@
 :root {
-  --bg: #0a0e17;
-  --surface: #121a2a;
-  --border: #1e2d42;
-  --text: #e8edf5;
-  --muted: #6b7a8f;
-  --accent: #00c389;
-  --accent-dim: #00996e;
-  --danger: #e5534b;
+  /* Light theme (default) */
+  --bg: #F9FAFB;
+  --surface: #F3F4F6;
+  --surface-raised: #E5E7EB;
+  --border: #E5E7EB;
+  --text: #111827;
+  --muted: #4B5563;
+  --accent: #00C389;
+  --accent-dim: #00996E;
+  --accent-transparent: rgba(0, 195, 137, 0.1);
+  --hover: #E5E7EB;
+  --danger: #DC2626;
+  --success: #059669;
+  --warning: #D97706;
+  --info: #2563EB;
   --radius: 10px;
   --font-sans: 'DM Sans', system-ui, sans-serif;
+}
+
+/* Dark theme - auto if OS prefers dark */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #111827;
+    --surface: #1F2937;
+    --surface-raised: #374151;
+    --border: #4B5563;
+    --text: #F9FAFB;
+    --muted: #9CA3AF;
+    --accent: #14B8A6;
+    --accent-dim: #0D9488;
+    --accent-transparent: rgba(20, 184, 166, 0.1);
+    --hover: #374151;
+    --danger: #EF4444;
+    --success: #10B981;
+    --warning: #F59E0B;
+    --info: #60A5FA;
+  }
+}
+
+/* Manual dark theme override (if user selects dark) */
+:root[data-theme="dark"] {
+  --bg: #111827;
+  --surface: #1F2937;
+  --surface-raised: #374151;
+  --border: #4B5563;
+  --text: #F9FAFB;
+  --muted: #9CA3AF;
+  --accent: #14B8A6;
+  --accent-dim: #0D9488;
+  --accent-transparent: rgba(20, 184, 166, 0.1);
+  --hover: #374151;
+  --danger: #EF4444;
+  --success: #10B981;
+  --warning: #F59E0B;
+  --info: #60A5FA;
+}
+
+/* Manual light theme override (if user selects light) */
+:root[data-theme="light"] {
+  --bg: #F9FAFB;
+  --surface: #F3F4F6;
+  --surface-raised: #E5E7EB;
+  --border: #E5E7EB;
+  --text: #111827;
+  --muted: #4B5563;
+  --accent: #0A7668;
+  --accent-dim: #095C4F;
+  --accent-transparent: rgba(10, 118, 104, 0.1);
+  --hover: #E5E7EB;
+  --danger: #DC2626;
+  --success: #059669;
+  --warning: #D97706;
+  --info: #2563EB;
 }
 
 * {


### PR DESCRIPTION
## Summary

Implements a light and dark theme foundation using semantic design tokens and CSS variables. Adds support for system preference and manual theme override.

## Changes

* Introduced semantic color tokens for `--surface`, `--text`, `--border`, `--accent`, and `--muted` (light/dark)
* Added CSS variable system with `prefers-color-scheme` support
* Enabled manual override via `data-theme` attribute
* Integrated `ThemeContext` and `ThemeToggle` for runtime switching
* Updated core layout/components to consume tokens
* Added theme documentation in `design-system/docs/theme-spec.md`

## Accessibility

* Verified key color pairs meet WCAG 2.1 AA contrast requirements

## Visuals

* Included before/after screenshots for light and dark modes

## Notes

* Backward compatible with existing variable usage
* UI adoption is incremental and limited to core components in this PR


Proofs : 

<img width="1916" height="875" alt="Screenshot 2026-04-24 014647" src="https://github.com/user-attachments/assets/c98eb2fe-5035-40df-80db-63cc76378dcc" />
<img width="1918" height="872" alt="Screenshot 2026-04-24 014653" src="https://github.com/user-attachments/assets/dc806d96-e617-49c0-9f65-47fbffa501c8" />




Closes #29 