### PR TITLE
design: design QA checklist and regression targets

### DIFF
--- a/design/qa/DESIGN_QA_CHECKLIST.md
+++ b/design/qa/DESIGN_QA_CHECKLIST.md
@@ -1,0 +1,281 @@
+# Design QA Checklist — Disciplr Frontend
+
+**Standard:** WCAG 2.1 AA (default theme, both light and dark)  
+**Owner:** Design + Engineering  
+**Cadence:** Every PR that touches `src/pages/`, `src/components/`, `src/index.css`, or `design-system/tokens/`  
+**Branch convention:** `design/qa-checklist-visual-regression`
+
+---
+
+## How to use this checklist
+
+Copy the relevant section(s) into your PR description and check each item before requesting review. Mark items `N/A` only when the surface genuinely has no such element (e.g. a page with no modals).
+
+Legend: ✅ Pass · ❌ Fail (block) · ⚠️ Fail (warn, document gap) · N/A
+
+---
+
+## 1. Contrast — Text & UI Components
+
+Target: **4.5 : 1** for normal text, **3 : 1** for large text (≥ 18 px regular / ≥ 14 px bold) and UI components.
+
+Use [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) or the browser DevTools accessibility panel.
+
+### Token reference (from `design-system/tokens/colors.json` + `src/index.css`)
+
+| Token pair | Light ratio | Dark ratio | AA? |
+|---|---|---|---|
+| `--text` (#111827) on `--bg` (#F9FAFB) | ~16 : 1 | — | ✅ |
+| `--text` (#F9FAFB) on `--bg` (#111827) | — | ~16 : 1 | ✅ |
+| `--muted` (#4B5563) on `--bg` (#F9FAFB) | ~7.0 : 1 | — | ✅ |
+| `--muted` (#9CA3AF) on `--bg` (#111827) | — | ~3.9 : 1 | ⚠️ borderline AA |
+| `--accent` (#0A7668) on `--bg` (#F9FAFB) | ~4.5 : 1 | — | ✅ |
+| `--accent` (#14B8A6) on `--bg` (#111827) | — | ~3.1 : 1 | ⚠️ large text only |
+| `--danger` (#DC2626) on `--bg` (#F9FAFB) | ~4.6 : 1 | — | ✅ |
+| `--danger` (#EF4444) on `--bg` (#111827) | — | ~4.0 : 1 | ✅ |
+| `--warning` (#D97706) on `--bg` (#F9FAFB) | ~3.1 : 1 | — | ⚠️ large text only |
+| `--warning` (#F59E0B) on `--bg` (#111827) | — | ~3.5 : 1 | ⚠️ large text only |
+| Button text (`--bg`) on `--accent` (light) | ~4.5 : 1 | — | ✅ |
+| Status badge text on badge bg | verify per badge | verify per badge | — |
+
+> **Known gap (dark mode):** `--muted` on `--bg` in dark theme is ~3.9 : 1. Acceptable for secondary/caption text only if font-size ≥ 18 px or bold ≥ 14 px. Flag any body-weight muted text smaller than 18 px as a fail.
+
+### Per-page contrast checks
+
+#### Home (`/`)
+- [ ] Hero headline (`--text` on `--bg`) ≥ 4.5 : 1
+- [ ] Subheading / description text ≥ 4.5 : 1
+- [ ] CTA button label on button background ≥ 4.5 : 1
+- [ ] Link text in body copy ≥ 4.5 : 1
+
+#### Vaults (`/vaults`)
+- [ ] Vault name (bold body) ≥ 4.5 : 1
+- [ ] Deadline caption (`--muted`) — verify size; if < 18 px regular, must be ≥ 4.5 : 1
+- [ ] Amount text (`--accent`) on `--surface` ≥ 3 : 1 (large/bold) or 4.5 : 1 (normal)
+- [ ] Status badge: each status color on its background ≥ 3 : 1
+  - [ ] Active (accent on accent-transparent)
+  - [ ] Completed (success on success-transparent)
+  - [ ] Failed (danger on danger-transparent)
+  - [ ] Cancelled (muted on muted-transparent)
+  - [ ] Pending Validation (warning on warning-transparent)
+- [ ] "+ Create Vault" button label on `--accent` ≥ 4.5 : 1
+
+#### Create Vault (`/vaults/create`)
+- [ ] Form label text ≥ 4.5 : 1
+- [ ] Input placeholder text (`--muted`) ≥ 3 : 1 (placeholders are informational, not required AA)
+- [ ] Input value text on `--surface` ≥ 4.5 : 1
+- [ ] Input border (`--border`) on `--bg` ≥ 3 : 1 (UI component)
+- [ ] Submit button label on `--accent` ≥ 4.5 : 1
+- [ ] Error message text on background ≥ 4.5 : 1
+
+#### Dashboard (`/dashboard`)
+- [ ] All stat/metric values ≥ 4.5 : 1
+- [ ] Chart labels and axis text ≥ 4.5 : 1
+- [ ] Table header text ≥ 4.5 : 1
+- [ ] Table row text ≥ 4.5 : 1
+
+#### Vault Detail (`/vaults/:id`)
+- [ ] Vault title ≥ 4.5 : 1
+- [ ] All metadata labels and values ≥ 4.5 : 1
+- [ ] Transaction list text ≥ 4.5 : 1
+- [ ] Action button labels ≥ 4.5 : 1
+
+#### Vault Transactions (`/vaults/:id/transactions`)
+- [ ] Transaction amount (positive/negative colors) ≥ 4.5 : 1 on background
+- [ ] Date/time text ≥ 4.5 : 1
+- [ ] Status indicators ≥ 3 : 1
+
+#### Notifications (`/notifications`)
+- [ ] Notification title ≥ 4.5 : 1
+- [ ] Notification body text ≥ 4.5 : 1
+- [ ] Timestamp (`--muted`) — verify size
+
+#### Notification Settings (`/notifications/settings`)
+- [ ] Setting label text ≥ 4.5 : 1
+- [ ] Toggle/checkbox labels ≥ 4.5 : 1
+- [ ] Description/helper text ≥ 4.5 : 1
+
+#### Modals (all)
+- [ ] Modal title ≥ 4.5 : 1 on modal background
+- [ ] Modal body text ≥ 4.5 : 1
+- [ ] Confirm/destructive button label ≥ 4.5 : 1
+- [ ] Cancel button label ≥ 4.5 : 1
+- [ ] Close (×) icon button — icon color on modal background ≥ 3 : 1
+
+---
+
+## 2. Focus Management
+
+All interactive elements must have a **visible focus indicator** that meets WCAG 2.1 AA (3 : 1 contrast between focused and unfocused state, or a 2 px outline with sufficient offset).
+
+### Global
+- [ ] Tab through the entire page — every interactive element receives focus in logical DOM order
+- [ ] Focus ring is visible on all interactive elements (no `outline: none` without a custom replacement)
+- [ ] Focus ring color contrasts ≥ 3 : 1 against adjacent background
+- [ ] Skip-to-main-content link present and functional (first focusable element)
+
+### Per-page focus order
+
+#### Home
+- [ ] Nav links → CTA button → footer links (logical order)
+
+#### Vaults
+- [ ] "Create Vault" button reachable by keyboard
+- [ ] Each vault card is focusable and activatable with Enter/Space
+- [ ] Focus order: header → create button → vault list items → pagination (if any)
+
+#### Create Vault
+- [ ] Form fields tab in visual top-to-bottom order
+- [ ] Submit button is last in tab order within the form
+- [ ] Required field errors announced to screen reader on submit
+
+#### Dashboard
+- [ ] Chart elements: if interactive, keyboard accessible; if decorative, `aria-hidden="true"`
+- [ ] Table rows: if clickable, focusable with Enter/Space
+
+#### Vault Detail / Transactions
+- [ ] Action buttons reachable and operable by keyboard
+- [ ] "Back" navigation reachable
+
+#### Modals
+- [ ] Focus moves into modal on open (first focusable element or modal title)
+- [ ] Focus is **trapped** inside modal while open
+- [ ] Escape key closes modal
+- [ ] Focus returns to trigger element on close
+- [ ] Modal has `role="dialog"` and `aria-labelledby` pointing to title
+
+#### Notification Settings
+- [ ] Toggle controls operable with Space
+- [ ] Grouped settings have `fieldset`/`legend` or equivalent `role="group"` + `aria-labelledby`
+
+---
+
+## 3. Breakpoints
+
+Test at these viewport widths. Use browser DevTools device emulation.
+
+| Breakpoint | Width | Device proxy |
+|---|---|---|
+| xs (mobile) | 375 px | iPhone SE |
+| sm | 640 px | CSS `@media (min-width: 640px)` boundary |
+| md | 768 px | iPad portrait |
+| lg | 1024 px | iPad landscape / small laptop |
+| xl | 1280 px | Desktop |
+| 2xl | 1440 px | Wide desktop |
+
+### Layout checks (all pages)
+
+- [ ] No horizontal scroll at any breakpoint (except intentional horizontal scroll containers)
+- [ ] Navigation collapses or adapts correctly on mobile
+- [ ] Touch targets ≥ 44 × 44 px on mobile (xs, sm) — verify buttons, links, vault cards
+- [ ] Text does not overflow containers or truncate unexpectedly
+- [ ] Images/icons scale proportionally
+- [ ] Spacing tokens (`--spacing-*`) produce comfortable density at each breakpoint
+
+### Per-page breakpoint checks
+
+#### Home
+- [ ] Hero layout stacks vertically on xs/sm
+- [ ] CTA button full-width or appropriately sized on mobile
+
+#### Vaults
+- [ ] Vault card layout: amount + status badge wrap gracefully on xs
+- [ ] "Create Vault" button accessible on mobile (not hidden behind overflow)
+
+#### Create Vault
+- [ ] Form max-width (400 px) respected; full-width on xs
+- [ ] Labels and inputs readable at all breakpoints
+
+#### Dashboard
+- [ ] Stat cards reflow to single column on xs/sm
+- [ ] Charts resize without clipping labels
+
+#### Vault Detail / Transactions
+- [ ] Transaction table scrolls horizontally if needed (not clipped)
+- [ ] Action buttons stack on mobile
+
+#### Modals
+- [ ] Modal width ≤ viewport width − 32 px on xs
+- [ ] Modal content scrollable if taller than viewport
+
+---
+
+## 4. Motion & Animation
+
+Reference: `design-system/tokens/motion.json`, `src/index.css` (`prefers-reduced-motion`).
+
+### Global
+- [ ] `@media (prefers-reduced-motion: reduce)` collapses all `--duration-*` tokens to `1ms`
+- [ ] `*, *::before, *::after` transition/animation durations set to `1ms !important` under reduced-motion
+- [ ] Framer Motion components use `useReducedMotion()` hook and skip or simplify animations when true
+- [ ] No animation loops indefinitely without user control (WCAG 2.2.2)
+- [ ] No content flashes more than 3 times per second (WCAG 2.3.1)
+
+### Per-surface motion checks
+
+#### Page transitions
+- [ ] Route change animation ≤ 300 ms (normal motion)
+- [ ] Route change animation ≤ 1 ms (reduced motion)
+
+#### Vault card hover
+- [ ] Border-color transition ≤ 150 ms (normal)
+- [ ] Transition disabled under reduced-motion
+
+#### Modals
+- [ ] Open/close animation ≤ 200 ms (normal)
+- [ ] No animation under reduced-motion (instant show/hide)
+
+#### Notifications
+- [ ] Toast/notification slide-in ≤ 300 ms
+- [ ] Instant under reduced-motion
+
+#### Loading states / spinners
+- [ ] Spinner animation pauses or is replaced with static indicator under reduced-motion
+
+---
+
+## 5. Screen Reader Smoke Test
+
+Run with VoiceOver (macOS/iOS) or NVDA (Windows). Test the happy path for each flow.
+
+- [ ] **Home:** Page title announced; CTA button label meaningful
+- [ ] **Vaults list:** Each vault card announces name, amount, status, and deadline
+- [ ] **Create Vault:** Form labels associated with inputs; required fields announced; error messages announced on submit
+- [ ] **Vault Detail:** Vault title, status, and action buttons announced
+- [ ] **Modals:** Dialog role, title, and close button announced; focus trap confirmed
+- [ ] **Notifications:** Each notification item announces title and body
+- [ ] **Theme toggle:** Button announces current state ("Switch to dark mode" / "Switch to light mode")
+
+---
+
+## 6. Dark Mode Gaps (document, do not block)
+
+The following are known or likely gaps in dark mode. Document findings here; they do not block release unless contrast fails AA.
+
+| Surface | Gap | Severity |
+|---|---|---|
+| `--muted` text < 18 px on dark `--bg` | ~3.9 : 1 (borderline) | ⚠️ Warn |
+| `--accent` (#14B8A6) on dark `--bg` | ~3.1 : 1 (large text only) | ⚠️ Warn |
+| `--warning` badge text on dark bg | verify per instance | TBD |
+| Status badge borders in dark mode | verify per instance | TBD |
+
+---
+
+## 7. Figma / Spec Traceability
+
+Each checked item should be traceable to a Figma frame or design-system token.
+
+- [ ] Link Figma file URL in PR description
+- [ ] Reference Figma node IDs for any new or changed components
+- [ ] Confirm token names in code match token names in `design-system/tokens/*.json`
+- [ ] Note any token updates needed in `design-system/tokens/*.json` in the PR description
+
+---
+
+## Sign-off
+
+| Role | Name | Date | Status |
+|---|---|---|---|
+| Design | | | |
+| Engineering | | | |
+| Accessibility | | | |

--- a/design/qa/RELEASE_GATE.md
+++ b/design/qa/RELEASE_GATE.md
@@ -1,0 +1,225 @@
+# Release Gate — Design-Approved Builds
+
+**Purpose:** Define the minimum pass/fail criteria that must be satisfied before a build is considered design-approved and eligible to merge to `main`.  
+**Applies to:** Any PR that touches `src/`, `design-system/`, `index.html`, or `public/`.  
+**Owner:** Design lead signs off; Engineering lead confirms CI gates.  
+**Timeframe:** Review must complete within 96 hours of PR opening.
+
+---
+
+## Gate summary
+
+| Gate | Type | Blocks merge? |
+|---|---|---|
+| G1 — Contrast (WCAG 2.1 AA) | Hard | ✅ Yes |
+| G2 — Focus management | Hard | ✅ Yes |
+| G3 — Touch targets | Hard | ✅ Yes |
+| G4 — No horizontal overflow | Hard | ✅ Yes |
+| G5 — Reduced-motion compliance | Hard | ✅ Yes |
+| G6 — Visual regression (Percy/Chromatic) | Hard | ✅ Yes (unapproved diffs) |
+| G7 — Screen reader smoke test | Hard | ✅ Yes (critical flows) |
+| G8 — Token alignment | Hard | ✅ Yes |
+| G9 — Dark mode contrast gaps | Soft | ⚠️ No (document only) |
+| G10 — Figma traceability | Soft | ⚠️ No (must document) |
+| G11 — Design critique sign-off | Soft | ⚠️ No (async OK) |
+
+---
+
+## Hard gates (block merge)
+
+### G1 — Contrast (WCAG 2.1 AA)
+
+**Pass:** Every text/UI element listed in `DESIGN_QA_CHECKLIST.md §1` meets its required ratio.
+
+**Fail criteria (any one fails the gate):**
+- Normal text (< 18 px regular, < 14 px bold) below **4.5 : 1**
+- Large text (≥ 18 px regular or ≥ 14 px bold) below **3 : 1**
+- UI component (button border, input border, focus ring) below **3 : 1**
+- Status badge text on badge background below **3 : 1**
+
+**How to verify:** WebAIM Contrast Checker, browser DevTools accessibility panel, or `axe-core` in CI.
+
+**Exception process:** If a token value must change to pass, update `design-system/tokens/colors.json` and `src/index.css` in the same PR. Tag the token change in the PR description.
+
+---
+
+### G2 — Focus management
+
+**Pass:** All interactive elements receive visible focus; modals trap focus; focus returns to trigger on close.
+
+**Fail criteria:**
+- Any interactive element unreachable by keyboard
+- Any interactive element with no visible focus indicator
+- Modal does not trap focus
+- Focus does not return to trigger after modal close
+- Form errors not announced to screen reader on submit
+
+---
+
+### G3 — Touch targets
+
+**Pass:** All interactive elements on mobile viewports (≤ 640 px) have a minimum hit area of **44 × 44 px**.
+
+**Fail criteria:**
+- Any button, link, or control with a rendered hit area smaller than 44 × 44 px at 375 px viewport
+- The `--touch-target: 44px` CSS variable is overridden to a smaller value without design approval
+
+---
+
+### G4 — No horizontal overflow
+
+**Pass:** No page produces a horizontal scrollbar at any tested viewport (375, 640, 768, 1024, 1280 px).
+
+**Fail criteria:**
+- `document.documentElement.scrollWidth > window.innerWidth` at any breakpoint
+- Any element visually clips outside the viewport
+
+**Quick test:**
+```js
+// Paste in DevTools console
+document.querySelectorAll('*').forEach(el => {
+  if (el.offsetWidth > document.documentElement.offsetWidth) {
+    console.warn('Overflow:', el);
+  }
+});
+```
+
+---
+
+### G5 — Reduced-motion compliance
+
+**Pass:** Under `prefers-reduced-motion: reduce`, all animation durations collapse to ≤ 1 ms and no content flashes > 3 times/second.
+
+**Fail criteria:**
+- Any CSS transition or animation duration > 1 ms under reduced-motion
+- Any Framer Motion component that does not check `useReducedMotion()`
+- Any looping animation that cannot be paused by the user
+
+**How to verify:** Enable "Emulate CSS media feature prefers-reduced-motion" in DevTools → Rendering panel.
+
+---
+
+### G6 — Visual regression (Percy/Chromatic)
+
+**Pass:** All Percy/Chromatic diffs on the PR have been reviewed and **explicitly approved** by the design lead.
+
+**Fail criteria:**
+- Any unreviewed diff (Percy/Chromatic shows "Changes detected" without approval)
+- Percy/Chromatic CI check is red
+
+**Exception:** If Percy/Chromatic is not yet configured, the manual snapshot list in `VISUAL_REGRESSION_TARGETS.md` must be completed and attached to the PR as before/after screenshots. Design lead must comment "✅ visual approved" on the PR.
+
+---
+
+### G7 — Screen reader smoke test
+
+**Pass:** The critical flows listed below complete without errors using VoiceOver (macOS) or NVDA (Windows).
+
+**Critical flows (must pass):**
+1. Navigate to Vaults list — each vault card announces name, amount, status
+2. Open Create Vault form — all labels announced; submit with empty fields announces errors
+3. Open and close a modal — dialog role announced; focus trap confirmed; focus returns to trigger
+4. Toggle theme — button state announced
+
+**Fail criteria:**
+- Any critical flow item above fails
+- A form input has no associated label
+- A modal lacks `role="dialog"` and `aria-labelledby`
+
+---
+
+### G8 — Token alignment
+
+**Pass:** All color, spacing, typography, and motion values used in code reference CSS variables or token values defined in `design-system/tokens/*.json`. No hardcoded hex values, pixel sizes, or durations outside the token system.
+
+**Fail criteria:**
+- Hardcoded color hex in component styles (e.g. `color: #14B8A6` instead of `color: var(--accent)`)
+- Hardcoded spacing in px that does not correspond to a `--spacing-*` token
+- New animation duration not defined in `design-system/tokens/motion.json`
+
+**Exception:** Third-party component overrides may use hardcoded values if the token cannot be applied. Document the exception in the PR.
+
+---
+
+## Soft gates (warn, do not block)
+
+### G9 — Dark mode contrast gaps
+
+Document any dark-mode contrast values below 4.5 : 1 for normal text in the PR description under "Dark mode gaps". These are tracked but do not block merge unless they are new regressions introduced by the PR.
+
+Known existing gaps (as of initial audit):
+- `--muted` (#9CA3AF) on dark `--bg` (#111827): ~3.9 : 1 — acceptable for caption/secondary text ≥ 18 px only
+- `--accent` (#14B8A6) on dark `--bg` (#111827): ~3.1 : 1 — acceptable for large/bold text only
+
+---
+
+### G10 — Figma traceability
+
+The PR description must include:
+- Figma file URL (or note "no Figma file — design in code")
+- Figma node IDs for any new or changed components
+- List of `design-system/tokens/*.json` files updated (or "no token changes")
+
+Missing traceability does not block merge but must be added within 48 hours of merge.
+
+---
+
+### G11 — Design critique sign-off
+
+A synchronous or async design critique (eng + design) must occur for any PR that:
+- Introduces a new page or modal
+- Changes the visual design of an existing page (not just a bug fix)
+- Updates token values
+
+Sign-off is recorded as a PR comment: "✅ design critique complete — [name], [date]".
+
+Async sign-off (Loom or annotated screenshot) is acceptable within the 96-hour window.
+
+---
+
+## PR description template
+
+Copy this into every design-touching PR:
+
+```markdown
+## Design QA
+
+### Gates
+- [ ] G1 Contrast — all items in DESIGN_QA_CHECKLIST.md §1 checked
+- [ ] G2 Focus — keyboard nav and modal focus trap verified
+- [ ] G3 Touch targets — 44×44 px minimum on mobile
+- [ ] G4 No horizontal overflow — verified at 375, 768, 1280 px
+- [ ] G5 Reduced-motion — verified with DevTools emulation
+- [ ] G6 Visual regression — Percy/Chromatic diffs approved (or manual screenshots attached)
+- [ ] G7 Screen reader — critical flows tested with VoiceOver/NVDA
+- [ ] G8 Token alignment — no hardcoded values outside token system
+
+### Soft gates
+- [ ] G9 Dark mode gaps documented (or "none")
+- [ ] G10 Figma link: <!-- paste URL -->
+- [ ] G11 Design critique: <!-- "complete — name, date" or "async — Loom link" -->
+
+### Token changes
+<!-- List any design-system/tokens/*.json changes, or "none" -->
+
+### Screenshots
+<!-- Before / after at 375 px and 1280 px, light and dark -->
+```
+
+---
+
+## Escalation
+
+If a hard gate cannot be met within the 96-hour window:
+
+1. Open a follow-up issue tagged `design-debt` with the specific failure and a proposed fix.
+2. Get explicit sign-off from both design lead and engineering lead to merge with the known gap.
+3. The follow-up issue must be resolved before the next release.
+
+---
+
+## Revision history
+
+| Date | Change | Author |
+|---|---|---|
+| 2026-04-29 | Initial version | Kiro |

--- a/design/qa/VISUAL_REGRESSION_TARGETS.md
+++ b/design/qa/VISUAL_REGRESSION_TARGETS.md
@@ -1,0 +1,257 @@
+# Visual Regression Targets — Disciplr Frontend
+
+**Purpose:** Define the canonical snapshot set for automated (Percy/Chromatic) and manual visual regression testing.  
+**Branch:** `design/qa-checklist-visual-regression`  
+**Related:** `design/qa/DESIGN_QA_CHECKLIST.md`, `design/qa/RELEASE_GATE.md`
+
+---
+
+## Tool recommendation
+
+| Option | Best for | Cost |
+|---|---|---|
+| **Percy** (BrowserStack) | CI-integrated, per-diff pricing, good Vite support | Free tier: 5 000 snapshots/mo |
+| **Chromatic** (Storybook) | Component-level isolation, Storybook-native | Free tier: 5 000 snapshots/mo |
+| **Manual screenshots** | No CI budget, quick audits | Free |
+
+**Recommendation for Disciplr:** Start with Percy for page-level snapshots (no Storybook required). Add Chromatic later when a component library is formalized.
+
+---
+
+## Option A — Percy (page-level, recommended)
+
+### 1. Install
+
+```bash
+npm install --save-dev @percy/cli @percy/playwright
+# or, if using Cypress:
+npm install --save-dev @percy/cli @percy/cypress
+```
+
+### 2. Set Percy token
+
+```bash
+# .env.local (never commit)
+PERCY_TOKEN=your_percy_project_token
+```
+
+Add to CI secrets (GitHub Actions: `Settings → Secrets → PERCY_TOKEN`).
+
+### 3. GitHub Actions workflow
+
+Create `.github/workflows/visual-regression.yml`:
+
+```yaml
+name: Visual Regression
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'design-system/**'
+      - 'index.css'
+
+jobs:
+  percy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Percy snapshot
+        run: npx percy snapshot ./dist --base-url /
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+```
+
+> For dynamic pages (auth-gated, data-driven), use Percy with Playwright to navigate and snapshot each route. See Option A-2 below.
+
+### 4. Percy + Playwright script (dynamic pages)
+
+Create `tests/visual/snapshots.ts`:
+
+```typescript
+import { test } from '@playwright/test';
+import { percySnapshot } from '@percy/playwright';
+
+const VIEWPORTS = [
+  { name: 'mobile', width: 375, height: 812 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'desktop', width: 1280, height: 800 },
+];
+
+const ROUTES = [
+  { path: '/',                          name: 'Home' },
+  { path: '/vaults',                    name: 'Vaults' },
+  { path: '/vaults/create',             name: 'CreateVault' },
+  { path: '/dashboard',                 name: 'Dashboard' },
+  { path: '/vaults/1',                  name: 'VaultDetail' },
+  { path: '/vaults/1/transactions',     name: 'VaultTransactions' },
+  { path: '/notifications',             name: 'Notifications' },
+  { path: '/notifications/settings',    name: 'NotificationSettings' },
+];
+
+for (const viewport of VIEWPORTS) {
+  test.describe(`${viewport.name} (${viewport.width}px)`, () => {
+    test.use({ viewport: { width: viewport.width, height: viewport.height } });
+
+    for (const route of ROUTES) {
+      test(`${route.name}`, async ({ page }) => {
+        await page.goto(route.path);
+        await page.waitForLoadState('networkidle');
+        await percySnapshot(page, `${route.name} — ${viewport.name}`);
+      });
+    }
+
+    // Modal states
+    test('CreateVault — validation errors', async ({ page }) => {
+      await page.goto('/vaults/create');
+      await page.click('button[type="submit"]');
+      await percySnapshot(page, `CreateVault validation errors — ${viewport.name}`);
+    });
+  });
+}
+
+// Theme variants
+test.describe('Dark theme', () => {
+  test.use({ colorScheme: 'dark' });
+  for (const route of ROUTES) {
+    test(route.name, async ({ page }) => {
+      await page.goto(route.path);
+      await page.waitForLoadState('networkidle');
+      await percySnapshot(page, `${route.name} — dark — desktop`);
+    });
+  }
+});
+```
+
+---
+
+## Option B — Chromatic (component-level)
+
+### 1. Prerequisites
+
+Chromatic requires Storybook. If Storybook is not yet set up:
+
+```bash
+npx storybook@latest init --type react_vite
+npm install --save-dev chromatic
+```
+
+### 2. Publish to Chromatic
+
+```bash
+npx chromatic --project-token=your_chromatic_token
+```
+
+### 3. GitHub Actions
+
+```yaml
+- name: Publish to Chromatic
+  uses: chromaui/action@latest
+  with:
+    projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+    exitZeroOnChanges: true   # don't fail CI; let reviewers approve
+```
+
+### 4. Stories to create (priority order)
+
+| Story | Variants |
+|---|---|
+| `VaultCard` | active, completed, failed, cancelled, pending_validation |
+| `StatusBadge` | all 5 statuses × light/dark |
+| `Button` | primary, secondary, destructive × default/hover/focus/disabled |
+| `FormInput` | default, focused, error, disabled |
+| `Modal` | open state with title + body + actions |
+| `NotificationItem` | unread, read |
+| `ThemeToggle` | light, dark |
+
+---
+
+## Manual Snapshot List
+
+Use this list when automated tooling is not available. Capture screenshots with browser DevTools at the specified viewport. Store in `design/qa/screenshots/YYYY-MM-DD/`.
+
+### Naming convention
+
+```
+{PageName}_{theme}_{viewport}_{state}.png
+```
+
+Example: `Vaults_light_375_default.png`
+
+### Required snapshots (light mode — primary)
+
+| # | Page / Surface | Viewport | State | Notes |
+|---|---|---|---|---|
+| 1 | Home | 375 | default | |
+| 2 | Home | 768 | default | |
+| 3 | Home | 1280 | default | |
+| 4 | Vaults | 375 | default (3 vaults shown) | |
+| 5 | Vaults | 1280 | default | |
+| 6 | CreateVault | 375 | empty form | |
+| 7 | CreateVault | 375 | validation errors | Submit with empty fields |
+| 8 | CreateVault | 1280 | empty form | |
+| 9 | Dashboard | 375 | default | |
+| 10 | Dashboard | 1280 | default | |
+| 11 | VaultDetail | 375 | active vault | |
+| 12 | VaultDetail | 1280 | active vault | |
+| 13 | VaultTransactions | 375 | default | |
+| 14 | VaultTransactions | 1280 | default | |
+| 15 | Notifications | 375 | unread items | |
+| 16 | Notifications | 1280 | unread items | |
+| 17 | NotificationSettings | 375 | default | |
+| 18 | NotificationSettings | 1280 | default | |
+| 19 | Modal (any) | 375 | open | |
+| 20 | Modal (any) | 1280 | open | |
+
+### Required snapshots (dark mode — note gaps)
+
+| # | Page / Surface | Viewport | State | Notes |
+|---|---|---|---|---|
+| 21 | Home | 1280 | default | |
+| 22 | Vaults | 1280 | default | Check muted text contrast |
+| 23 | CreateVault | 1280 | empty form | Check input border contrast |
+| 24 | Dashboard | 1280 | default | |
+| 25 | VaultDetail | 1280 | active vault | |
+| 26 | Notifications | 1280 | unread items | |
+| 27 | Modal (any) | 1280 | open | |
+
+### Focus state snapshots (light mode)
+
+| # | Element | Notes |
+|---|---|---|
+| 28 | Vault card (focused) | Tab to first card, screenshot |
+| 29 | Create Vault submit button (focused) | Tab to button |
+| 30 | Modal close button (focused) | Open modal, Tab to × |
+| 31 | Nav link (focused) | Tab to first nav item |
+
+---
+
+## Baseline management
+
+1. On the first run, all snapshots become the **baseline**.
+2. On subsequent PRs, Percy/Chromatic diffs against the baseline.
+3. A reviewer must **approve** visual diffs before merging — do not auto-approve.
+4. Update the baseline intentionally after a design-approved change by accepting diffs in the Percy/Chromatic UI.
+5. Tag baseline snapshots with the release version in Percy project settings.
+
+---
+
+## Figma traceability
+
+Link each snapshot target to its Figma frame:
+
+| Snapshot target | Figma frame name | Figma node ID |
+|---|---|---|
+| Home — desktop | `Home / Desktop` | *(add node ID)* |
+| Vaults — mobile | `Vaults / Mobile` | *(add node ID)* |
+| CreateVault — form | `Create Vault / Form` | *(add node ID)* |
+| Modal — open | `Modal / Default` | *(add node ID)* |
+| *(add rows as frames are created)* | | |
+
+> To get a Figma node ID: right-click a frame → "Copy link" → the `node-id` query param is the ID.


### PR DESCRIPTION
design: QA checklist and visual regression targets
  
  Establishes a repeatable design QA process for Disciplr Frontend, covering all
  pages (Home, Vaults, Create Vault, Dashboard, Vault Detail, Vault Transactions,
  Notifications, Notification Settings) and modals.
  
  What's added
  
  - design/qa/DESIGN_QA_CHECKLIST.md — per-PR checklist for contrast (WCAG 2.1
  AA), keyboard focus order, breakpoints (375–1440 px), motion/reduced-motion,
  and screen reader smoke tests
  - design/qa/VISUAL_REGRESSION_TARGETS.md — Percy + Playwright setup guide,
  Chromatic/Storybook alternative, and a 31-item manual snapshot list with Figma
  node ID traceability table
  - design/qa/RELEASE_GATE.md — 8 hard gates (block merge) + 3 soft gates (warn),
  PR description template, and escalation process
  
  Token notes
  
  No token values changed. Two known dark-mode contrast gaps documented (not new
  regressions):
  
  - --muted on dark --bg ≈ 3.9 : 1 (caption/secondary text only)
  - --accent on dark --bg ≈ 3.1 : 1 (large/bold text only)
  
  Testing
  
  Checklist items verified against existing src/index.css token values and
  design-system/tokens/colors.json. No runtime changes.
  closes #56
