### PR TITLE
feat: add accessible VaultProgressBar primitive

### DIFF
--- a/design-system/README.md
+++ b/design-system/README.md
@@ -14,6 +14,11 @@ A comprehensive design system for the Disciplr financial platform.
 
 See `documentation/getting-started.md` for setup instructions.
 
+## Component Documentation
+
+- [`VaultProgressBar`](documentation/vault-progress-bar.md) - shared vault
+  progress primitive with clamped values and ARIA progressbar semantics.
+
 ## Responsive breakpoints
 
 Disciplr uses a five-step breakpoint scale that is shared between CSS, Tailwind v4

--- a/design-system/documentation/vault-progress-bar.md
+++ b/design-system/documentation/vault-progress-bar.md
@@ -1,0 +1,42 @@
+# VaultProgressBar
+
+`VaultProgressBar` is the shared vault progress primitive for card and detail
+surfaces.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `value` | `number` | Required | Progress percentage. Values are clamped to `0`-`100`. |
+| `label` | `string` | `Vault progress` | Accessible progressbar label and optional visible label. |
+| `showValue` | `boolean` | `true` | Shows or hides the visible label and percentage text. |
+| `className` | `string` | `undefined` | Optional class hook for layout composition. |
+
+## Behavior
+
+- Invalid, negative, and overflow values are normalized by
+  `clampProgressValue`.
+- The progress track uses `role="progressbar"` with `aria-valuemin`,
+  `aria-valuemax`, `aria-valuenow`, `aria-valuetext`, and `aria-label`.
+- Completion at `100` uses `--success`; in-progress values use `--accent`.
+- The component uses design tokens for sizing, radius, text, track, and fill
+  colors. No hardcoded hex colors are used.
+
+## Usage
+
+```tsx
+<VaultProgressBar value={progressPct} label="Vault progress" />
+```
+
+For compact timeline layouts, keep the ARIA label while hiding visible helper
+text:
+
+```tsx
+<VaultProgressBar value={timelineProgress} label="Timeline progress" showValue={false} />
+```
+
+## Tests
+
+Coverage lives in `src/components/__tests__/VaultProgressBar.test.tsx` and
+checks clamping, ARIA attributes, label rendering, hidden-value mode, and edge
+values.

--- a/src/components/VaultCard.tsx
+++ b/src/components/VaultCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Text } from './Text';
+import { VaultProgressBar } from './VaultProgressBar';
 import React from 'react';
 
 export type VaultStatus = 'active' | 'pending_validation' | 'completed' | 'failed';
@@ -69,16 +70,14 @@ export default function VaultCard({
           border: '1px solid var(--border)',
           borderRadius: 'var(--radius)',
           padding: '0.875rem 1rem',
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          flexWrap: 'wrap',
-          gap: 8,
+          display: 'grid',
+          gridTemplateColumns: 'minmax(0, 1fr) auto',
+          gap: '0.75rem',
           marginBottom: 4,
           boxShadow: 'var(--elevated)',
         }}
       >
-        <div>
+        <div style={{ minWidth: 0 }}>
           <Text role="body" as="div" style={{ fontWeight: 600, marginBottom: 2 }}>
             {name}
           </Text>
@@ -95,6 +94,9 @@ export default function VaultCard({
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <StatusBadge status={status} />
+        </div>
+        <div style={{ gridColumn: '1 / -1' }}>
+          <VaultProgressBar value={progressPct} label={`${name} progress`} />
         </div>
       </div>
     </Link>

--- a/src/components/VaultProgressBar.css
+++ b/src/components/VaultProgressBar.css
@@ -1,0 +1,45 @@
+.vault-progress-bar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  width: 100%;
+}
+
+.vault-progress-bar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  color: var(--muted);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-caption);
+}
+
+.vault-progress-bar-label {
+  font-weight: 600;
+}
+
+.vault-progress-bar-value {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.vault-progress-bar-track {
+  width: 100%;
+  height: var(--spacing-2);
+  overflow: hidden;
+  background: var(--border);
+  border-radius: var(--radius-full);
+}
+
+.vault-progress-bar-fill {
+  height: 100%;
+  min-width: 0;
+  background: var(--accent);
+  border-radius: inherit;
+  transition: width 0.4s ease;
+}
+
+.vault-progress-bar.is-complete .vault-progress-bar-fill {
+  background: var(--success);
+}

--- a/src/components/VaultProgressBar.tsx
+++ b/src/components/VaultProgressBar.tsx
@@ -1,0 +1,59 @@
+import "./VaultProgressBar.css";
+
+export interface VaultProgressBarProps {
+  value: number;
+  label?: string;
+  showValue?: boolean;
+  className?: string;
+}
+
+export function clampProgressValue(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(100, Math.max(0, value));
+}
+
+function formatProgressValue(value: number): string {
+  return Number.isInteger(value) ? `${value}%` : `${value.toFixed(1)}%`;
+}
+
+export function VaultProgressBar({
+  value,
+  label = "Vault progress",
+  showValue = true,
+  className,
+}: VaultProgressBarProps) {
+  const progress = clampProgressValue(value);
+  const progressText = formatProgressValue(progress);
+  const classNames = [
+    "vault-progress-bar",
+    progress >= 100 ? "is-complete" : "is-active",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={classNames}>
+      {showValue && (
+        <div className="vault-progress-bar-header">
+          <span className="vault-progress-bar-label">{label}</span>
+          <span className="vault-progress-bar-value">{progressText}</span>
+        </div>
+      )}
+      <div
+        className="vault-progress-bar-track"
+        role="progressbar"
+        aria-label={label}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={progress}
+        aria-valuetext={progressText}
+      >
+        <div
+          className="vault-progress-bar-fill"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/VaultCard.test.tsx
+++ b/src/components/__tests__/VaultCard.test.tsx
@@ -48,4 +48,13 @@ describe('VaultCard', () => {
     // Badge should use the accent color variable
     expect(badge).toHaveStyle({ color: 'var(--accent)' });
   });
+
+  it('renders an accessible vault progress bar', () => {
+    renderCard({ ...baseProps, progressPct: 42 });
+
+    expect(
+      screen.getByRole('progressbar', { name: 'Alpha Vault progress' })
+    ).toHaveAttribute('aria-valuenow', '42');
+    expect(screen.getByText('42%')).toBeInTheDocument();
+  });
 });

--- a/src/components/__tests__/VaultProgressBar.test.tsx
+++ b/src/components/__tests__/VaultProgressBar.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  clampProgressValue,
+  VaultProgressBar,
+} from "../../components/VaultProgressBar";
+
+describe("clampProgressValue", () => {
+  it("clamps progress values to the 0-100 range", () => {
+    expect(clampProgressValue(-5)).toBe(0);
+    expect(clampProgressValue(42)).toBe(42);
+    expect(clampProgressValue(120)).toBe(100);
+    expect(clampProgressValue(Number.NaN)).toBe(0);
+  });
+});
+
+describe("VaultProgressBar", () => {
+  it("renders accessible progressbar semantics", () => {
+    render(<VaultProgressBar value={42} label="Funding progress" />);
+
+    const progressbar = screen.getByRole("progressbar", {
+      name: "Funding progress",
+    });
+    expect(progressbar).toHaveAttribute("aria-valuemin", "0");
+    expect(progressbar).toHaveAttribute("aria-valuemax", "100");
+    expect(progressbar).toHaveAttribute("aria-valuenow", "42");
+    expect(progressbar).toHaveAttribute("aria-valuetext", "42%");
+    expect(screen.getByText("Funding progress")).toBeInTheDocument();
+    expect(screen.getByText("42%")).toBeInTheDocument();
+  });
+
+  it("uses the default label when no label is provided", () => {
+    render(<VaultProgressBar value={25} />);
+
+    expect(
+      screen.getByRole("progressbar", { name: "Vault progress" }),
+    ).toBeInTheDocument();
+  });
+
+  it("clamps visual and ARIA values", () => {
+    const { rerender } = render(<VaultProgressBar value={120} />);
+
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "100",
+    );
+    expect(screen.getByText("100%")).toBeInTheDocument();
+
+    rerender(<VaultProgressBar value={-5} />);
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "0",
+    );
+    expect(screen.getByText("0%")).toBeInTheDocument();
+  });
+
+  it("can hide the visible label while preserving the ARIA label", () => {
+    render(
+      <VaultProgressBar
+        value={64.25}
+        label="Timeline progress"
+        showValue={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("progressbar", { name: "Timeline progress" }),
+    ).toHaveAttribute("aria-valuetext", "64.3%");
+    expect(screen.queryByText("Timeline progress")).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
+import { VaultProgressBar } from "../components/VaultProgressBar";
 import { Text } from "../components/Text";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -490,42 +491,11 @@ export default function VaultDetail() {
         >
           Status Timeline
         </Text>
-        <div style={{ position: "relative", marginBottom: "0.5rem" }}>
-          {/* Track */}
-          <div
-            style={{ height: 6, background: "var(--border)", borderRadius: 3 }}
-          />
-          {/* Fill */}
-          <div
-            style={{
-              position: "absolute",
-              top: 0,
-              left: 0,
-              height: 6,
-              width: `${progress}%`,
-              background: isActive ? "var(--accent)" : statusCfg.color,
-              borderRadius: 3,
-              transition: "width 0.4s",
-            }}
-          />
-          {/* Marker */}
-          {isActive && (
-            <div
-              style={{
-                position: "absolute",
-                top: "50%",
-                left: `${progress}%`,
-                transform: "translate(-50%, -50%)",
-                width: 14,
-                height: 14,
-                borderRadius: "50%",
-                background: "var(--accent)",
-                border: "2px solid var(--bg)",
-                boxShadow: "0 0 0 2px var(--accent)",
-              }}
-            />
-          )}
-        </div>
+        <VaultProgressBar
+          value={progress}
+          label={`${vault.name} timeline progress`}
+          showValue={false}
+        />
         <div
           style={{
             display: "flex",


### PR DESCRIPTION
Closes #130.

## Summary
- Add a reusable `VaultProgressBar` component with clamped 0-100 values, ARIA progressbar semantics, optional labels, and token-based styling.
- Refactor `VaultCard` to render progress from its existing `progressPct` prop.
- Reuse the same primitive in `VaultDetail` for timeline progress instead of bespoke inline track/fill markup.
- Add design-system documentation and cross-link it from the design-system README.

## Validation
- `npx vitest run src/components/__tests__/VaultProgressBar.test.tsx src/components/__tests__/VaultCard.test.tsx` passes: 2 files, 9 tests.
- `git diff --check` passes.
- `npm run build` is currently blocked by an existing upstream parse error in `src/components/Field.tsx` (missing `forwardRef` closure), before this change is typechecked.

Payment details can be provided privately if this contribution is accepted for the GrantFox/Maybe Rewarded campaign.