### PR TITLE
docs: add design system getting started guide

### DIFF
--- a/design-system/README.md
+++ b/design-system/README.md
@@ -14,6 +14,8 @@ A comprehensive design system for the Disciplr financial platform.
 
 See `documentation/getting-started.md` for setup instructions.
 
+For a token-to-component map, see `documentation/token-catalog.md`.
+
 ## Responsive breakpoints
 
 Disciplr uses a five-step breakpoint scale that is shared between CSS, Tailwind v4

--- a/design-system/documentation/getting-started.md
+++ b/design-system/documentation/getting-started.md
@@ -1,0 +1,64 @@
+# Design System Getting Started
+
+This guide explains how the React app consumes the Disciplr design-system
+tokens and where contributors should add or validate new tokens.
+
+## Source Files
+
+Design tokens live in `design-system/tokens/`:
+
+| Token file | Runtime surface | Notes |
+| --- | --- | --- |
+| `colors.json` | CSS variables in `src/index.css` such as `--bg`, `--surface`, `--text`, `--muted`, `--accent`, `--success`, `--warning`, and chart variables used by analytics views. | Use semantic names in components instead of hard-coded colors. |
+| `typography.json` | Typography CSS variables and classes in `src/index.css`, plus `src/utils/typography.ts`. | Components should use the `Text` component or `classifyTypography()` roles where possible. |
+| `spacing.json` | Spacing, container, touch-target, and breakpoint CSS variables in `src/index.css`; breakpoint details are documented in `documentation/breakpoints.md`. | Prefer `--spacing-*`, `--container-*`, and breakpoint tokens over one-off values. |
+| `borders.json` | Radius, border-width, and semantic border CSS variables in `src/index.css`. | Use `--radius-*`, `--border-width-*`, and semantic border variables for cards, fields, buttons, and modals. |
+| `shadows.json` | Elevation language for raised surfaces and overlays. | Match existing component surfaces before adding a new shadow. |
+| `motion.json` | JS motion constants in `src/utils/motion.ts` and reduced-motion guidance in `documentation/breakpoints.md`. | Use the exported `duration`, `ease`, and standard transitions for Framer Motion flows. |
+
+## Consuming Tokens In Components
+
+1. Import existing components first: `Text`, `Field`, `VaultCard`,
+   `ConfirmationModal`, wallet components, and dashboard surfaces already bind
+   to token-backed CSS variables.
+2. Use CSS variables directly when the component has no wrapper yet. Common
+   examples are `var(--accent)`, `var(--accent-transparent)`, `var(--success)`,
+   `var(--surface)`, `var(--surface-raised)`, `var(--border)`,
+   `var(--radius-md)`, and `var(--radius-full)`.
+3. Use `src/utils/typography.ts` for text roles. `getTypographyClass()` maps
+   `display`, `title`, `subtitle`, `body`, `caption`, and `mono` to the
+   responsive classes defined in `src/index.css`.
+4. Use `src/utils/motion.ts` for Framer Motion transitions. This keeps
+   dropdowns, pages, and tooltips aligned with `motion.json`.
+
+## Adding A Token
+
+1. Add the token to the correct file in `design-system/tokens/`.
+2. If it must be available at runtime, add the corresponding CSS variable or
+   utility export in `src/index.css`, `src/utils/typography.ts`, or
+   `src/utils/motion.ts`.
+3. Validate the token shape through `design-system/src/utils/validators.ts`.
+   Color and chart additions should satisfy `isValidColorToken()` or
+   `isValidChartTokens()` as applicable.
+4. Update `documentation/token-catalog.md` when the new token is consumed by a
+   component.
+5. Run the relevant checks:
+
+```sh
+npm test
+npm run lint
+npm run build
+git diff --check
+```
+
+For documentation-only changes, verify every referenced file, CSS variable, and
+component path exists before opening the PR.
+
+## Related Documentation
+
+- `documentation/token-catalog.md` maps token groups to consumers.
+- `documentation/breakpoints.md` documents the responsive spacing and layout
+  scale.
+- `documentation/chart-palette.md` documents analytics chart color usage.
+- `documentation/field.md` and `documentation/confirmation-modal.md` document
+  component-level accessibility behavior.

--- a/design-system/documentation/token-catalog.md
+++ b/design-system/documentation/token-catalog.md
@@ -1,0 +1,44 @@
+# Token Catalog
+
+This catalog maps token groups to their runtime CSS variables, utility files,
+and component consumers. Keep it current when adding tokens or migrating
+components to the design system.
+
+| Token group | Token source | Runtime variables or utilities | Current consumers |
+| --- | --- | --- | --- |
+| Core color surfaces | `tokens/colors.json` | `--bg`, `--surface`, `--surface-raised`, `--border`, `--text`, `--muted`, `--hover` in `src/index.css` | `Layout`, `Dashboard`, `VaultCard`, `Field`, `ConfirmationModal`, wallet components, notification settings |
+| Semantic colors | `tokens/colors.json` | `--accent`, `--accent-dim`, `--accent-transparent`, `--danger`, `--success`, `--warning`, `--info` | Primary actions, dashboard status badges, analytics filters, notification toggles, icons, focus rings |
+| Chart colors | `tokens/colors.json` | Read through `src/pages/analyticsTheme.ts` and documented in `documentation/chart-palette.md` | `Analytics`, Recharts series, chart tooltips, chart screen-reader summaries |
+| Typography | `tokens/typography.json` | `--font-size-*`, `--line-height-*`, `--font-weight-*`, `.text-*` classes, `src/utils/typography.ts` | `Text`, page headings, captions, body copy, dashboard metrics, financial mono text |
+| Spacing | `tokens/spacing.json` | `--spacing-*`, `--container-*`, `--touch-target`; responsive breakpoints documented in `documentation/breakpoints.md` | Page sections, form spacing, cards, grids, navigation, dashboard panels |
+| Borders and radius | `tokens/borders.json` | `--radius-*`, `--border-width-*`, `--border-default`, `--border-subtle`, `--border-emphasis`, `--border-interactive`, `--border-error`, `--border-success` | `Field`, `VaultCard`, `ConfirmationModal`, wallet dropdowns, pills, avatars, focus states |
+| Shadows | `tokens/shadows.json` | Elevation references for raised surfaces and overlays | Modals, dropdowns, raised cards, dashboard surfaces |
+| Motion | `tokens/motion.json` | `src/utils/motion.ts` exports `duration`, `ease`, `transitionEnter`, `transitionExit`, and `transitionPage` | `Notification`, animated overlays, dropdowns, page transitions |
+
+## Component Notes
+
+- `Text` should be the default wrapper for semantic typography roles. It maps
+  roles to the responsive text classes in `src/index.css`.
+- `Field` consumes border, radius, focus, spacing, and text tokens. See
+  `documentation/field.md` before changing form-control styles.
+- `VaultCard` consumes surface, border, radius, spacing, success/accent status,
+  and typography tokens.
+- `ConfirmationModal` consumes overlay, surface, radius, spacing, action, focus,
+  and accessibility patterns documented in `documentation/confirmation-modal.md`.
+- Analytics views should use the chart palette and `src/pages/analyticsTheme.ts`
+  instead of hard-coded chart colors.
+
+## Validation Entry Points
+
+Token shape validation lives in `design-system/src/utils/validators.ts`:
+
+- `isValidHexColor`, `isValidRgbColor`, `isValidHslColor`, and
+  `isValidColorString` validate raw color values.
+- `isKebabCase` and `hasValidTokenPrefix` validate token naming conventions.
+- `isValidColorToken` validates color token objects and optional accessibility
+  metadata.
+- `isValidChartTokens` validates chart surface, categorical, and sequential
+  ramps.
+
+When a token group changes, update the token file, runtime CSS or utility
+mapping, this catalog, and the relevant focused docs in `documentation/`.


### PR DESCRIPTION
## Summary

Closes #140.

Adds the missing design-system getting-started guide and a token/component catalog so contributors have one place to learn how tokens move from `design-system/tokens/*.json` into app CSS variables, utility files, and components.

## Changes

- Added `design-system/documentation/getting-started.md` with token source files, runtime surfaces, component consumption guidance, and the workflow for adding tokens.
- Added `design-system/documentation/token-catalog.md` mapping token groups to CSS variables/utilities and current consumers such as `Text`, `Field`, `VaultCard`, `ConfirmationModal`, wallet components, and analytics views.
- Linked the token catalog from `design-system/README.md`, alongside the now-existing getting-started guide.

## Verification

- Confirmed referenced token files exist: `colors.json`, `typography.json`, `spacing.json`, `shadows.json`, `motion.json`, and `borders.json`.
- Confirmed referenced app files and utilities exist: `src/index.css`, `src/utils/motion.ts`, `src/utils/typography.ts`, `src/pages/analyticsTheme.ts`, `design-system/src/utils/validators.ts`, and the referenced component files.
- Confirmed sampled CSS variables exist in `src/index.css`, including `--accent`, `--success`, `--radius-full`, spacing, container, and typography variables.
- `git diff --check` passed.

Payment details can be provided privately if this is accepted.