### PR TITLE
docs: refresh root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,215 @@
 # disciplr-frontend
 
-Web app for [Disciplr](https://github.com/your-org/Disciplr): programmable time-locked capital vaults on Stellar.
+Frontend for Disciplr, a Stellar-oriented vault application for programmable,
+time-locked capital, verifier workflows, wallet connection, analytics, and
+notification surfaces.
 
-## What it does
+## What It Does
 
-- **Home:** Overview and quick links to create or view vaults.
-- **Vaults:** List your productivity vaults (placeholder until backend is wired).
-- **Create Vault:** Form to define amount (USDC), deadline, success/failure Stellar addresses (UI only; backend/contract integration pending).
+- Create and inspect USDC vaults with deadlines, success destinations, failure
+  destinations, milestones, and transaction history.
+- Connect a Stellar wallet through Freighter using `@stellar/freighter-api`.
+- Support verifier review flows for pending validations, decision details, and
+  validation history.
+- Provide dashboard and analytics pages for vault status, activity, and export
+  workflows.
+- Maintain a separate `design-system/` package for tokens, validators, and
+  design documentation.
 
-## Tech stack
+## Tech Stack
 
-- **React 18** + **TypeScript**
-- **Vite** for build and dev server
-- **React Router** for routes
-- CSS variables for theming (dark theme by default)
+- React 18 and TypeScript
+- Vite with `@vitejs/plugin-react`
+- React Router for client-side routes
+- Vitest and Testing Library for frontend tests
+- Freighter wallet integration through `@stellar/freighter-api`
+- Zustand for notification state
+- Recharts and jsPDF for analytics/charting and export-related UI
+- Lucide React and React Icons for icons
+- A local `design-system/` package with Jest-tested token utilities
 
-## Local setup
+## Route And Page Map
+
+Routes mounted in `src/App.tsx`:
+
+| Path | Page | Purpose |
+| --- | --- | --- |
+| `/` | `Home` | Landing overview and vault entry points |
+| `/dashboard` | `Dashboard` | Vault and activity dashboard |
+| `/vaults` | `Vaults` | Vault listing and state handling |
+| `/vaults/create` | `CreateVault` | Vault creation form |
+| `/vaults/:id` | `VaultDetail` | Milestones, addresses, status, and transactions for one vault |
+| `/vaults/:id/transactions` | `VaultTransactions` | Transaction filters, summaries, and export actions |
+| `/verifier` | `VerifierDashboard` | Verifier overview |
+| `/verifier/queue` | `PendingValidations` | Pending validation queue |
+| `/verifier/queue/:vaultId` | `ValidationDetail` | Validation decision details |
+| `/verifier/history` | `ValidationHistory` | Historical validation records |
+| `*` | `NotFound` | Catch-all fallback |
+
+Implemented pages that are present in `src/pages/` but are not currently mounted
+by `src/App.tsx`:
+
+- `Analytics.tsx` and `analyticsTheme.ts`; the global layout links to
+  `/analytics`, but `App.tsx` does not currently register that route.
+- `Notification.tsx`; this page links to `/notification/settings`.
+- `NotificationSettings.tsx`.
+
+## Wallet Integration
+
+Wallet state lives in `src/context/WalletContext.tsx` and is consumed by the
+wallet UI in `src/components/Wallet/`.
+
+- `WalletConnectButton.tsx` opens the wallet modal when disconnected and shows a
+  truncated address plus network badge when connected.
+- `WalletSelectionModal.tsx` calls Freighter through `setAllowed`,
+  `requestAccess`, `getAddress`, and `getNetworkDetails`.
+- `WalletDropdown.tsx` shows the connected address, mock USDC balance, explorer
+  link, switch action, copy action, and disconnect action.
+- Supported wallet network labels come from `WalletNetwork`: `TESTNET` and
+  `PUBLIC`.
+
+## Design System
+
+The `design-system/` package contains Disciplr's token source and validation
+utilities.
+
+- `design-system/tokens/` stores colors, spacing, typography, borders, shadows,
+  motion, and breakpoint-related token data.
+- `design-system/src/utils/token-loader.ts` loads token data.
+- `design-system/src/utils/validators.ts` validates color, accessibility, chart,
+  and token naming rules.
+- `design-system/documentation/` contains focused guidance for breakpoints,
+  chart palettes, fields, confirmation modals, analytics charts, and
+  notification settings.
+- `design-system/README.md` is the entry point for package-specific design
+  system documentation.
+- `.kiro/specs/design-system-brand-foundation/` contains the brand foundation
+  requirements, design notes, and task plan.
+
+## Local Setup
 
 ### Prerequisites
 
 - Node.js 18+
-- npm or yarn
+- npm
 
-### Install and run
+### Install And Run
 
 ```bash
-# From repo root
-cd disciplr-frontend
 npm install
 npm run dev
 ```
 
-App runs at **http://localhost:5173**. API requests to `/api` are proxied to `http://localhost:3000` (configure in `vite.config.ts`).
+The Vite dev server runs on `http://localhost:5173`. Requests to `/api` are
+proxied to `http://localhost:3000` through `vite.config.ts`.
 
-### Scripts
+## Scripts
 
-| Command     | Description              |
-|------------|--------------------------|
-| `npm run dev`    | Start dev server        |
-| `npm run build`  | TypeScript + Vite build |
-| `npm run preview`| Preview production build |
-| `npm run lint`   | Run ESLint              |
+Root package scripts:
 
-## Project layout
+| Command | Description |
+| --- | --- |
+| `npm run dev` | Start the Vite development server |
+| `npm run build` | Run TypeScript build mode and create a Vite production build |
+| `npm run preview` | Preview the production build locally |
+| `npm run lint` | Run ESLint across the frontend |
+| `npm run test` | Run the Vitest suite with coverage |
 
-```
-disciplr-frontend/
-├── public/
-├── src/
-│   ├── components/   # Layout, shared UI
-│   ├── pages/        # Home, Vaults, CreateVault
-│   ├── App.tsx
-│   ├── main.tsx
-│   └── index.css
-├── index.html
-├── package.json
-├── tsconfig.json
-├── vite.config.ts
-└── README.md
-```
+Design-system package scripts:
 
-## Merging into a remote
+| Command | Description |
+| --- | --- |
+| `cd design-system && npm run build` | Compile the design-system TypeScript package |
+| `cd design-system && npm test` | Run the Jest token and validator tests |
+| `cd design-system && npm run test:watch` | Run Jest in watch mode |
+| `cd design-system && npm run lint` | Run ESLint for design-system sources |
+| `cd design-system && npm run format` | Format design-system source files |
 
-This directory is a separate git repo. To push to your own remote:
+## Testing
+
+Frontend tests use Vitest, the DOM test setup in `src/setupTests.ts`, and
+Testing Library.
 
 ```bash
-cd disciplr-frontend
-git remote add origin <your-disciplr-frontend-repo-url>
-git push -u origin main
+npm run test
 ```
 
-Replace `<your-disciplr-frontend-repo-url>` with your actual repository URL.
+For targeted frontend checks during development, run Vitest directly:
+
+```bash
+npx vitest run src/pages/__tests__/Vaults.test.tsx
+```
+
+Design-system tests use Jest:
+
+```bash
+cd design-system
+npm test
+```
+
+## Project Layout
+
+```text
+disciplr-frontend/
+|-- .kiro/specs/design-system-brand-foundation/
+|-- design-system/
+|   |-- documentation/
+|   |-- src/
+|   |   |-- __tests__/
+|   |   |-- types/
+|   |   `-- utils/
+|   |-- tokens/
+|   |-- package.json
+|   `-- README.md
+|-- public/
+|-- src/
+|   |-- components/
+|   |   |-- Notification/
+|   |   |-- Wallet/
+|   |   |-- __tests__/
+|   |   |-- ConfirmationModal.tsx
+|   |   |-- Field.tsx
+|   |   |-- Layout.tsx
+|   |   |-- MobileDrawer.tsx
+|   |   |-- NavLink.tsx
+|   |   |-- Skeleton.tsx
+|   |   |-- Text.tsx
+|   |   |-- ThemeToggle.tsx
+|   |   `-- VaultCard.tsx
+|   |-- context/
+|   |   |-- ThemeContext.tsx
+|   |   `-- WalletContext.tsx
+|   |-- pages/
+|   |   |-- __tests__/
+|   |   |-- Analytics.tsx
+|   |   |-- CreateVault.tsx
+|   |   |-- Dashboard.tsx
+|   |   |-- Home.tsx
+|   |   |-- Notification.tsx
+|   |   |-- NotificationSettings.tsx
+|   |   |-- PendingValidations.tsx
+|   |   |-- ValidationDetail.tsx
+|   |   |-- ValidationHistory.tsx
+|   |   |-- VaultDetail.tsx
+|   |   |-- VaultTransactions.tsx
+|   |   |-- Vaults.tsx
+|   |   `-- VerifierDashboard.tsx
+|   |-- utils/
+|   |-- Zustand/
+|   |-- App.tsx
+|   |-- index.css
+|   |-- main.tsx
+|   `-- setupTests.ts
+|-- package.json
+|-- tsconfig.json
+|-- vite.config.ts
+`-- README.md
+```
+
+## Contributor Notes
+
+- Keep route documentation aligned with `src/App.tsx`.
+- Keep wallet documentation aligned with `src/context/WalletContext.tsx` and
+  `src/components/Wallet/`.
+- Keep token and validator documentation aligned with the `design-system/`
+  package.


### PR DESCRIPTION
Closes #139.

## Summary
- Rewrite the root README so it reflects the current vault, verifier, wallet, analytics, notification, and design-system surfaces.
- Replace the stale `your-org` placeholder and broken layout tree with an accurate ASCII project map.
- Document the mounted route map, implemented-but-unmounted notification/analytics pages, Freighter wallet integration, root Vitest workflow, and design-system Jest workflow.

## Validation
- `git diff --check` passes.
- Verified documented scripts exist in `package.json` and `design-system/package.json`.
- Verified referenced paths exist, including `src/App.tsx`, wallet context/components, page files, `design-system/README.md`, token utilities, and `.kiro/specs/design-system-brand-foundation/`.

Payment details can be provided privately if this contribution is accepted for the GrantFox/Maybe Rewarded campaign.