### PR TITLE
feat: theme-align NotificationSettings with design tokens

### DIFF
--- a/design-system/documentation/notification-settings.md
+++ b/design-system/documentation/notification-settings.md
@@ -1,0 +1,11 @@
+# Notification Settings Theming
+
+NotificationSettings uses semantic app tokens instead of fixed light-mode Tailwind colors:
+
+- Panels use `--surface`, `--text`, and `--border`.
+- Form controls use `--surface-raised`, `--text`, `--border`, and `--accent` focus outlines.
+- Toggle tracks use neutral surface tokens when off and `--accent` when checked.
+- Toggle thumbs use `--bg`, `--surface`, and `--border` so they remain visible in light and dark themes.
+- Peer focus rings keep the existing Tailwind focus affordance and theme the ring with `--accent-transparent`.
+
+These tokens are backed by `design-system/tokens/colors.json` neutral and secondary/accent values and mirrored in `src/index.css` for runtime theme switching.

--- a/src/pages/NotificationSettings.tsx
+++ b/src/pages/NotificationSettings.tsx
@@ -1,5 +1,30 @@
 import { vaults } from "@/components/Notification/exampleNotification/example";
+import { Text } from "@/components/Text";
 import { useState } from "react";
+
+type SettingsToggleProps = {
+  checked?: boolean;
+  label: string;
+  onChange?: (checked: boolean) => void;
+};
+
+function SettingsToggle({ checked, label, onChange }: SettingsToggleProps) {
+  return (
+    <label className="relative inline-flex items-center cursor-pointer">
+      <input
+        type="checkbox"
+        className="sr-only peer"
+        checked={checked}
+        aria-label={label}
+        onChange={(event) => onChange?.(event.target.checked)}
+      />
+      <span
+        className="notification-settings-toggle peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-[var(--accent-transparent)]"
+        aria-hidden="true"
+      />
+    </label>
+  );
+}
 
 export default function NotificationSettings() {
   const [emailNotification, setEmailNotification] = useState(true);
@@ -8,61 +33,41 @@ export default function NotificationSettings() {
   const [quietHours, setQuietHours] = useState("12:00");
   return (
     <>
-      <div className="w-full bg-white text-black rounded-md z-20 px-3">
-        <h2 className="text-xl font-bold">Notification Setting </h2>
+      <div className="w-full rounded-md z-20 px-3 py-3 notification-settings-panel">
+        <Text role="title" as="h2">Notification Settings</Text>
         <div>
           <div className="grid grid-cols-2 justify-center items-center mt-5">
-            <p>Email Notification</p>
+            <Text role="body" as="p">Email Notification</Text>
             <div className="flex flex-col items-end justify-end gap-4">
-              <label className="relative inline-flex items-center cursor-pointer">
-                {/* Hidden Checkbox */}
-                <input
-                  type="checkbox"
-                  className="sr-only peer"
-                  checked={emailNotification}
-                  onChange={(e) => {
-                    setEmailNotification(e.target.checked);
-                  }}
-                />
-
-                {/* The Track (Background) */}
-                <div className="w-8 h-3 bg-gray-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[-6px] after:start-[-4px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-6 after:w-6 after:transition-all peer-checked:bg-blue-600"></div>
-
-                {/* Optional Label Text */}
-              </label>
+              <SettingsToggle
+                label="Email Notification"
+                checked={emailNotification}
+                onChange={setEmailNotification}
+              />
             </div>
           </div>
           <div className="grid grid-cols-2 justify-center items-center mt-5">
-            <p>Push Notification</p>
+            <Text role="body" as="p">Push Notification</Text>
             <div className="flex flex-col items-end justify-end gap-4">
-              <label className="relative inline-flex items-center cursor-pointer">
-                {/* Hidden Checkbox */}
-                <input
-                  type="checkbox"
-                  className="sr-only peer"
-                  checked={pushNotification}
-                  onChange={(e) => {
-                    setPushNotification(e.target.checked);
-                  }}
-                />
-
-                {/* The Track (Background) */}
-                <div className="w-8 h-3 bg-gray-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[-6px] after:start-[-4px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-6 after:w-6 after:transition-all peer-checked:bg-blue-600"></div>
-
-                {/* Optional Label Text */}
-              </label>
+              <SettingsToggle
+                label="Push Notification"
+                checked={pushNotification}
+                onChange={setPushNotification}
+              />
             </div>
           </div>
           <div className="flex justify-between items-center mt-5">
-            <p>Notification Frequency</p>
+            <label htmlFor="notification-frequency">
+              <Text role="body" as="span">Notification Frequency</Text>
+            </label>
             <select
-              className="w-[200px]"
+              className="w-[200px] notification-settings-field"
               value={frequency}
               onChange={(e) => {
                 setFrequency(e.target.value);
               }}
-              name=""
-              id=""
+              name="notification-frequency"
+              id="notification-frequency"
             >
               <option value="1">Occurance</option>
               <option value="2">Daily</option>
@@ -71,10 +76,13 @@ export default function NotificationSettings() {
             </select>
           </div>
           <div className="flex justify-between items-center mt-5">
-            <p>Quiet Hours</p>
+            <label htmlFor="quiet-hours">
+              <Text role="body" as="span">Quiet Hours</Text>
+            </label>
             <input
-              className="w-[200px]"
+              className="w-[200px] notification-settings-field"
               type="time"
+              id="quiet-hours"
               value={quietHours}
               onChange={(e) => {
                 setQuietHours(e.target.value);
@@ -84,25 +92,79 @@ export default function NotificationSettings() {
         </div>
       </div>
 
-      <div className="w-full bg-white text-black rounded-md z-20 px-3 mt-5">
-        <h2 className="text-xl font-bold">Vault Notifications</h2>
+      <div className="w-full rounded-md z-20 px-3 py-3 mt-5 notification-settings-panel">
+        <Text role="title" as="h2">Vault Notifications</Text>
         {vaults.map((v) => (
-          <div className="grid grid-cols-2 justify-center items-center mt-5">
-            <p>{v.name}</p>
+          <div className="grid grid-cols-2 justify-center items-center mt-5" key={v.name}>
+            <Text role="body" as="p">{v.name}</Text>
             <div className="flex flex-col items-end justify-end gap-4">
-              <label className="relative inline-flex items-center cursor-pointer">
-                {/* Hidden Checkbox */}
-                <input type="checkbox" className="sr-only peer" />
-
-                {/* The Track (Background) */}
-                <div className="w-8 h-3 bg-gray-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[-6px] after:start-[-4px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-6 after:w-6 after:transition-all peer-checked:bg-blue-600"></div>
-
-                {/* Optional Label Text */}
-              </label>
+              <SettingsToggle label={`${v.name} notifications`} />
             </div>
           </div>
         ))}
       </div>
+
+      <style>{`
+        .notification-settings-panel {
+          background: var(--surface);
+          color: var(--text);
+          border: 1px solid var(--border);
+        }
+
+        .notification-settings-field {
+          background: var(--surface-raised);
+          color: var(--text);
+          border: 1px solid var(--border);
+          border-radius: var(--radius);
+          padding: var(--spacing-1) var(--spacing-2);
+        }
+
+        .notification-settings-field:focus {
+          border-color: var(--accent);
+          outline: 2px solid var(--accent-transparent);
+          outline-offset: 2px;
+        }
+
+        .notification-settings-toggle {
+          position: relative;
+          width: 2rem;
+          height: 0.75rem;
+          border-radius: 9999px;
+          background: var(--surface-raised);
+          border: 1px solid var(--border);
+          transition: background 150ms ease, border-color 150ms ease;
+        }
+
+        .notification-settings-toggle::after {
+          content: "";
+          position: absolute;
+          top: -0.4rem;
+          left: -0.25rem;
+          width: 1.5rem;
+          height: 1.5rem;
+          border-radius: 9999px;
+          background: var(--bg);
+          border: 1px solid var(--border);
+          box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+          transition: transform 150ms ease, background 150ms ease, border-color 150ms ease;
+        }
+
+        .peer:checked + .notification-settings-toggle {
+          background: var(--accent);
+          border-color: var(--accent);
+        }
+
+        .peer:checked + .notification-settings-toggle::after {
+          transform: translateX(1rem);
+          background: var(--surface);
+          border-color: var(--accent);
+        }
+
+        .peer:focus + .notification-settings-toggle {
+          outline: 4px solid var(--accent-transparent);
+          outline-offset: 4px;
+        }
+      `}</style>
     </>
   );
 }

--- a/src/pages/__tests__/NotificationSettings.test.tsx
+++ b/src/pages/__tests__/NotificationSettings.test.tsx
@@ -1,0 +1,39 @@
+type SourceAssertion = {
+  name: string;
+  pattern: RegExp;
+};
+
+const sourceAssertions: SourceAssertion[] = [
+  {
+    name: "uses checked state for email notifications",
+    pattern: /checked=\{emailNotification\}/,
+  },
+  {
+    name: "uses checked state for push notifications",
+    pattern: /checked=\{pushNotification\}/,
+  },
+  {
+    name: "uses tokenized surface and text colors",
+    pattern: /background:\s*var\(--surface\)[\s\S]*color:\s*var\(--text\)/,
+  },
+  {
+    name: "themes toggle focus rings with the accent token",
+    pattern: /peer-focus:ring-\[var\(--accent-transparent\)\]/,
+  },
+  {
+    name: "themes checked toggle tracks with the accent token",
+    pattern: /\.peer:checked \+ \.notification-settings-toggle[\s\S]*background:\s*var\(--accent\)/,
+  },
+];
+
+export function assertNotificationSettingsSource(source: string) {
+  const missing = sourceAssertions
+    .filter(({ pattern }) => !pattern.test(source))
+    .map(({ name }) => name);
+
+  if (missing.length > 0) {
+    throw new Error(`NotificationSettings theming assertions failed: ${missing.join(", ")}`);
+  }
+}
+
+export const notificationSettingsThemeTestCases = sourceAssertions.map(({ name }) => name);


### PR DESCRIPTION
Closes #81

---

## Summary
- Theme-aligned NotificationSettings with `--surface`, `--text`, border, neutral, and accent tokens.
- Replaced hardcoded Tailwind toggle colors with shared tokenized toggle styling.
- Added NotificationSettings theming documentation and source-level test assertions.

## Verification
- `git diff --check` passed.
