### PR TITLE
feat: add MilestoneTracker component

### DIFF
--- a/design-system/README.md
+++ b/design-system/README.md
@@ -14,6 +14,11 @@ A comprehensive design system for the Disciplr financial platform.
 
 See `documentation/getting-started.md` for setup instructions.
 
+## Component Documentation
+
+- [`MilestoneTracker`](documentation/milestone-tracker.md) - ordered vault
+  milestone progress with status badges and current-step accessibility.
+
 ## Responsive breakpoints
 
 Disciplr uses a five-step breakpoint scale that is shared between CSS, Tailwind v4

--- a/design-system/documentation/milestone-tracker.md
+++ b/design-system/documentation/milestone-tracker.md
@@ -1,0 +1,64 @@
+# MilestoneTracker
+
+`MilestoneTracker` renders vault milestones as an ordered progress list for the
+Vault Detail page.
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `milestones` | `Milestone[]` | Ordered milestone records from the vault detail model. |
+
+The `Milestone` shape matches the vault detail model:
+
+```ts
+type MilestoneStatus = "pending" | "validated" | "failed";
+
+interface Milestone {
+  id: string;
+  title: string;
+  description: string;
+  criteria: string;
+  status: MilestoneStatus;
+  validatedAt?: string;
+  evidenceUrl?: string;
+}
+```
+
+## States
+
+| Status | Badge | Token |
+| --- | --- | --- |
+| `pending` | Pending | `--warning` |
+| `validated` | Validated | `--success` |
+| `failed` | Failed | `--danger` |
+
+The first pending milestone is treated as the current step and receives
+`aria-current="step"`. Empty lists render a neutral empty state instead of an
+empty ordered list. Single-milestone lists keep the same marker, badge, and
+current-step behavior.
+
+## Token Usage
+
+- Structure uses `--bg`, `--surface`, `--surface-raised`, `--border`, and
+  `--accent-transparent`.
+- Status colors use only `--success`, `--warning`, and `--danger`.
+- Spacing, border widths, and radii use `--spacing-*`, `--border-width-*`,
+  `--radius`, and `--radius-full`.
+- No component styles use hardcoded hex color values.
+
+## Accessibility
+
+- The tracker is an ordered list with `aria-label="Vault milestone progress"`.
+- The active milestone is exposed with `aria-current="step"`.
+- Evidence links use normal anchor semantics and open in a new tab with
+  `rel="noopener noreferrer"`.
+- The empty state uses `aria-live="polite"` so late-loaded vault data can be
+  announced without interrupting the user.
+
+## Tests
+
+Component coverage lives in
+`src/components/__tests__/MilestoneTracker.test.tsx` and verifies status
+rendering, current-step exposure, empty-state handling, evidence links, and
+single-milestone behavior.

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -63,6 +63,7 @@ export const Field = React.forwardRef<HTMLInputElement, FieldProps>(
       )}
     </div>
   )
-}
+  }
+)
 
 Field.displayName = 'Field'

--- a/src/components/MilestoneTracker.css
+++ b/src/components/MilestoneTracker.css
@@ -1,0 +1,142 @@
+.milestone-tracker {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.milestone-tracker-empty {
+  margin: 0;
+  padding: var(--spacing-4);
+  color: var(--muted);
+  background: var(--bg);
+  border: var(--border-width-1) dashed var(--border);
+  border-radius: var(--radius);
+}
+
+.milestone-tracker-step {
+  display: grid;
+  grid-template-columns: var(--touch-target) 1fr;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
+  background: var(--bg);
+  border: var(--border-width-1) solid var(--border);
+  border-left: var(--border-width-4) solid var(--muted);
+  border-radius: var(--radius);
+}
+
+.milestone-tracker-step[aria-current="step"] {
+  border-color: var(--accent);
+  background: var(--surface);
+  box-shadow: 0 0 0 var(--border-width-2) var(--accent-transparent);
+}
+
+.milestone-tracker-marker {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--touch-target);
+  height: var(--touch-target);
+  color: var(--muted);
+  background: var(--surface-raised);
+  border: var(--border-width-1) solid var(--border);
+  border-radius: var(--radius-full);
+  font-weight: 700;
+}
+
+.milestone-tracker-content {
+  min-width: 0;
+}
+
+.milestone-tracker-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+}
+
+.milestone-tracker-title {
+  margin: 0;
+  font-weight: 700;
+}
+
+.milestone-tracker-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--spacing-6);
+  padding: var(--spacing-1) var(--spacing-2);
+  color: var(--muted);
+  background: var(--surface-raised);
+  border: var(--border-width-1) solid currentColor;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-caption);
+  font-weight: 700;
+}
+
+.milestone-tracker-copy {
+  margin: 0 0 var(--spacing-2);
+  color: var(--muted);
+}
+
+.milestone-tracker-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-2);
+}
+
+.milestone-tracker-validated-at {
+  color: var(--success);
+  font-weight: 600;
+}
+
+.milestone-tracker-evidence {
+  color: var(--accent);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-caption);
+  font-weight: 700;
+}
+
+.milestone-tracker-step.is-pending {
+  border-left-color: var(--warning);
+}
+
+.milestone-tracker-step.is-pending .milestone-tracker-badge,
+.milestone-tracker-step.is-pending .milestone-tracker-marker {
+  color: var(--warning);
+}
+
+.milestone-tracker-step.is-validated {
+  border-left-color: var(--success);
+}
+
+.milestone-tracker-step.is-validated .milestone-tracker-badge,
+.milestone-tracker-step.is-validated .milestone-tracker-marker {
+  color: var(--success);
+}
+
+.milestone-tracker-step.is-failed {
+  border-left-color: var(--danger);
+}
+
+.milestone-tracker-step.is-failed .milestone-tracker-badge,
+.milestone-tracker-step.is-failed .milestone-tracker-marker {
+  color: var(--danger);
+}
+
+@media (max-width: 639px) {
+  .milestone-tracker-step {
+    grid-template-columns: 1fr;
+  }
+
+  .milestone-tracker-marker {
+    width: var(--spacing-8);
+    height: var(--spacing-8);
+  }
+}

--- a/src/components/MilestoneTracker.tsx
+++ b/src/components/MilestoneTracker.tsx
@@ -1,0 +1,114 @@
+import { Text } from "./Text";
+import "./MilestoneTracker.css";
+
+export type MilestoneStatus = "pending" | "validated" | "failed";
+
+export interface Milestone {
+  id: string;
+  title: string;
+  description: string;
+  criteria: string;
+  status: MilestoneStatus;
+  validatedAt?: string;
+  evidenceUrl?: string;
+}
+
+export interface MilestoneTrackerProps {
+  milestones: Milestone[];
+}
+
+const MILESTONE_STATUS_CONFIG: Record<
+  MilestoneStatus,
+  { label: string; className: string }
+> = {
+  pending: { label: "Pending", className: "is-pending" },
+  validated: { label: "Validated", className: "is-validated" },
+  failed: { label: "Failed", className: "is-failed" },
+};
+
+function formatValidatedAt(iso: string): string {
+  return new Date(iso).toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function MilestoneTracker({ milestones }: MilestoneTrackerProps) {
+  if (milestones.length === 0) {
+    return (
+      <Text
+        role="body"
+        as="p"
+        className="milestone-tracker-empty"
+        aria-live="polite"
+      >
+        No milestones have been defined for this vault.
+      </Text>
+    );
+  }
+
+  const currentIndex = milestones.findIndex(
+    (milestone) => milestone.status === "pending",
+  );
+
+  return (
+    <ol className="milestone-tracker" aria-label="Vault milestone progress">
+      {milestones.map((milestone, index) => {
+        const status = MILESTONE_STATUS_CONFIG[milestone.status];
+        const isCurrent = index === currentIndex;
+
+        return (
+          <li
+            key={milestone.id}
+            className={`milestone-tracker-step ${status.className}`}
+            aria-current={isCurrent ? "step" : undefined}
+          >
+            <div className="milestone-tracker-marker" aria-hidden="true">
+              {index + 1}
+            </div>
+            <div className="milestone-tracker-content">
+              <div className="milestone-tracker-header">
+                <Text role="body" as="h3" className="milestone-tracker-title">
+                  {milestone.title}
+                </Text>
+                <span className="milestone-tracker-badge">{status.label}</span>
+              </div>
+
+              <Text role="caption" as="p" className="milestone-tracker-copy">
+                {milestone.description}
+              </Text>
+              <Text role="caption" as="p" className="milestone-tracker-copy">
+                <strong>Criteria:</strong> {milestone.criteria}
+              </Text>
+
+              <div className="milestone-tracker-meta">
+                {milestone.validatedAt && (
+                  <Text
+                    role="caption"
+                    as="span"
+                    className="milestone-tracker-validated-at"
+                  >
+                    Validated {formatValidatedAt(milestone.validatedAt)}
+                  </Text>
+                )}
+                {milestone.evidenceUrl && (
+                  <a
+                    className="milestone-tracker-evidence"
+                    href={milestone.evidenceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    View evidence
+                  </a>
+                )}
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/src/components/__tests__/MilestoneTracker.test.tsx
+++ b/src/components/__tests__/MilestoneTracker.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  Milestone,
+  MilestoneTracker,
+} from "../../components/MilestoneTracker";
+
+const milestones: Milestone[] = [
+  {
+    id: "m1",
+    title: "Phase 1 Complete",
+    description: "Complete initial development phase",
+    criteria: "All unit tests passing, code reviewed",
+    status: "validated",
+    validatedAt: "2024-02-20T14:30:00Z",
+    evidenceUrl: "https://github.com/org/repo/pull/42",
+  },
+  {
+    id: "m2",
+    title: "Beta Launch",
+    description: "Launch beta version to 100 users",
+    criteria: "Beta deployed, 100 active users onboarded",
+    status: "pending",
+  },
+  {
+    id: "m3",
+    title: "Production Audit",
+    description: "Security audit before production release",
+    criteria: "Critical findings resolved",
+    status: "failed",
+  },
+];
+
+describe("MilestoneTracker", () => {
+  it("renders milestone titles, criteria, and status badges in order", () => {
+    render(<MilestoneTracker milestones={milestones} />);
+
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems).toHaveLength(3);
+    expect(screen.getByText("Phase 1 Complete")).toBeInTheDocument();
+    expect(
+      screen.getByText(/All unit tests passing, code reviewed/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Validated")).toBeInTheDocument();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  it("marks the first pending milestone as the current step", () => {
+    render(<MilestoneTracker milestones={milestones} />);
+
+    const currentStep = screen.getByText("Beta Launch").closest("li");
+    const validatedStep = screen.getByText("Phase 1 Complete").closest("li");
+
+    expect(currentStep).toHaveAttribute("aria-current", "step");
+    expect(validatedStep).not.toHaveAttribute("aria-current");
+  });
+
+  it("renders evidence links and formatted validation timestamps", () => {
+    render(<MilestoneTracker milestones={milestones} />);
+
+    expect(screen.getByText(/Validated Feb 20, 2024/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View evidence" })).toHaveAttribute(
+      "href",
+      "https://github.com/org/repo/pull/42",
+    );
+  });
+
+  it("handles a single pending milestone", () => {
+    render(<MilestoneTracker milestones={[milestones[1]]} />);
+
+    const currentStep = screen.getByText("Beta Launch").closest("li");
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+    expect(currentStep).toHaveAttribute("aria-current", "step");
+  });
+
+  it("handles an empty milestone list", () => {
+    render(<MilestoneTracker milestones={[]} />);
+
+    expect(
+      screen.getByText("No milestones have been defined for this vault."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
+import { MilestoneTracker } from "../components/MilestoneTracker";
 import { Text } from "../components/Text";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -212,15 +213,6 @@ const STATUS_CONFIG: Record<
     color: "var(--warning)",
     bg: "rgba(245,158,11,0.1)",
   },
-};
-
-const MILESTONE_CONFIG: Record<
-  MilestoneStatus,
-  { label: string; color: string }
-> = {
-  pending: { label: "Pending", color: "var(--muted)" },
-  validated: { label: "Validated", color: "var(--success)" },
-  failed: { label: "Failed", color: "var(--danger)" },
 };
 
 const TX_LABELS: Record<string, string> = {
@@ -638,78 +630,7 @@ export default function VaultDetail() {
         >
           Milestones
         </Text>
-        <div
-          style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}
-        >
-          {vault.milestones.map((m, i) => {
-            const mCfg = MILESTONE_CONFIG[m.status];
-            return (
-              <div
-                key={m.id}
-                style={{
-                  background: "var(--bg)",
-                  border: "1px solid var(--border)",
-                  borderRadius: "var(--radius)",
-                  padding: "1rem",
-                  borderLeft: `3px solid ${mCfg.color}`,
-                }}
-              >
-                <div
-                  style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "flex-start",
-                    flexWrap: "wrap",
-                    gap: 8,
-                    marginBottom: "0.4rem",
-                  }}
-                >
-                  <Text role="body" as="span" style={{ fontWeight: 600 }}>
-                    {i + 1}. {m.title}
-                  </Text>
-                  <span
-                    style={{ color: mCfg.color, fontSize: 12, fontWeight: 600 }}
-                  >
-                    {mCfg.label}
-                  </span>
-                </div>
-                <Text
-                  role="caption"
-                  as="p"
-                  style={{ color: "var(--muted)", margin: "0 0 0.3rem" }}
-                >
-                  {m.description}
-                </Text>
-                <Text
-                  role="caption"
-                  as="p"
-                  style={{ color: "var(--muted)", margin: "0 0 0.3rem" }}
-                >
-                  <strong>Criteria:</strong> {m.criteria}
-                </Text>
-                {m.validatedAt && (
-                  <Text
-                    role="caption"
-                    as="p"
-                    style={{ color: "var(--success)", margin: "0 0 0.3rem" }}
-                  >
-                    Validated {fmtDateTime(m.validatedAt)}
-                  </Text>
-                )}
-                {m.evidenceUrl && (
-                  <a
-                    href={m.evidenceUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{ fontSize: 12, color: "var(--accent)" }}
-                  >
-                    View evidence ↗
-                  </a>
-                )}
-              </div>
-            );
-          })}
-        </div>
+        <MilestoneTracker milestones={vault.milestones} />
       </Card>
 
       {/* ── Transactions ── */}


### PR DESCRIPTION
Closes #122.

## Summary
- Add a typed `MilestoneTracker` component that renders ordered milestone progress, status badges, evidence links, formatted validation timestamps, empty state, and `aria-current="step"` for the first pending milestone.
- Refactor `VaultDetail` to use the shared tracker instead of inline milestone markup.
- Document the component in the design system and cross-link it from the design-system README.
- Fix the existing `Field` `forwardRef` closure so TypeScript can parse that component.

## Validation
- `npx vitest run src/components/__tests__/MilestoneTracker.test.tsx` passes: 5 tests.
- `git diff --check` passes.
- `npm run build` is still blocked by existing project-wide TypeScript/test config issues unrelated to this component, including unused imports, missing test globals, a bad `../../Layout` test import, and missing `@testing-library/user-event`.

Payment details can be provided privately if this contribution is accepted for the GrantFox/Maybe Rewarded campaign.