### PR TITLE
test: add full coverage for design-system validators

### DIFF
--- a/design-system/src/__tests__/validators.test.ts
+++ b/design-system/src/__tests__/validators.test.ts
@@ -1,0 +1,233 @@
+import {
+  hasValidTokenPrefix,
+  isKebabCase,
+  isValidChartTokens,
+  isValidColorString,
+  isValidColorToken,
+  isValidHexColor,
+  isValidHslColor,
+  isValidRgbColor,
+} from '../utils/validators';
+
+const colorToken = (value = '#112233') => ({
+  $type: 'color',
+  $value: value,
+});
+
+const tokenGroup = (value = '#112233') => ({
+  light: colorToken(value),
+  dark: colorToken(value),
+});
+
+const ramp = (steps = 5) =>
+  Object.fromEntries(
+    Array.from({ length: steps }, (_, index) => [
+      `step-${index + 1}`,
+      tokenGroup(`#11223${index}`),
+    ]),
+  );
+
+const validChart = () => ({
+  axis: tokenGroup(),
+  grid: tokenGroup(),
+  tooltipBg: tokenGroup(),
+  tooltipBorder: tokenGroup(),
+  tooltipText: tokenGroup(),
+  tooltipLabel: tokenGroup(),
+  categorical: ramp(5),
+  sequential: ramp(5),
+});
+
+describe('standalone color string validators', () => {
+  it('validates six-digit hex colors case-insensitively', () => {
+    expect(isValidHexColor('#ABCDEF')).toBe(true);
+    expect(isValidHexColor('#abcdef')).toBe(true);
+    expect(isValidHexColor('#123abz')).toBe(false);
+    expect(isValidHexColor('#abc')).toBe(false);
+    expect(isValidHexColor('ABCDEF')).toBe(false);
+  });
+
+  it('validates rgb colors with numeric channels', () => {
+    expect(isValidRgbColor('rgb(0,0,0)')).toBe(true);
+    expect(isValidRgbColor('rgb(255, 255, 255)')).toBe(true);
+    expect(isValidRgbColor('rgba(0, 0, 0, 1)')).toBe(false);
+    expect(isValidRgbColor('rgb(a, b, c)')).toBe(false);
+  });
+
+  it('validates hsl colors with percentage saturation and lightness', () => {
+    expect(isValidHslColor('hsl(210, 50%, 40%)')).toBe(true);
+    expect(isValidHslColor('hsl(210, 50, 40)')).toBe(false);
+    expect(isValidHslColor('hsla(210, 50%, 40%, 1)')).toBe(false);
+  });
+
+  it('accepts any supported color string format', () => {
+    expect(isValidColorString('#112233')).toBe(true);
+    expect(isValidColorString('rgb(17, 34, 51)')).toBe(true);
+    expect(isValidColorString('hsl(210, 50%, 13%)')).toBe(true);
+    expect(isValidColorString('var(--accent)')).toBe(false);
+  });
+});
+
+describe('token name validators', () => {
+  it('validates kebab-case names', () => {
+    expect(isKebabCase('color-chart-step-1')).toBe(true);
+    expect(isKebabCase('color')).toBe(true);
+    expect(isKebabCase('Color-chart')).toBe(false);
+    expect(isKebabCase('color--chart')).toBe(false);
+    expect(isKebabCase('-color-chart')).toBe(false);
+  });
+
+  it('requires one of the supported token prefixes', () => {
+    expect(hasValidTokenPrefix('color-accent')).toBe(true);
+    expect(hasValidTokenPrefix('spacing-4')).toBe(true);
+    expect(hasValidTokenPrefix('typography-title')).toBe(true);
+    expect(hasValidTokenPrefix('shadow-card')).toBe(true);
+    expect(hasValidTokenPrefix('radius-md')).toBe(true);
+    expect(hasValidTokenPrefix('border-default')).toBe(true);
+    expect(hasValidTokenPrefix('motion-fast')).toBe(true);
+    expect(hasValidTokenPrefix('chart-accent')).toBe(false);
+    expect(hasValidTokenPrefix('color')).toBe(false);
+  });
+});
+
+describe('isValidColorToken', () => {
+  it('accepts a valid color token with optional accessibility metadata', () => {
+    expect(
+      isValidColorToken({
+        ...colorToken(),
+        accessibility: {
+          wcagLevel: 'AAA',
+          colorblindSafe: true,
+          colorblindSimulation: {
+            protanopia: '#112234',
+            deuteranopia: 'rgb(17, 34, 53)',
+            tritanopia: 'hsl(210, 50%, 13%)',
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects non-token and malformed token values', () => {
+    expect(isValidColorToken(null)).toBe(false);
+    expect(isValidColorToken('not-an-object')).toBe(false);
+    expect(isValidColorToken({ $type: 'dimension', $value: '#112233' })).toBe(
+      false,
+    );
+    expect(isValidColorToken({ $type: 'color', $value: 123 })).toBe(false);
+    expect(isValidColorToken({ $type: 'color', $value: '#bad' })).toBe(false);
+  });
+
+  it('validates accessibility metadata branches', () => {
+    const valid = colorToken();
+
+    expect(
+      isValidColorToken({ ...valid, accessibility: { wcagLevel: 'AA' } }),
+    ).toBe(true);
+    expect(
+      isValidColorToken({ ...valid, accessibility: { wcagLevel: 'A' } }),
+    ).toBe(false);
+    expect(
+      isValidColorToken({
+        ...valid,
+        accessibility: { colorblindSafe: 'true' },
+      }),
+    ).toBe(false);
+    expect(
+      isValidColorToken({ ...valid, accessibility: 'not-an-object' }),
+    ).toBe(false);
+    expect(
+      isValidColorToken({
+        ...valid,
+        accessibility: { colorblindSimulation: 'not-an-object' },
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects malformed colorblind simulations for each supported key', () => {
+    expect(
+      isValidColorToken({
+        ...colorToken(),
+        accessibility: { colorblindSimulation: { protanopia: 'bad' } },
+      }),
+    ).toBe(false);
+    expect(
+      isValidColorToken({
+        ...colorToken(),
+        accessibility: { colorblindSimulation: { deuteranopia: 'bad' } },
+      }),
+    ).toBe(false);
+    expect(
+      isValidColorToken({
+        ...colorToken(),
+        accessibility: { colorblindSimulation: { tritanopia: 'bad' } },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isValidChartTokens', () => {
+  it('accepts a complete chart token set', () => {
+    expect(isValidChartTokens(validChart())).toBe(true);
+  });
+
+  it('rejects missing or malformed surface tokens', () => {
+    expect(isValidChartTokens(null)).toBe(false);
+    expect(isValidChartTokens('not-an-object')).toBe(false);
+    expect(isValidChartTokens({})).toBe(false);
+    expect(isValidChartTokens({ ...validChart(), axis: null })).toBe(false);
+    expect(
+      isValidChartTokens({ ...validChart(), tooltipText: { light: colorToken() } }),
+    ).toBe(false);
+    expect(
+      isValidChartTokens({
+        ...validChart(),
+        tooltipLabel: { light: colorToken(), dark: colorToken('bad') },
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects missing, undersized, and malformed categorical ramps', () => {
+    const chart = validChart();
+
+    expect(isValidChartTokens({ ...chart, categorical: undefined })).toBe(false);
+    expect(isValidChartTokens({ ...chart, categorical: ramp(4) })).toBe(false);
+    expect(
+      isValidChartTokens({
+        ...chart,
+        categorical: { ...ramp(4), 'step-5': 'not-a-token-group' },
+      }),
+    ).toBe(false);
+    expect(
+      isValidChartTokens({
+        ...chart,
+        categorical: {
+          ...ramp(4),
+          'step-5': { light: colorToken('bad'), dark: colorToken() },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects missing, undersized, and malformed sequential ramps', () => {
+    const chart = validChart();
+
+    expect(isValidChartTokens({ ...chart, sequential: undefined })).toBe(false);
+    expect(isValidChartTokens({ ...chart, sequential: ramp(4) })).toBe(false);
+    expect(
+      isValidChartTokens({
+        ...chart,
+        sequential: { ...ramp(4), 'step-5': 'not-a-token-group' },
+      }),
+    ).toBe(false);
+    expect(
+      isValidChartTokens({
+        ...chart,
+        sequential: {
+          ...ramp(4),
+          'step-5': { light: colorToken(), dark: colorToken('bad') },
+        },
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #131.

## Summary
- Add a dedicated `design-system/src/__tests__/validators.test.ts` suite for every exported validator in `src/utils/validators.ts`.
- Cover color string formats, token prefix/name checks, color token accessibility metadata, colorblind simulation validation, and chart surface/categorical/sequential branches.
- Include null, non-object, wrong `$type`, malformed color values, undersized ramps, and invalid light/dark token groups.

## Validation
- `npm test -- validators.test.ts --coverage --collectCoverageFrom=src/utils/validators.ts` passes with 100% statements, branches, functions, and lines for `validators.ts`.
- `npm test` from `design-system/` passes: 3 test suites, 24 tests.
- `git diff --check` passes.

Payment details can be provided privately if this contribution is accepted for the GrantFox/Maybe Rewarded campaign.