### PR TITLE
feat: validate CreateVault form

### DIFF
--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -12,6 +12,7 @@ export const Field = React.forwardRef<HTMLInputElement, FieldProps>(
   const fieldId = id || `field-${label.toLowerCase().replace(/\s+/g, '-')}`
   const errorId = error ? `${fieldId}-error` : undefined
   const hintId = hint ? `${fieldId}-hint` : undefined
+  const describedBy = [errorId, hintId].filter(Boolean).join(' ') || undefined
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
@@ -29,7 +30,8 @@ export const Field = React.forwardRef<HTMLInputElement, FieldProps>(
         ref={ref}
         id={fieldId}
         required={required}
-        aria-describedby={[errorId, hintId].filter(Boolean).join(' ')}
+        aria-label={label}
+        aria-describedby={describedBy}
         aria-invalid={!!error}
         style={{
           width: '100%',
@@ -63,6 +65,6 @@ export const Field = React.forwardRef<HTMLInputElement, FieldProps>(
       )}
     </div>
   )
-}
+})
 
 Field.displayName = 'Field'

--- a/src/pages/CreateVault.tsx
+++ b/src/pages/CreateVault.tsx
@@ -1,15 +1,30 @@
 import { useState } from 'react'
 import { Text } from '../components/Text'
 import { Field } from '../components/Field'
+import type { CreateVaultErrors } from '../utils/vaultValidation'
+import {
+  hasCreateVaultErrors,
+  validateCreateVault,
+} from '../utils/vaultValidation'
 
 export default function CreateVault() {
   const [amount, setAmount] = useState('')
   const [deadline, setDeadline] = useState('')
   const [successAddress, setSuccessAddress] = useState('')
   const [failureAddress, setFailureAddress] = useState('')
+  const [errors, setErrors] = useState<CreateVaultErrors>({})
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
+    const nextErrors = validateCreateVault({
+      amount,
+      deadline,
+      successAddress,
+      failureAddress,
+    })
+    setErrors(nextErrors)
+    if (hasCreateVaultErrors(nextErrors)) return
+
     // Placeholder: will call backend / contract
     console.log({ amount, deadline, successAddress, failureAddress })
   }
@@ -24,6 +39,7 @@ export default function CreateVault() {
       </Text>
       <form
         onSubmit={handleSubmit}
+        noValidate
         style={{
           display: 'flex',
           flexDirection: 'column',
@@ -35,31 +51,47 @@ export default function CreateVault() {
           label="Amount (USDC)"
           type="text"
           value={amount}
-          onChange={(e) => setAmount(e.target.value)}
+          onChange={(e) => {
+            setAmount(e.target.value)
+            setErrors((current) => ({ ...current, amount: undefined }))
+          }}
           placeholder="1000"
+          error={errors.amount}
           required
         />
         <Field
           label="Deadline (ISO date)"
           type="datetime-local"
           value={deadline}
-          onChange={(e) => setDeadline(e.target.value)}
+          onChange={(e) => {
+            setDeadline(e.target.value)
+            setErrors((current) => ({ ...current, deadline: undefined }))
+          }}
+          error={errors.deadline}
           required
         />
         <Field
           label="Success destination (Stellar address)"
           type="text"
           value={successAddress}
-          onChange={(e) => setSuccessAddress(e.target.value)}
+          onChange={(e) => {
+            setSuccessAddress(e.target.value)
+            setErrors((current) => ({ ...current, successAddress: undefined }))
+          }}
           placeholder="G..."
+          error={errors.successAddress}
           required
         />
         <Field
           label="Failure destination (Stellar address)"
           type="text"
           value={failureAddress}
-          onChange={(e) => setFailureAddress(e.target.value)}
+          onChange={(e) => {
+            setFailureAddress(e.target.value)
+            setErrors((current) => ({ ...current, failureAddress: undefined }))
+          }}
           placeholder="G..."
+          error={errors.failureAddress}
           required
         />
         <button

--- a/src/pages/__tests__/CreateVault.test.tsx
+++ b/src/pages/__tests__/CreateVault.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import CreateVault from '../CreateVault';
+
+const successAddress = `G${'A'.repeat(55)}`;
+const failureAddress = `G${'B'.repeat(55)}`;
+
+function fillField(label: RegExp, value: string) {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } });
+}
+
+describe('CreateVault', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders accessible inline errors and blocks invalid submissions', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    render(<CreateVault />);
+
+    fireEvent.click(screen.getByRole('button', { name: /create vault/i }));
+
+    expect(
+      screen.getByText('Enter a positive USDC amount with up to 7 decimal places.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Choose a future deadline.')).toBeInTheDocument();
+    expect(screen.getAllByText('Enter a valid Stellar public key starting with G.')).toHaveLength(2);
+
+    const amount = screen.getByLabelText(/amount/i);
+    expect(amount).toHaveAttribute('aria-invalid', 'true');
+    expect(amount).toHaveAttribute('aria-describedby', 'field-amount-(usdc)-error');
+    expect(consoleLog).not.toHaveBeenCalled();
+  });
+
+  it('rejects identical destination addresses', () => {
+    render(<CreateVault />);
+
+    fillField(/amount/i, '100');
+    fillField(/deadline/i, '2030-01-01T00:00');
+    fillField(/success destination/i, successAddress);
+    fillField(/failure destination/i, successAddress);
+    fireEvent.click(screen.getByRole('button', { name: /create vault/i }));
+
+    expect(
+      screen.getByText('Failure destination must be different from success destination.'),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/failure destination/i)).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('submits valid vault parameters', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    render(<CreateVault />);
+
+    fillField(/amount/i, '100.1234567');
+    fillField(/deadline/i, '2030-01-01T00:00');
+    fillField(/success destination/i, successAddress);
+    fillField(/failure destination/i, failureAddress);
+    fireEvent.click(screen.getByRole('button', { name: /create vault/i }));
+
+    expect(screen.queryByText(/Enter a positive USDC amount/)).not.toBeInTheDocument();
+    expect(consoleLog).toHaveBeenCalledWith({
+      amount: '100.1234567',
+      deadline: '2030-01-01T00:00',
+      successAddress,
+      failureAddress,
+    });
+  });
+});

--- a/src/utils/__tests__/vaultValidation.test.ts
+++ b/src/utils/__tests__/vaultValidation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isFutureDeadline,
+  isValidStellarAddress,
+  isValidUsdcAmount,
+  validateCreateVault,
+} from '../vaultValidation';
+
+const successAddress = `G${'A'.repeat(55)}`;
+const failureAddress = `G${'B'.repeat(55)}`;
+const now = new Date('2026-06-18T00:00:00Z');
+
+describe('vaultValidation', () => {
+  it('validates positive USDC amounts with up to 7 decimals', () => {
+    expect(isValidUsdcAmount('1')).toBe(true);
+    expect(isValidUsdcAmount('0.0000001')).toBe(true);
+    expect(isValidUsdcAmount('0')).toBe(false);
+    expect(isValidUsdcAmount('-1')).toBe(false);
+    expect(isValidUsdcAmount('1.12345678')).toBe(false);
+    expect(isValidUsdcAmount('1e3')).toBe(false);
+  });
+
+  it('validates Stellar public key shape', () => {
+    expect(isValidStellarAddress(successAddress)).toBe(true);
+    expect(isValidStellarAddress(` ${successAddress} `)).toBe(true);
+    expect(isValidStellarAddress(`M${'A'.repeat(55)}`)).toBe(false);
+    expect(isValidStellarAddress(`G${'A'.repeat(54)}`)).toBe(false);
+    expect(isValidStellarAddress(`G${'0'.repeat(55)}`)).toBe(false);
+  });
+
+  it('requires a valid future deadline', () => {
+    expect(isFutureDeadline('2026-06-18T00:00:01Z', now)).toBe(true);
+    expect(isFutureDeadline('2026-06-18T00:00:00Z', now)).toBe(false);
+    expect(isFutureDeadline('not-a-date', now)).toBe(false);
+  });
+
+  it('returns field-specific errors for invalid create-vault values', () => {
+    const errors = validateCreateVault(
+      {
+        amount: '1.12345678',
+        deadline: '2020-01-01T00:00:00Z',
+        successAddress: 'bad',
+        failureAddress: 'bad',
+      },
+      now,
+    );
+
+    expect(errors).toEqual({
+      amount: 'Enter a positive USDC amount with up to 7 decimal places.',
+      deadline: 'Choose a future deadline.',
+      successAddress: 'Enter a valid Stellar public key starting with G.',
+      failureAddress: 'Enter a valid Stellar public key starting with G.',
+    });
+  });
+
+  it('rejects identical success and failure destinations', () => {
+    const errors = validateCreateVault(
+      {
+        amount: '100',
+        deadline: '2026-06-19T00:00:00Z',
+        successAddress,
+        failureAddress: successAddress,
+      },
+      now,
+    );
+
+    expect(errors).toEqual({
+      failureAddress: 'Failure destination must be different from success destination.',
+    });
+  });
+
+  it('returns no errors for valid create-vault values', () => {
+    expect(
+      validateCreateVault(
+        {
+          amount: '100.1234567',
+          deadline: '2026-06-19T00:00:00Z',
+          successAddress,
+          failureAddress,
+        },
+        now,
+      ),
+    ).toEqual({});
+  });
+});

--- a/src/utils/vaultValidation.ts
+++ b/src/utils/vaultValidation.ts
@@ -1,0 +1,59 @@
+export interface CreateVaultFormValues {
+  amount: string;
+  deadline: string;
+  successAddress: string;
+  failureAddress: string;
+}
+
+export type CreateVaultErrors = Partial<Record<keyof CreateVaultFormValues, string>>;
+
+const STELLAR_PUBLIC_KEY = /^G[A-Z2-7]{55}$/;
+const USDC_AMOUNT = /^(?:0|[1-9]\d*)(?:\.\d{1,7})?$/;
+
+export function isValidStellarAddress(address: string): boolean {
+  return STELLAR_PUBLIC_KEY.test(address.trim());
+}
+
+export function isValidUsdcAmount(amount: string): boolean {
+  const normalized = amount.trim();
+  if (!USDC_AMOUNT.test(normalized)) return false;
+  return Number(normalized) > 0;
+}
+
+export function isFutureDeadline(deadline: string, now = new Date()): boolean {
+  const timestamp = new Date(deadline).getTime();
+  return Number.isFinite(timestamp) && timestamp > now.getTime();
+}
+
+export function validateCreateVault(
+  values: CreateVaultFormValues,
+  now = new Date(),
+): CreateVaultErrors {
+  const errors: CreateVaultErrors = {};
+  const successAddress = values.successAddress.trim();
+  const failureAddress = values.failureAddress.trim();
+
+  if (!isValidUsdcAmount(values.amount)) {
+    errors.amount = 'Enter a positive USDC amount with up to 7 decimal places.';
+  }
+
+  if (!isFutureDeadline(values.deadline, now)) {
+    errors.deadline = 'Choose a future deadline.';
+  }
+
+  if (!isValidStellarAddress(successAddress)) {
+    errors.successAddress = 'Enter a valid Stellar public key starting with G.';
+  }
+
+  if (!isValidStellarAddress(failureAddress)) {
+    errors.failureAddress = 'Enter a valid Stellar public key starting with G.';
+  } else if (successAddress === failureAddress) {
+    errors.failureAddress = 'Failure destination must be different from success destination.';
+  }
+
+  return errors;
+}
+
+export function hasCreateVaultErrors(errors: CreateVaultErrors): boolean {
+  return Object.keys(errors).length > 0;
+}


### PR DESCRIPTION
Closes #123.

## Summary
- Add pure `vaultValidation` helpers for Stellar public keys, positive USDC amounts with up to 7 decimals, future deadlines, and duplicate destination detection.
- Wire validation into `CreateVault` so invalid values render inline `Field` errors and block submission.
- Keep valid submissions flowing to the existing placeholder submit path.
- Repair the existing `Field` forwardRef closure and preserve a clean input aria-label/aria-describedby relationship for inline errors.

## Validation
- `npx vitest run src/utils/__tests__/vaultValidation.test.ts src/pages/__tests__/CreateVault.test.tsx src/components/__tests__/Field.test.tsx` passes: 13 tests.
- `git diff --check` passes.

Payment details can be provided privately if this contribution is accepted for the GrantFox/Maybe Rewarded campaign.