### PR TITLE
feat: filter ValidationHistory

### DIFF
--- a/design-system/documentation/validation-history.md
+++ b/design-system/documentation/validation-history.md
@@ -1,0 +1,29 @@
+# Validation History Filters
+
+The verifier validation history page supports client-side filtering, search, and
+pagination for completed milestone decisions.
+
+## Controls
+
+- Outcome filter: `All outcomes`, `Approved`, or `Rejected`.
+- Search: matches `vaultName` and `owner` text from each validation task.
+- Page size: verifier-selectable page size values of 5, 10, or 25.
+- Pagination: Previous and Next buttons expose explicit `aria-label` text and
+  disabled states at the first and last pages.
+
+## Empty States
+
+- When there is no validation history at all, the page renders the existing
+  "No History Found" message.
+- When filters match no history records, the page renders "No matching
+  validations" with guidance to adjust filters.
+
+## Token Usage
+
+The surface uses semantic tokens:
+
+- `--surface` and `--bg` for panels and nested note blocks.
+- `--border` for panel, row, and control borders.
+- `--muted` for labels and helper text.
+- `--success` for approved status.
+- `--danger` for rejected status.

--- a/src/pages/ValidationHistory.tsx
+++ b/src/pages/ValidationHistory.tsx
@@ -1,84 +1,217 @@
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Text } from '../components/Text';
 import { useVerifierStore } from '../Zustand/Store';
+import {
+  filterValidationHistory,
+  paginate,
+} from '../utils/paginate';
+import type { ValidationHistoryStatusFilter } from '../utils/paginate';
+
+const PAGE_SIZE_OPTIONS = [5, 10, 25];
 
 export default function ValidationHistory() {
   const navigate = useNavigate();
   const { validationHistory } = useVerifierStore();
+  const [statusFilter, setStatusFilter] = useState<ValidationHistoryStatusFilter>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [pageSize, setPageSize] = useState(5);
+  const [page, setPage] = useState(1);
 
   // Calculate the Approve/Reject Ratio
   const total = validationHistory.length;
   const approvedCount = validationHistory.filter((t) => t.status === 'approved').length;
   const rejectedCount = validationHistory.filter((t) => t.status === 'rejected').length;
   const approvalRate = total > 0 ? Math.round((approvedCount / total) * 100) : 0;
+  const filteredHistory = useMemo(
+    () => filterValidationHistory(validationHistory, { status: statusFilter, query: searchQuery }),
+    [validationHistory, statusFilter, searchQuery],
+  );
+  const pagination = paginate(filteredHistory, page, pageSize);
+
+  const updateStatusFilter = (status: ValidationHistoryStatusFilter) => {
+    setStatusFilter(status);
+    setPage(1);
+  };
+
+  const updateSearchQuery = (query: string) => {
+    setSearchQuery(query);
+    setPage(1);
+  };
+
+  const updatePageSize = (size: number) => {
+    setPageSize(size);
+    setPage(1);
+  };
 
   return (
     <div className="flex flex-col gap-6 p-6">
       <header className="mb-2">
         <button 
           onClick={() => navigate('/verifier')}
-          className="text-gray-500 hover:text-gray-800 mb-2 text-sm font-medium transition"
+          className="mb-2 text-sm font-medium transition"
+          style={{ color: 'var(--muted)' }}
         >
           &larr; Back to Dashboard
         </button>
         <Text role="display" as="h1">Validation History</Text>
-        <Text role="body" as="p" className="text-gray-500 mt-1">
+        <Text role="body" as="p" className="mt-1" style={{ color: 'var(--muted)' }}>
           A complete log of your past milestone verifications and notes.
         </Text>
       </header>
 
       {/* Stats / Ratio Banner */}
-      <section className="flex flex-col md:flex-row gap-4 bg-white p-6 border rounded-lg shadow-sm">
+      <section
+        className="flex flex-col md:flex-row gap-4 p-6 border rounded-lg shadow-sm"
+        style={{ background: 'var(--surface)', borderColor: 'var(--border)' }}
+      >
         <div className="flex-1">
-          <Text role="body" as="p" className="text-gray-500">Total Validated</Text>
+          <Text role="body" as="p" style={{ color: 'var(--muted)' }}>Total Validated</Text>
           <Text role="display" as="h2">{total}</Text>
         </div>
         <div className="flex-1">
-          <Text role="body" as="p" className="text-gray-500">Approved</Text>
-          <Text role="display" as="h2" className="text-green-600">{approvedCount}</Text>
+          <Text role="body" as="p" style={{ color: 'var(--muted)' }}>Approved</Text>
+          <Text role="display" as="h2" style={{ color: 'var(--success)' }}>{approvedCount}</Text>
         </div>
         <div className="flex-1">
-          <Text role="body" as="p" className="text-gray-500">Rejected</Text>
-          <Text role="display" as="h2" className="text-red-600">{rejectedCount}</Text>
+          <Text role="body" as="p" style={{ color: 'var(--muted)' }}>Rejected</Text>
+          <Text role="display" as="h2" style={{ color: 'var(--danger)' }}>{rejectedCount}</Text>
         </div>
         <div className="flex-1">
-          <Text role="body" as="p" className="text-gray-500">Approval Rate</Text>
+          <Text role="body" as="p" style={{ color: 'var(--muted)' }}>Approval Rate</Text>
           <Text role="display" as="h2">{approvalRate}%</Text>
         </div>
       </section>
 
+      <section
+        className="flex flex-col md:flex-row gap-4 p-4 border rounded-lg"
+        style={{ background: 'var(--surface)', borderColor: 'var(--border)' }}
+        aria-label="Validation history filters"
+      >
+        <label className="flex flex-col gap-1 flex-1">
+          <Text role="caption" as="span" style={{ color: 'var(--muted)' }}>Search vault or owner</Text>
+          <input
+            aria-label="Search validation history by vault or owner"
+            value={searchQuery}
+            onChange={(event) => updateSearchQuery(event.target.value)}
+            placeholder="Search vault or owner"
+            style={{
+              background: 'var(--bg)',
+              color: 'var(--text)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: '0.65rem 0.75rem',
+            }}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <Text role="caption" as="span" style={{ color: 'var(--muted)' }}>Outcome</Text>
+          <select
+            aria-label="Filter validation history by outcome"
+            value={statusFilter}
+            onChange={(event) => updateStatusFilter(event.target.value as ValidationHistoryStatusFilter)}
+            style={{
+              background: 'var(--bg)',
+              color: 'var(--text)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: '0.65rem 0.75rem',
+            }}
+          >
+            <option value="all">All outcomes</option>
+            <option value="approved">Approved</option>
+            <option value="rejected">Rejected</option>
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <Text role="caption" as="span" style={{ color: 'var(--muted)' }}>Page size</Text>
+          <select
+            aria-label="Validation history page size"
+            value={pageSize}
+            onChange={(event) => updatePageSize(Number(event.target.value))}
+            style={{
+              background: 'var(--bg)',
+              color: 'var(--text)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: '0.65rem 0.75rem',
+            }}
+          >
+            {PAGE_SIZE_OPTIONS.map((size) => (
+              <option key={size} value={size}>{size} per page</option>
+            ))}
+          </select>
+        </label>
+      </section>
+
       {/* History Log */}
-      <section className="bg-white border rounded-lg shadow-sm overflow-hidden">
+      <section
+        className="border rounded-lg shadow-sm overflow-hidden"
+        style={{ background: 'var(--surface)', borderColor: 'var(--border)' }}
+      >
         {total === 0 ? (
-          <div className="p-12 text-center text-gray-500">
+          <div className="p-12 text-center" style={{ color: 'var(--muted)' }}>
             <Text role="body" as="h3">No History Found</Text>
             <Text role="body" as="p" className="mt-2">You haven't processed any validations yet.</Text>
           </div>
+        ) : filteredHistory.length === 0 ? (
+          <div className="p-12 text-center" style={{ color: 'var(--muted)' }}>
+            <Text role="body" as="h3">No matching validations</Text>
+            <Text role="body" as="p" className="mt-2">
+              Adjust the outcome filter or search query to see more results.
+            </Text>
+          </div>
         ) : (
           <div className="flex flex-col">
-            {validationHistory.map((task) => (
+            {pagination.items.map((task) => (
               <div 
                 key={task.id} 
-                className="p-6 border-b border-gray-100 last:border-b-0 hover:bg-gray-50 transition flex flex-col md:flex-row gap-4 justify-between"
+                className="p-6 border-b last:border-b-0 transition flex flex-col md:flex-row gap-4 justify-between"
+                style={{ borderColor: 'var(--border)' }}
               >
                 <div className="flex flex-col gap-2 md:w-1/3">
                   <div className="flex items-center gap-3">
-                    <span className={`px-2 py-1 rounded text-xs font-bold uppercase ${
-                      task.status === 'approved' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
-                    }`}>
+                    <span
+                      className="px-2 py-1 rounded text-xs font-bold uppercase"
+                      style={{
+                        color: task.status === 'approved' ? 'var(--success)' : 'var(--danger)',
+                        border: `1px solid ${task.status === 'approved' ? 'var(--success)' : 'var(--danger)'}`,
+                        background: task.status === 'approved'
+                          ? 'var(--success-transparent)'
+                          : 'var(--danger-transparent)',
+                      }}
+                    >
                       {task.status}
                     </span>
-                    <Text role="body" as="span" className="text-sm text-gray-500">ID: {task.id}</Text>
+                    <Text role="body" as="span" className="text-sm" style={{ color: 'var(--muted)' }}>
+                      ID: {task.id}
+                    </Text>
                   </div>
                   <Text role="body" as="h3">{task.vaultName}</Text>
                   <Text role="body" as="p" className="text-sm font-medium">{task.milestone}</Text>
-                  <span className="bg-gray-100 text-gray-700 text-xs px-2 py-1 rounded font-mono w-max">
+                  <span
+                    className="text-xs px-2 py-1 rounded font-mono w-max"
+                    style={{
+                      background: 'var(--bg)',
+                      color: 'var(--text)',
+                      border: '1px solid var(--border)',
+                    }}
+                  >
                     Owner: {task.owner}
                   </span>
                 </div>
 
-                <div className="md:w-2/3 bg-gray-50 p-4 rounded border text-sm text-gray-700">
-                  <Text role="body" as="p" className="font-bold mb-1 text-xs uppercase text-gray-500">
+                <div
+                  className="md:w-2/3 p-4 rounded border text-sm"
+                  style={{
+                    background: 'var(--bg)',
+                    borderColor: 'var(--border)',
+                    color: 'var(--text)',
+                  }}
+                >
+                  <Text role="body" as="p" className="font-bold mb-1 text-xs uppercase" style={{ color: 'var(--muted)' }}>
                     Verification Notes:
                   </Text>
                   <Text role="body" as="p" className="italic">
@@ -90,6 +223,52 @@ export default function ValidationHistory() {
           </div>
         )}
       </section>
+
+      {total > 0 && filteredHistory.length > 0 && (
+        <nav
+          className="flex flex-col md:flex-row gap-3 md:items-center md:justify-between"
+          aria-label="Validation history pagination"
+        >
+          <Text role="caption" as="p" style={{ color: 'var(--muted)' }}>
+            Showing {pagination.items.length} of {pagination.totalItems} matching validations.
+          </Text>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              aria-label="Go to previous validation history page"
+              disabled={pagination.currentPage === 1}
+              onClick={() => setPage((current) => current - 1)}
+              className="px-3 py-2 rounded text-sm font-medium"
+              style={{
+                border: '1px solid var(--border)',
+                color: 'var(--text)',
+                background: 'var(--surface)',
+                opacity: pagination.currentPage === 1 ? 0.5 : 1,
+              }}
+            >
+              Previous
+            </button>
+            <Text role="caption" as="span" aria-live="polite">
+              Page {pagination.currentPage} of {pagination.pageCount}
+            </Text>
+            <button
+              type="button"
+              aria-label="Go to next validation history page"
+              disabled={pagination.currentPage === pagination.pageCount}
+              onClick={() => setPage((current) => current + 1)}
+              className="px-3 py-2 rounded text-sm font-medium"
+              style={{
+                border: '1px solid var(--border)',
+                color: 'var(--text)',
+                background: 'var(--surface)',
+                opacity: pagination.currentPage === pagination.pageCount ? 0.5 : 1,
+              }}
+            >
+              Next
+            </button>
+          </div>
+        </nav>
+      )}
     </div>
   );
 }

--- a/src/pages/__tests__/ValidationHistory.test.tsx
+++ b/src/pages/__tests__/ValidationHistory.test.tsx
@@ -1,0 +1,188 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ValidationTask } from '../../Zustand/Store';
+import { useVerifierStore } from '../../Zustand/Store';
+import ValidationHistory from '../ValidationHistory';
+
+vi.mock('../../Zustand/Store', () => ({
+  useVerifierStore: vi.fn(),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const baseHistory: ValidationTask[] = [
+  {
+    id: 'v-001',
+    vaultName: 'Alpha Vault',
+    owner: 'GOWNERALPHA',
+    amount: '1,000 USDC',
+    deadline: '2026-01-01',
+    daysRemaining: 0,
+    status: 'approved',
+    milestone: 'Launch',
+    notes: 'Approved launch evidence.',
+  },
+  {
+    id: 'v-002',
+    vaultName: 'Beta Reserve',
+    owner: 'GOWNERBETA',
+    amount: '2,000 USDC',
+    deadline: '2026-01-02',
+    daysRemaining: 0,
+    status: 'rejected',
+    milestone: 'Audit',
+    notes: 'Missing audit proof.',
+  },
+  {
+    id: 'v-003',
+    vaultName: 'Gamma Fund',
+    owner: 'GOWNERGAMMA',
+    amount: '3,000 USDC',
+    deadline: '2026-01-03',
+    daysRemaining: 0,
+    status: 'approved',
+    milestone: 'Delivery',
+  },
+  {
+    id: 'v-004',
+    vaultName: 'Delta Grant',
+    owner: 'GOWNERDELTA',
+    amount: '4,000 USDC',
+    deadline: '2026-01-04',
+    daysRemaining: 0,
+    status: 'rejected',
+    milestone: 'Design',
+  },
+  {
+    id: 'v-005',
+    vaultName: 'Epsilon Pool',
+    owner: 'GOWNEREPSILON',
+    amount: '5,000 USDC',
+    deadline: '2026-01-05',
+    daysRemaining: 0,
+    status: 'approved',
+    milestone: 'Docs',
+  },
+  {
+    id: 'v-006',
+    vaultName: 'Zeta Treasury',
+    owner: 'GOWNERZETA',
+    amount: '6,000 USDC',
+    deadline: '2026-01-06',
+    daysRemaining: 0,
+    status: 'approved',
+    milestone: 'Payout',
+  },
+];
+
+function renderHistory(history = baseHistory) {
+  vi.mocked(useVerifierStore).mockReturnValue({
+    validationHistory: history,
+  } as ReturnType<typeof useVerifierStore>);
+
+  return render(<ValidationHistory />);
+}
+
+describe('ValidationHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders summary stats and first page of validation history', () => {
+    renderHistory();
+
+    expect(screen.getByRole('heading', { name: 'Validation History' })).toBeInTheDocument();
+    expect(screen.getByText('6')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('67%')).toBeInTheDocument();
+
+    expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
+    expect(screen.getByText('Epsilon Pool')).toBeInTheDocument();
+    expect(screen.queryByText('Zeta Treasury')).not.toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+  });
+
+  it('filters by rejected status', () => {
+    renderHistory();
+
+    fireEvent.change(screen.getByLabelText('Filter validation history by outcome'), {
+      target: { value: 'rejected' },
+    });
+
+    expect(screen.getByText('Beta Reserve')).toBeInTheDocument();
+    expect(screen.getByText('Delta Grant')).toBeInTheDocument();
+    expect(screen.queryByText('Alpha Vault')).not.toBeInTheDocument();
+    expect(screen.getByText('Showing 2 of 2 matching validations.')).toBeInTheDocument();
+  });
+
+  it('searches vault names and owners', () => {
+    renderHistory();
+
+    fireEvent.change(screen.getByLabelText('Search validation history by vault or owner'), {
+      target: { value: 'gamma' },
+    });
+
+    expect(screen.getByText('Gamma Fund')).toBeInTheDocument();
+    expect(screen.queryByText('Alpha Vault')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Search validation history by vault or owner'), {
+      target: { value: 'GOWNERBETA' },
+    });
+
+    expect(screen.getByText('Beta Reserve')).toBeInTheDocument();
+    expect(screen.queryByText('Gamma Fund')).not.toBeInTheDocument();
+  });
+
+  it('paginates results with accessible controls', () => {
+    renderHistory();
+
+    const nav = screen.getByRole('navigation', { name: 'Validation history pagination' });
+    const previous = within(nav).getByRole('button', { name: 'Go to previous validation history page' });
+    const next = within(nav).getByRole('button', { name: 'Go to next validation history page' });
+
+    expect(previous).toBeDisabled();
+    expect(next).not.toBeDisabled();
+
+    fireEvent.click(next);
+
+    expect(screen.getByText('Zeta Treasury')).toBeInTheDocument();
+    expect(screen.queryByText('Alpha Vault')).not.toBeInTheDocument();
+    expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+    expect(next).toBeDisabled();
+    expect(previous).not.toBeDisabled();
+  });
+
+  it('updates page size and shows no-match empty state', () => {
+    renderHistory();
+
+    fireEvent.change(screen.getByLabelText('Validation history page size'), {
+      target: { value: '10' },
+    });
+
+    expect(screen.getByText('Zeta Treasury')).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 1')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Search validation history by vault or owner'), {
+      target: { value: 'nothing matches' },
+    });
+
+    expect(screen.getByText('No matching validations')).toBeInTheDocument();
+    expect(screen.queryByRole('navigation', { name: 'Validation history pagination' })).not.toBeInTheDocument();
+  });
+
+  it('navigates back to the verifier dashboard', () => {
+    renderHistory();
+
+    fireEvent.click(screen.getByRole('button', { name: /back to dashboard/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/verifier');
+  });
+});

--- a/src/utils/__tests__/paginate.test.ts
+++ b/src/utils/__tests__/paginate.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import type { ValidationTask } from '../../Zustand/Store';
+import { filterValidationHistory, paginate } from '../paginate';
+
+const history: ValidationTask[] = [
+  {
+    id: 'v-1',
+    vaultName: 'Alpha Vault',
+    owner: 'GBVZ...QK7L',
+    amount: '1,000 USDC',
+    deadline: '2026-01-01',
+    daysRemaining: 0,
+    status: 'approved',
+    milestone: 'Launch',
+  },
+  {
+    id: 'v-2',
+    vaultName: 'Beta Reserve',
+    owner: 'GFAIL...QK7L',
+    amount: '2,000 USDC',
+    deadline: '2026-01-02',
+    daysRemaining: 0,
+    status: 'rejected',
+    milestone: 'Audit',
+  },
+  {
+    id: 'v-3',
+    vaultName: 'Gamma Fund',
+    owner: 'GSUCC...QK7L',
+    amount: '3,000 USDC',
+    deadline: '2026-01-03',
+    daysRemaining: 0,
+    status: 'approved',
+    milestone: 'Delivery',
+  },
+];
+
+describe('filterValidationHistory', () => {
+  it('filters by approved or rejected status', () => {
+    expect(filterValidationHistory(history, { status: 'approved', query: '' }).map((t) => t.id)).toEqual([
+      'v-1',
+      'v-3',
+    ]);
+    expect(filterValidationHistory(history, { status: 'rejected', query: '' }).map((t) => t.id)).toEqual([
+      'v-2',
+    ]);
+  });
+
+  it('searches vault names and owners case-insensitively', () => {
+    expect(filterValidationHistory(history, { status: 'all', query: 'reserve' }).map((t) => t.id)).toEqual([
+      'v-2',
+    ]);
+    expect(filterValidationHistory(history, { status: 'all', query: 'gsucc' }).map((t) => t.id)).toEqual([
+      'v-3',
+    ]);
+  });
+
+  it('combines status and query filters', () => {
+    expect(filterValidationHistory(history, { status: 'rejected', query: 'alpha' })).toEqual([]);
+  });
+});
+
+describe('paginate', () => {
+  it('returns a normalized page of items', () => {
+    const result = paginate(history, 2, 2);
+
+    expect(result.items.map((item) => item.id)).toEqual(['v-3']);
+    expect(result.currentPage).toBe(2);
+    expect(result.pageCount).toBe(2);
+    expect(result.totalItems).toBe(3);
+    expect(result.pageSize).toBe(2);
+  });
+
+  it('clamps page and page size to safe values', () => {
+    expect(paginate(history, 99, 2).currentPage).toBe(2);
+    expect(paginate(history, -1, 0)).toMatchObject({
+      currentPage: 1,
+      pageSize: 1,
+      pageCount: 3,
+    });
+  });
+});

--- a/src/utils/paginate.ts
+++ b/src/utils/paginate.ts
@@ -1,0 +1,52 @@
+import type { ValidationTask } from '../Zustand/Store';
+
+export type ValidationHistoryStatusFilter = 'all' | 'approved' | 'rejected';
+
+export interface ValidationHistoryFilterOptions {
+  status: ValidationHistoryStatusFilter;
+  query: string;
+}
+
+export interface PaginationResult<T> {
+  items: T[];
+  currentPage: number;
+  pageCount: number;
+  totalItems: number;
+  pageSize: number;
+}
+
+export function filterValidationHistory(
+  tasks: ValidationTask[],
+  { status, query }: ValidationHistoryFilterOptions,
+): ValidationTask[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return tasks.filter((task) => {
+    const matchesStatus = status === 'all' || task.status === status;
+    const matchesQuery =
+      normalizedQuery.length === 0 ||
+      task.vaultName.toLowerCase().includes(normalizedQuery) ||
+      task.owner.toLowerCase().includes(normalizedQuery);
+
+    return matchesStatus && matchesQuery;
+  });
+}
+
+export function paginate<T>(
+  items: T[],
+  page: number,
+  pageSize: number,
+): PaginationResult<T> {
+  const safePageSize = Math.max(1, Math.floor(pageSize));
+  const pageCount = Math.max(1, Math.ceil(items.length / safePageSize));
+  const currentPage = Math.min(Math.max(1, Math.floor(page)), pageCount);
+  const start = (currentPage - 1) * safePageSize;
+
+  return {
+    items: items.slice(start, start + safePageSize),
+    currentPage,
+    pageCount,
+    totalItems: items.length,
+    pageSize: safePageSize,
+  };
+}


### PR DESCRIPTION
Closes #129.

## Summary
- Add reusable `filterValidationHistory` and `paginate` helpers for verifier validation history.
- Add outcome filtering, vault/owner search, configurable page size, no-match empty state, and accessible pagination controls to `ValidationHistory`.
- Move the page surface toward semantic design tokens for panels, borders, muted text, and approved/rejected status accents.
- Document the validation-history filter and pagination behavior in `design-system/documentation/validation-history.md`.

## Validation
- `npx vitest run src/utils/__tests__/paginate.test.ts src/pages/__tests__/ValidationHistory.test.tsx` passes: 11 tests.
- `git diff --check` passes.

Payment details can be provided privately if this contribution is accepted for the GrantFox/Maybe Rewarded campaign.