### PR TITLE
[codex] Refactor verifier pages to design tokens

### DIFF
--- a/design-system/documentation/verifier-token-mapping.md
+++ b/design-system/documentation/verifier-token-mapping.md
@@ -1,0 +1,23 @@
+# Verifier Token Mapping
+
+The verifier workflow uses semantic CSS variables from `src/index.css` rather than hardcoded Tailwind color utilities. This keeps the dashboard, queue, and review detail surfaces theme-aware across the default dark theme and manual light mode.
+
+## Surface Mapping
+
+| Surface | Token |
+| --- | --- |
+| Page cards, tables, and detail panels | `--bg` with `--border` |
+| Table headers and evidence panels | `--surface` |
+| Muted labels, metadata, and empty states | `--muted` |
+| Primary navigation and evidence links | `--info` |
+| Pending or urgent deadline accents | `--warning` |
+| Completed and approved amounts/actions | `--success` |
+| Reject/destructive actions | `--danger` |
+
+## Covered Pages
+
+- `src/pages/VerifierDashboard.tsx`
+- `src/pages/PendingValidations.tsx`
+- `src/pages/ValidationDetail.tsx`
+
+Tests assert that the verifier page markup no longer uses hardcoded Tailwind color utilities such as `bg-blue-*`, `bg-white`, `text-gray-*`, or `border-l-green-*`.

--- a/src/pages/PendingValidations.tsx
+++ b/src/pages/PendingValidations.tsx
@@ -1,88 +1,114 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { CountdownDeadline } from '../components/CountdownDeadline';
-import { Text } from '../components/Text';
-import { useVerifierStore } from '../Zustand/Store';
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Text } from "../components/Text";
+import { useVerifierStore } from "../Zustand/Store";
+import "./VerifierPages.css";
 
 export default function PendingValidations() {
   const navigate = useNavigate();
   const { pendingValidations } = useVerifierStore();
-  
+
   // Optional: Simple state to handle sorting by days remaining
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
 
   const sortedValidations = [...pendingValidations].sort((a, b) => {
-    return sortOrder === 'asc' 
-      ? a.daysRemaining - b.daysRemaining 
+    return sortOrder === "asc"
+      ? a.daysRemaining - b.daysRemaining
       : b.daysRemaining - a.daysRemaining;
   });
 
   return (
-    <div className="flex flex-col gap-6 p-6">
-      <header className="flex flex-col md:flex-row md:justify-between md:items-center gap-4 mb-2">
+    <div className="verifier-page">
+      <header className="verifier-page__header">
         <div>
-          <button 
-            onClick={() => navigate('/verifier')}
-            className="text-gray-500 hover:text-gray-800 mb-2 text-sm font-medium transition"
+          <button
+            onClick={() => navigate("/verifier")}
+            className="verifier-page__link-button"
           >
             &larr; Back to Dashboard
           </button>
-          <Text role="display" as="h1">Pending Validations</Text>
-          <Text role="body" as="p" className="text-gray-500 mt-1">
+          <Text role="display" as="h1">
+            Pending Validations
+          </Text>
+          <Text role="body" as="p" className="verifier-page__lede">
             Review and validate milestones submitted by vault owners.
           </Text>
         </div>
-        
-        <button 
-          onClick={() => setSortOrder(prev => prev === 'asc' ? 'desc' : 'asc')}
-          className="px-4 py-2 border border-gray-300 rounded text-sm font-medium hover:bg-gray-50 transition"
+
+        <button
+          onClick={() =>
+            setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"))
+          }
+          className="verifier-page__button"
         >
-          Sort by Urgency: {sortOrder === 'asc' ? 'High to Low' : 'Low to High'}
+          Sort by Urgency: {sortOrder === "asc" ? "High to Low" : "Low to High"}
         </button>
       </header>
 
-      <section className="bg-white border rounded-lg shadow-sm overflow-x-auto">
+      <section className="verifier-table-card">
         {sortedValidations.length === 0 ? (
-          <div className="p-12 text-center text-gray-500">
-            <Text role="body" as="h3">All caught up!</Text>
-            <Text role="body" as="p" className="mt-2">There are no pending validations in your queue.</Text>
+          <div className="verifier-page__empty">
+            <Text role="body" as="h3">
+              All caught up!
+            </Text>
+            <Text role="body" as="p" className="verifier-page__lede">
+              There are no pending validations in your queue.
+            </Text>
           </div>
         ) : (
-          <table className="w-full text-left border-collapse">
+          <table className="verifier-table">
             <thead>
-              <tr className="bg-gray-50 border-b border-gray-200">
-                <th className="p-4 font-medium text-sm text-gray-600">Vault & Milestone</th>
-                <th className="p-4 font-medium text-sm text-gray-600">Owner</th>
-                <th className="p-4 font-medium text-sm text-gray-600">Amount at Stake</th>
-                <th className="p-4 font-medium text-sm text-gray-600">Deadline</th>
-                <th className="p-4 font-medium text-sm text-gray-600 text-right">Actions</th>
+              <tr className="verifier-table__head-row">
+                <th className="verifier-table__header">Vault & Milestone</th>
+                <th className="verifier-table__header">Owner</th>
+                <th className="verifier-table__header">Amount at Stake</th>
+                <th className="verifier-table__header">Deadline</th>
+                <th className="verifier-table__header verifier-table__header--actions">
+                  Actions
+                </th>
               </tr>
             </thead>
             <tbody>
               {sortedValidations.map((task) => (
-                <tr key={task.id} className="border-b border-gray-100 hover:bg-gray-50 transition">
-                  <td className="p-4">
-                    <Text role="body" as="p" className="font-semibold text-gray-800">{task.vaultName}</Text>
-                    <Text role="body" as="p" className="text-sm text-gray-500 mt-1">{task.milestone}</Text>
+                <tr key={task.id} className="verifier-table__row">
+                  <td className="verifier-table__cell">
+                    <Text role="body" as="p" className="verifier-table__title">
+                      {task.vaultName}
+                    </Text>
+                    <Text
+                      role="body"
+                      as="p"
+                      className="verifier-table__subtext"
+                    >
+                      {task.milestone}
+                    </Text>
                   </td>
-                  <td className="p-4">
-                    <span className="bg-gray-100 text-gray-700 text-xs px-2 py-1 rounded font-mono">
-                      {task.owner}
-                    </span>
+                  <td className="verifier-table__cell">
+                    <span className="verifier-table__wallet">{task.owner}</span>
                   </td>
-                  <td className="p-4">
-                    <Text role="body" as="p" className="font-medium text-gray-800">{task.amount}</Text>
+                  <td className="verifier-table__cell">
+                    <Text role="body" as="p" className="verifier-table__amount">
+                      {task.amount}
+                    </Text>
                   </td>
-                  <td className="p-4">
-                    <div className="flex flex-col">
-                      <Text role="body" as="p" className="text-sm">{task.deadline}</Text>
-                      <CountdownDeadline deadline={task.deadline} />
+                  <td className="verifier-table__cell">
+                    <div className="verifier-table__deadline-cell">
+                      <Text role="body" as="p">
+                        {task.deadline}
+                      </Text>
+                      <span
+                        className={`verifier-table__deadline ${
+                          task.daysRemaining <= 3 ? "is-urgent" : ""
+                        }`}
+                      >
+                        {task.daysRemaining} days left
+                      </span>
                     </div>
                   </td>
-                  <td className="p-4 text-right">
-                    <button 
+                  <td className="verifier-table__cell verifier-table__cell--actions">
+                    <button
                       onClick={() => navigate(`/verifier/queue/${task.id}`)}
-                      className="px-4 py-2 bg-blue-50 text-blue-700 rounded hover:bg-blue-100 transition text-sm font-medium"
+                      className="verifier-table__review-button"
                     >
                       Review
                     </button>

--- a/src/pages/ValidationDetail.tsx
+++ b/src/pages/ValidationDetail.tsx
@@ -1,20 +1,24 @@
-import { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { Text } from '../components/Text';
-import { useVerifierStore } from '../Zustand/Store';
-import { ConfirmationModal } from '../components/ConfirmationModal';
-import { SafeLink } from '../components/SafeLink';
+import { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { Text } from "../components/Text";
+import { useVerifierStore } from "../Zustand/Store";
+import { ConfirmationModal } from "../components/ConfirmationModal";
+import { SafeLink } from "../components/SafeLink";
+import "./VerifierPages.css";
 
 export default function ValidationDetail() {
   const { vaultId } = useParams<{ vaultId: string }>();
   const navigate = useNavigate();
-  
+
   // Pull data and actions from Zustand
-  const { pendingValidations, approveValidation, rejectValidation } = useVerifierStore();
-  
+  const { pendingValidations, approveValidation, rejectValidation } =
+    useVerifierStore();
+
   // Local state for notes and the confirmation modal
-  const [notes, setNotes] = useState('');
-  const [confirmAction, setConfirmAction] = useState<'approve' | 'reject' | null>(null);
+  const [notes, setNotes] = useState("");
+  const [confirmAction, setConfirmAction] = useState<
+    "approve" | "reject" | null
+  >(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   // Find the specific task based on the URL parameter
@@ -22,14 +26,16 @@ export default function ValidationDetail() {
 
   if (!task) {
     return (
-      <div className="p-12 text-center flex flex-col items-center gap-4">
-        <Text role="display" as="h2">Validation Not Found</Text>
-        <Text role="body" as="p" className="text-gray-500">
+      <div className="verifier-detail__not-found">
+        <Text role="display" as="h2">
+          Validation Not Found
+        </Text>
+        <Text role="body" as="p" className="verifier-page__meta">
           This validation task may have already been processed or doesn't exist.
         </Text>
-        <button 
-          onClick={() => navigate('/verifier/queue')}
-          className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+        <button
+          onClick={() => navigate("/verifier/queue")}
+          className="verifier-page__button verifier-detail__return-button"
         >
           Return to Queue
         </button>
@@ -38,116 +44,201 @@ export default function ValidationDetail() {
   }
 
   // Action Handlers
-  const handleOpenModal = (action: 'approve' | 'reject') => {
+  const handleOpenModal = (action: "approve" | "reject") => {
     setConfirmAction(action);
     setIsModalOpen(true);
   };
 
-  const executeAction = (decision: 'approve' | 'reject', modalNotes: string) => {
-    if (decision === 'approve') {
+  const executeAction = (
+    decision: "approve" | "reject",
+    modalNotes: string,
+  ) => {
+    if (decision === "approve") {
       approveValidation(task.id, modalNotes);
-    } else if (decision === 'reject') {
+    } else if (decision === "reject") {
       rejectValidation(task.id, modalNotes);
     }
     setIsModalOpen(false);
-    navigate('/verifier/queue'); // Send them back to the list
+    navigate("/verifier/queue"); // Send them back to the list
   };
 
   return (
-    <div className="flex flex-col gap-6 p-6 relative">
+    <div className="verifier-page">
       <header>
-        <button 
-          onClick={() => navigate('/verifier/queue')}
-          className="text-gray-500 hover:text-gray-800 mb-4 text-sm font-medium transition"
+        <button
+          onClick={() => navigate("/verifier/queue")}
+          className="verifier-page__link-button"
         >
           &larr; Back to Queue
         </button>
-        <div className="flex flex-col md:flex-row md:justify-between md:items-end gap-4">
+        <div className="verifier-detail__header-row">
           <div>
-            <Text role="display" as="h1">Review Milestone</Text>
-            <Text role="body" as="p" className="text-gray-500 mt-1">
+            <Text role="display" as="h1">
+              Review Milestone
+            </Text>
+            <Text role="body" as="p" className="verifier-page__meta">
               Task ID: {task.id}
             </Text>
           </div>
-          <div className={`px-4 py-2 rounded font-bold text-sm ${task.daysRemaining <= 3 ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'}`}>
+          <div
+            className={`verifier-detail__deadline-badge ${
+              task.daysRemaining <= 3 ? "is-urgent" : ""
+            }`}
+          >
             Deadline: {task.daysRemaining} days remaining
           </div>
         </div>
       </header>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div className="verifier-detail__grid">
         {/* Left Column: Details & Evidence */}
-        <div className="lg:col-span-2 flex flex-col gap-6">
-          <section className="p-6 border rounded-lg bg-white shadow-sm">
-            <Text role="display" as="h2" className="mb-4">Vault Summary</Text>
-            <div className="grid grid-cols-2 gap-4">
+        <div className="verifier-detail__main">
+          <section className="verifier-detail__card">
+            <Text
+              role="display"
+              as="h2"
+              className="verifier-detail__section-title"
+            >
+              Vault Summary
+            </Text>
+            <div className="verifier-detail__summary-grid">
               <div>
-                <Text role="body" as="p" className="text-sm text-gray-500">Vault Name</Text>
-                <Text role="body" as="p" className="font-medium">{task.vaultName}</Text>
+                <Text
+                  role="body"
+                  as="p"
+                  className="verifier-detail__field-label"
+                >
+                  Vault Name
+                </Text>
+                <Text
+                  role="body"
+                  as="p"
+                  className="verifier-detail__field-value"
+                >
+                  {task.vaultName}
+                </Text>
               </div>
               <div>
-                <Text role="body" as="p" className="text-sm text-gray-500">Owner Wallet</Text>
-                <span className="bg-gray-100 text-gray-700 text-xs px-2 py-1 rounded font-mono block w-max mt-1">
-                  {task.owner}
-                </span>
+                <Text
+                  role="body"
+                  as="p"
+                  className="verifier-detail__field-label"
+                >
+                  Owner Wallet
+                </Text>
+                <span className="verifier-detail__wallet">{task.owner}</span>
               </div>
               <div>
-                <Text role="body" as="p" className="text-sm text-gray-500">Amount at Stake</Text>
-                <Text role="body" as="p" className="font-bold text-green-700">{task.amount}</Text>
+                <Text
+                  role="body"
+                  as="p"
+                  className="verifier-detail__field-label"
+                >
+                  Amount at Stake
+                </Text>
+                <Text role="body" as="p" className="verifier-detail__amount">
+                  {task.amount}
+                </Text>
               </div>
               <div>
-                <Text role="body" as="p" className="text-sm text-gray-500">Deadline Date</Text>
-                <Text role="body" as="p" className="font-medium">{task.deadline}</Text>
+                <Text
+                  role="body"
+                  as="p"
+                  className="verifier-detail__field-label"
+                >
+                  Deadline Date
+                </Text>
+                <Text
+                  role="body"
+                  as="p"
+                  className="verifier-detail__field-value"
+                >
+                  {task.deadline}
+                </Text>
               </div>
             </div>
           </section>
 
-          <section className="p-6 border rounded-lg bg-white shadow-sm">
-            <Text role="display" as="h2" className="mb-4">Milestone Evidence</Text>
-            <div className="p-4 bg-gray-50 border rounded mb-4">
-              <Text role="body" as="p" className="font-bold">Target Milestone:</Text>
-              <Text role="body" as="p" className="mt-1">{task.milestone}</Text>
+          <section className="verifier-detail__card">
+            <Text
+              role="display"
+              as="h2"
+              className="verifier-detail__section-title"
+            >
+              Milestone Evidence
+            </Text>
+            <div className="verifier-detail__evidence-box">
+              <Text
+                role="body"
+                as="p"
+                className="verifier-detail__evidence-label"
+              >
+                Target Milestone:
+              </Text>
+              <Text role="body" as="p">
+                {task.milestone}
+              </Text>
             </div>
-            
-            <Text role="body" as="p" className="font-bold mb-2">Submitted Proof:</Text>
+
+            <Text
+              role="body"
+              as="p"
+              className="verifier-detail__evidence-label"
+            >
+              Submitted Proof:
+            </Text>
             {task.evidenceUrl ? (
               <SafeLink
                 href={task.evidenceUrl}
-                className="inline-block px-4 py-2 border border-blue-300 text-blue-700 bg-blue-50 rounded hover:bg-blue-100 transition font-medium text-sm"
+                className="verifier-detail__evidence-link"
               >
                 &#128279; View Attached Evidence
               </SafeLink>
             ) : (
-              <Text role="body" as="p" className="text-gray-500 italic">No evidence link provided.</Text>
+              <Text role="body" as="p" className="verifier-detail__no-evidence">
+                No evidence link provided.
+              </Text>
             )}
           </section>
         </div>
 
         {/* Right Column: Verification Actions */}
-        <div className="flex flex-col gap-4">
-          <section className="p-6 border rounded-lg bg-white shadow-sm flex flex-col h-full">
-            <Text role="display" as="h2" className="mb-4">Verification Actions</Text>
-            
-            <label className="flex flex-col gap-2 mb-6 flex-grow">
-              <Text role="body" as="span" className="font-medium text-sm">Initial Verification Notes (Optional)</Text>
-              <textarea 
+        <div className="verifier-detail__side">
+          <section className="verifier-detail__card verifier-detail__actions-card">
+            <Text
+              role="display"
+              as="h2"
+              className="verifier-detail__section-title"
+            >
+              Verification Actions
+            </Text>
+
+            <label className="verifier-detail__notes-label">
+              <Text
+                role="body"
+                as="span"
+                className="verifier-detail__field-value"
+              >
+                Initial Verification Notes (Optional)
+              </Text>
+              <textarea
                 value={notes}
                 onChange={(e) => setNotes(e.target.value)}
                 placeholder="Start adding your review notes here..."
-                className="w-full border rounded p-3 text-sm h-32 focus:ring-2 focus:ring-blue-500 outline-none resize-none"
+                className="verifier-detail__textarea"
               />
             </label>
 
-            <div className="flex flex-col gap-3 mt-auto">
-              <button 
-                onClick={() => handleOpenModal('approve')}
-                className="w-full py-3 bg-green-600 text-white font-bold rounded hover:bg-green-700 transition"
+            <div className="verifier-detail__action-stack">
+              <button
+                onClick={() => handleOpenModal("approve")}
+                className="verifier-detail__action-button verifier-detail__action-button--approve"
               >
                 Approve Milestone
               </button>
-              <button 
-                onClick={() => handleOpenModal('reject')}
-                className="w-full py-3 bg-red-600 text-white font-bold rounded hover:bg-red-700 transition"
+              <button
+                onClick={() => handleOpenModal("reject")}
+                className="verifier-detail__action-button verifier-detail__action-button--reject"
               >
                 Reject Milestone
               </button>

--- a/src/pages/VerifierDashboard.tsx
+++ b/src/pages/VerifierDashboard.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { Text } from '../components/Text';
 import { useVerifierStore } from '../Zustand/Store';
+import './VerifierPages.css';
 
 export default function VerifierDashboard() {
   const navigate = useNavigate();
@@ -14,77 +15,77 @@ export default function VerifierDashboard() {
   const totalAssigned = totalPending + totalCompleted;
 
   return (
-    <div className="flex flex-col gap-6 p-6">
-      <header className="mb-4">
+    <div className="verifier-dashboard">
+      <header className="verifier-dashboard__header">
         <Text role="display" as="h1">Verifier Dashboard</Text>
-        <Text role="body" as="p" className="text-gray-500 mt-1">
+        <Text role="body" as="p" className="verifier-dashboard__lede">
           Overview of your assigned vaults and validation activity.
         </Text>
       </header>
 
       {/* Overview Stats Cards */}
-      <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="p-6 border rounded-lg shadow-sm bg-white">
-          <Text role="body" as="p" className="text-gray-500 mb-2">Total Assigned</Text>
+      <section className="verifier-dashboard__stats" aria-label="Validation statistics">
+        <div className="verifier-dashboard__stat-card">
+          <Text role="body" as="p" className="verifier-dashboard__stat-label">Total Assigned</Text>
           <Text role="display" as="h1">{totalAssigned}</Text>
         </div>
-        <div className="p-6 border rounded-lg shadow-sm bg-white border-l-4 border-l-blue-500">
-          <Text role="body" as="p" className="text-gray-500 mb-2">Pending Validations</Text>
+        <div className="verifier-dashboard__stat-card verifier-dashboard__stat-card--pending">
+          <Text role="body" as="p" className="verifier-dashboard__stat-label">Pending Validations</Text>
           <Text role="display" as="h1">{totalPending}</Text>
         </div>
-        <div className="p-6 border rounded-lg shadow-sm bg-white border-l-4 border-l-green-500">
-          <Text role="body" as="p" className="text-gray-500 mb-2">Completed</Text>
+        <div className="verifier-dashboard__stat-card verifier-dashboard__stat-card--completed">
+          <Text role="body" as="p" className="verifier-dashboard__stat-label">Completed</Text>
           <Text role="display" as="h1">{totalCompleted}</Text>
         </div>
       </section>
 
       {/* Quick Actions / Navigation */}
-      <section className="flex gap-4 mt-4">
+      <section className="verifier-dashboard__actions" aria-label="Verifier navigation">
         <button 
           onClick={() => navigate('/verifier/queue')}
-          className="px-6 py-3 bg-blue-600 text-white font-medium rounded hover:bg-blue-700 transition"
+          className="verifier-dashboard__button verifier-dashboard__button--primary"
         >
           View Pending Queue
         </button>
         <button 
           onClick={() => navigate('/verifier/history')}
-          className="px-6 py-3 border border-gray-300 font-medium rounded hover:bg-gray-50 transition"
+          className="verifier-dashboard__button verifier-dashboard__button--secondary"
         >
           View History
         </button>
       </section>
 
       {/* Recent / Urgent Activity Snippet */}
-      <section className="mt-8">
-        <Text role="display" as="h2" className="mb-4">Urgent Pending Validations</Text>
-        <div className="flex flex-col gap-3">
+      <section className="verifier-dashboard__urgent">
+        <Text role="display" as="h2" className="verifier-dashboard__section-title">Urgent Pending Validations</Text>
+        <div className="verifier-dashboard__task-list">
           {pendingValidations.length === 0 ? (
-            <div className="p-8 border rounded shadow-sm text-center text-gray-500 bg-gray-50">
+            <div className="verifier-dashboard__empty-state">
               <Text role="body" as="p">You have no pending validations at this time.</Text>
             </div>
           ) : (
             pendingValidations.slice(0, 3).map((task) => (
               <div 
                 key={task.id} 
-                className="p-4 border rounded shadow-sm flex flex-col md:flex-row justify-between md:items-center bg-white hover:shadow-md transition gap-4"
+                className="verifier-dashboard__task-card"
               >
                 <div>
                   <Text role="body" as="h3">{task.vaultName}</Text>
-                  <Text role="body" as="p" className="text-sm text-gray-500 mt-1">
+                  <Text role="body" as="p" className="verifier-dashboard__task-meta">
                     Milestone: {task.milestone}
                   </Text>
                 </div>
-                <div className="text-left md:text-right">
+                <div className="verifier-dashboard__task-actions">
                   <Text 
                     role="body" 
                     as="p"
-                    className={`font-bold ${task.daysRemaining <= 3 ? 'text-red-600' : 'text-gray-700'}`}
+                    className={`verifier-dashboard__deadline ${task.daysRemaining <= 3 ? 'is-urgent' : ''}`}
                   >
                     {task.daysRemaining} days left
                   </Text>
                   <button 
                     onClick={() => navigate(`/verifier/queue/${task.id}`)}
-                    className="text-blue-600 hover:text-blue-800 font-medium text-sm mt-2"
+                    className="verifier-dashboard__review-button"
                   >
                     Review Now &rarr;
                   </button>

--- a/src/pages/VerifierPages.css
+++ b/src/pages/VerifierPages.css
@@ -1,0 +1,537 @@
+.verifier-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+  padding: var(--spacing-6);
+}
+
+.verifier-dashboard__header {
+  margin-bottom: var(--spacing-4);
+}
+
+.verifier-dashboard__lede,
+.verifier-dashboard__stat-label,
+.verifier-dashboard__task-meta,
+.verifier-dashboard__empty-state {
+  color: var(--muted);
+}
+
+.verifier-dashboard__lede,
+.verifier-dashboard__task-meta {
+  margin-top: var(--spacing-1);
+}
+
+.verifier-dashboard__stats {
+  display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+  gap: var(--spacing-4);
+}
+
+.verifier-dashboard__stat-card,
+.verifier-dashboard__task-card,
+.verifier-dashboard__empty-state {
+  background: var(--bg);
+  border: var(--border-width-1) solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--text) 8%, transparent);
+}
+
+.verifier-dashboard__stat-card {
+  padding: var(--spacing-6);
+}
+
+.verifier-dashboard__stat-card--pending {
+  border-left: var(--border-width-4) solid var(--warning);
+}
+
+.verifier-dashboard__stat-card--completed {
+  border-left: var(--border-width-4) solid var(--success);
+}
+
+.verifier-dashboard__stat-label {
+  margin-bottom: var(--spacing-2);
+}
+
+.verifier-dashboard__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-4);
+  margin-top: var(--spacing-4);
+}
+
+.verifier-dashboard__button,
+.verifier-dashboard__review-button {
+  border-radius: var(--radius-md);
+  border: var(--border-width-1) solid transparent;
+  cursor: pointer;
+  font-weight: 600;
+  transition:
+    background var(--duration-fast, 150ms) ease,
+    border-color var(--duration-fast, 150ms) ease,
+    color var(--duration-fast, 150ms) ease,
+    box-shadow var(--duration-fast, 150ms) ease;
+}
+
+.verifier-dashboard__button {
+  min-height: var(--touch-target);
+  padding: var(--spacing-3) var(--spacing-6);
+}
+
+.verifier-dashboard__button--primary {
+  background: var(--info);
+  color: var(--bg);
+}
+
+.verifier-dashboard__button--primary:hover {
+  background: color-mix(in srgb, var(--info) 84%, var(--text));
+}
+
+.verifier-dashboard__button--secondary {
+  background: transparent;
+  border-color: var(--border-emphasis);
+  color: var(--text);
+}
+
+.verifier-dashboard__button--secondary:hover {
+  background: var(--hover);
+}
+
+.verifier-dashboard__urgent {
+  margin-top: var(--spacing-8);
+}
+
+.verifier-dashboard__section-title {
+  margin-bottom: var(--spacing-4);
+}
+
+.verifier-dashboard__task-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.verifier-dashboard__empty-state {
+  padding: var(--spacing-8);
+  text-align: center;
+}
+
+.verifier-dashboard__task-card {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  justify-content: space-between;
+  padding: var(--spacing-4);
+}
+
+.verifier-dashboard__task-card:hover {
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--text) 10%, transparent);
+}
+
+.verifier-dashboard__task-actions {
+  text-align: left;
+}
+
+.verifier-dashboard__deadline {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.verifier-dashboard__deadline.is-urgent {
+  color: var(--danger);
+}
+
+.verifier-dashboard__review-button {
+  background: transparent;
+  color: var(--info);
+  font-size: var(--font-size-caption);
+  margin-top: var(--spacing-2);
+  padding: 0;
+}
+
+.verifier-dashboard__review-button:hover {
+  color: color-mix(in srgb, var(--info) 72%, var(--text));
+}
+
+@media (min-width: 768px) {
+  .verifier-dashboard__stats {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .verifier-dashboard__task-card {
+    align-items: center;
+    flex-direction: row;
+  }
+
+  .verifier-dashboard__task-actions {
+    text-align: right;
+  }
+}
+
+.verifier-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+  padding: var(--spacing-6);
+  position: relative;
+}
+
+.verifier-page__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-2);
+}
+
+.verifier-page__lede,
+.verifier-page__meta,
+.verifier-page__empty,
+.verifier-table__subtext,
+.verifier-detail__field-label,
+.verifier-detail__no-evidence {
+  color: var(--muted);
+}
+
+.verifier-page__lede,
+.verifier-page__meta,
+.verifier-table__subtext {
+  margin-top: var(--spacing-1);
+}
+
+.verifier-page__link-button,
+.verifier-page__button,
+.verifier-table__review-button,
+.verifier-detail__evidence-link,
+.verifier-detail__action-button {
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-weight: 600;
+  transition:
+    background var(--duration-fast, 150ms) ease,
+    border-color var(--duration-fast, 150ms) ease,
+    color var(--duration-fast, 150ms) ease,
+    box-shadow var(--duration-fast, 150ms) ease;
+}
+
+.verifier-page__link-button {
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  font-size: var(--font-size-caption);
+  margin-bottom: var(--spacing-2);
+  padding: 0;
+}
+
+.verifier-page__link-button:hover {
+  color: var(--text);
+}
+
+.verifier-page__button {
+  background: transparent;
+  border: var(--border-width-1) solid var(--border-emphasis);
+  color: var(--text);
+  min-height: var(--touch-target);
+  padding: var(--spacing-2) var(--spacing-4);
+}
+
+.verifier-page__button:hover {
+  background: var(--hover);
+}
+
+.verifier-table-card,
+.verifier-detail__card,
+.verifier-detail__not-found {
+  background: var(--bg);
+  border: var(--border-width-1) solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--text) 8%, transparent);
+}
+
+.verifier-table-card {
+  overflow-x: auto;
+}
+
+.verifier-page__empty {
+  padding: 3rem;
+  text-align: center;
+}
+
+.verifier-table {
+  border-collapse: collapse;
+  text-align: left;
+  width: 100%;
+}
+
+.verifier-table__head-row {
+  background: var(--surface);
+  border-bottom: var(--border-width-1) solid var(--border);
+}
+
+.verifier-table__header,
+.verifier-table__cell {
+  padding: var(--spacing-4);
+}
+
+.verifier-table__header {
+  color: var(--muted);
+  font-size: var(--font-size-caption);
+  font-weight: 600;
+}
+
+.verifier-table__header--actions,
+.verifier-table__cell--actions {
+  text-align: right;
+}
+
+.verifier-table__row {
+  border-bottom: var(--border-width-1) solid var(--border-subtle);
+  transition: background var(--duration-fast, 150ms) ease;
+}
+
+.verifier-table__row:hover {
+  background: var(--surface);
+}
+
+.verifier-table__title,
+.verifier-table__amount {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.verifier-table__wallet,
+.verifier-detail__wallet {
+  background: var(--surface);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  display: inline-block;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-caption);
+  padding: var(--spacing-1) var(--spacing-2);
+}
+
+.verifier-table__deadline {
+  color: var(--success);
+  display: inline-block;
+  font-size: var(--font-size-caption);
+  font-weight: 700;
+  margin-top: var(--spacing-1);
+}
+
+.verifier-table__deadline.is-urgent {
+  color: var(--warning);
+}
+
+.verifier-table__deadline-cell {
+  display: flex;
+  flex-direction: column;
+}
+
+.verifier-table__review-button {
+  background: color-mix(in srgb, var(--info) 12%, transparent);
+  border: 0;
+  color: var(--info);
+  font-size: var(--font-size-caption);
+  padding: var(--spacing-2) var(--spacing-4);
+}
+
+.verifier-table__review-button:hover {
+  background: color-mix(in srgb, var(--info) 18%, transparent);
+}
+
+.verifier-detail__not-found {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  padding: 3rem;
+  text-align: center;
+}
+
+.verifier-detail__return-button,
+.verifier-dashboard__button--primary {
+  background: var(--info);
+  border: var(--border-width-1) solid transparent;
+  color: var(--bg);
+}
+
+.verifier-detail__return-button {
+  min-height: var(--touch-target);
+  padding: var(--spacing-2) var(--spacing-6);
+}
+
+.verifier-detail__return-button:hover,
+.verifier-dashboard__button--primary:hover {
+  background: color-mix(in srgb, var(--info) 84%, var(--text));
+}
+
+.verifier-detail__header-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.verifier-detail__deadline-badge {
+  align-self: flex-start;
+  background: color-mix(in srgb, var(--success) 14%, transparent);
+  border-radius: var(--radius-md);
+  color: var(--success);
+  font-size: var(--font-size-caption);
+  font-weight: 700;
+  padding: var(--spacing-2) var(--spacing-4);
+}
+
+.verifier-detail__deadline-badge.is-urgent {
+  background: color-mix(in srgb, var(--warning) 16%, transparent);
+  color: var(--warning);
+}
+
+.verifier-detail__grid {
+  display: grid;
+  gap: var(--spacing-6);
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.verifier-detail__main,
+.verifier-detail__side {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+}
+
+.verifier-detail__card {
+  padding: var(--spacing-6);
+}
+
+.verifier-detail__summary-grid {
+  display: grid;
+  gap: var(--spacing-4);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.verifier-detail__field-label {
+  font-size: var(--font-size-caption);
+}
+
+.verifier-detail__field-value {
+  font-weight: 600;
+}
+
+.verifier-detail__amount {
+  color: var(--success);
+  font-weight: 700;
+}
+
+.verifier-detail__wallet {
+  display: block;
+  margin-top: var(--spacing-1);
+  width: max-content;
+}
+
+.verifier-detail__evidence-box {
+  background: var(--surface);
+  border: var(--border-width-1) solid var(--border);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--spacing-4);
+  padding: var(--spacing-4);
+}
+
+.verifier-detail__section-title {
+  margin-bottom: var(--spacing-4);
+}
+
+.verifier-detail__evidence-label {
+  font-weight: 700;
+  margin-bottom: var(--spacing-2);
+}
+
+.verifier-detail__evidence-link {
+  background: color-mix(in srgb, var(--info) 12%, transparent);
+  border: var(--border-width-1) solid color-mix(in srgb, var(--info) 36%, transparent);
+  color: var(--info);
+  display: inline-block;
+  font-size: var(--font-size-caption);
+  padding: var(--spacing-2) var(--spacing-4);
+}
+
+.verifier-detail__evidence-link:hover {
+  background: color-mix(in srgb, var(--info) 18%, transparent);
+  text-decoration: none;
+}
+
+.verifier-detail__actions-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.verifier-detail__notes-label {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-6);
+}
+
+.verifier-detail__textarea {
+  background: var(--bg);
+  border: var(--border-width-1) solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text);
+  min-height: 8rem;
+  outline: none;
+  padding: var(--spacing-3);
+  resize: none;
+  width: 100%;
+}
+
+.verifier-detail__textarea:focus {
+  border-color: var(--info);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--info) 18%, transparent);
+}
+
+.verifier-detail__action-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  margin-top: auto;
+}
+
+.verifier-detail__action-button {
+  border: 0;
+  color: var(--bg);
+  font-weight: 700;
+  min-height: var(--touch-target);
+  padding: var(--spacing-3);
+  width: 100%;
+}
+
+.verifier-detail__action-button--approve {
+  background: var(--success);
+}
+
+.verifier-detail__action-button--approve:hover {
+  background: color-mix(in srgb, var(--success) 84%, var(--text));
+}
+
+.verifier-detail__action-button--reject {
+  background: var(--danger);
+}
+
+.verifier-detail__action-button--reject:hover {
+  background: color-mix(in srgb, var(--danger) 84%, var(--text));
+}
+
+@media (min-width: 768px) {
+  .verifier-page__header,
+  .verifier-detail__header-row {
+    align-items: flex-end;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 1024px) {
+  .verifier-detail__grid {
+    grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+  }
+}

--- a/src/pages/__tests__/PendingValidations.test.tsx
+++ b/src/pages/__tests__/PendingValidations.test.tsx
@@ -1,16 +1,19 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
-import PendingValidations from '../PendingValidations';
-import { useVerifierStore } from '../../Zustand/Store';
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import PendingValidations from "../PendingValidations";
+import { useVerifierStore } from "../../Zustand/Store";
 
-vi.mock('../../Zustand/Store', () => ({
+vi.mock("../../Zustand/Store", () => ({
   useVerifierStore: vi.fn(),
 }));
 
 const mockNavigate = vi.fn();
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock("react-router-dom", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
   return {
     ...actual,
     useNavigate: () => mockNavigate,
@@ -19,34 +22,34 @@ vi.mock('react-router-dom', async () => {
 
 const makeTasks = () => [
   {
-    id: 'v-1',
-    vaultName: 'Alpha Vault',
-    owner: '0xAAAA',
-    amount: '10,000 USDC',
-    deadline: '2026-07-01',
+    id: "v-1",
+    vaultName: "Alpha Vault",
+    owner: "0xAAAA",
+    amount: "10,000 USDC",
+    deadline: "2026-07-01",
     daysRemaining: 10,
-    status: 'pending' as const,
-    milestone: 'Phase 1',
+    status: "pending" as const,
+    milestone: "Phase 1",
   },
   {
-    id: 'v-2',
-    vaultName: 'Beta Vault',
-    owner: '0xBBBB',
-    amount: '5,000 USDC',
-    deadline: '2026-06-20',
+    id: "v-2",
+    vaultName: "Beta Vault",
+    owner: "0xBBBB",
+    amount: "5,000 USDC",
+    deadline: "2026-06-20",
     daysRemaining: 2,
-    status: 'pending' as const,
-    milestone: 'Phase 2',
+    status: "pending" as const,
+    milestone: "Phase 2",
   },
   {
-    id: 'v-3',
-    vaultName: 'Gamma Vault',
-    owner: '0xCCCC',
-    amount: '20,000 USDC',
-    deadline: '2026-07-10',
+    id: "v-3",
+    vaultName: "Gamma Vault",
+    owner: "0xCCCC",
+    amount: "20,000 USDC",
+    deadline: "2026-07-10",
     daysRemaining: 20,
-    status: 'pending' as const,
-    milestone: 'Phase 3',
+    status: "pending" as const,
+    milestone: "Phase 3",
   },
 ];
 
@@ -54,126 +57,144 @@ function renderPage() {
   return render(
     <MemoryRouter>
       <PendingValidations />
-    </MemoryRouter>
+    </MemoryRouter>,
   );
 }
 
-describe('PendingValidations', () => {
+describe("PendingValidations", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: makeTasks() });
+    (useVerifierStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      pendingValidations: makeTasks(),
+    });
   });
 
-  it('renders the page heading', () => {
+  it("renders the page heading", () => {
     renderPage();
-    expect(screen.getByText('Pending Validations')).toBeInTheDocument();
+    expect(screen.getByText("Pending Validations")).toBeInTheDocument();
   });
 
   it('shows "All caught up!" when there are no pending validations', () => {
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+    (useVerifierStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      pendingValidations: [],
+    });
     renderPage();
-    expect(screen.getByText('All caught up!')).toBeInTheDocument();
+    expect(screen.getByText("All caught up!")).toBeInTheDocument();
     expect(screen.getByText(/no pending validations/i)).toBeInTheDocument();
   });
 
-  it('does not render the table when queue is empty', () => {
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+  it("does not render the table when queue is empty", () => {
+    (useVerifierStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      pendingValidations: [],
+    });
     renderPage();
-    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 
-  it('renders a row for each pending task', () => {
+  it("renders a row for each pending task", () => {
     renderPage();
-    expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
-    expect(screen.getByText('Beta Vault')).toBeInTheDocument();
-    expect(screen.getByText('Gamma Vault')).toBeInTheDocument();
+    expect(screen.getByText("Alpha Vault")).toBeInTheDocument();
+    expect(screen.getByText("Beta Vault")).toBeInTheDocument();
+    expect(screen.getByText("Gamma Vault")).toBeInTheDocument();
   });
 
   it('default sort is ascending (most urgent first) and button shows "High to Low"', () => {
     renderPage();
-    expect(screen.getByRole('button', { name: /High to Low/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /High to Low/i }),
+    ).toBeInTheDocument();
 
-    // ascending: v-2 (2 days) → v-1 (10 days) → v-3 (20 days)
     const vaultCells = screen.getAllByText(/Vault$/);
-    expect(vaultCells[0].textContent).toBe('Beta Vault');
-    expect(vaultCells[1].textContent).toBe('Alpha Vault');
-    expect(vaultCells[2].textContent).toBe('Gamma Vault');
+    expect(vaultCells[0].textContent).toBe("Beta Vault");
+    expect(vaultCells[1].textContent).toBe("Alpha Vault");
+    expect(vaultCells[2].textContent).toBe("Gamma Vault");
   });
 
   it('toggling sort reverses the order and button shows "Low to High"', () => {
     renderPage();
-    fireEvent.click(screen.getByRole('button', { name: /High to Low/i }));
+    fireEvent.click(screen.getByRole("button", { name: /High to Low/i }));
 
-    expect(screen.getByRole('button', { name: /Low to High/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Low to High/i }),
+    ).toBeInTheDocument();
 
-    // descending: v-3 (20 days) → v-1 (10 days) → v-2 (2 days)
     const vaultCells = screen.getAllByText(/Vault$/);
-    expect(vaultCells[0].textContent).toBe('Gamma Vault');
-    expect(vaultCells[1].textContent).toBe('Alpha Vault');
-    expect(vaultCells[2].textContent).toBe('Beta Vault');
+    expect(vaultCells[0].textContent).toBe("Gamma Vault");
+    expect(vaultCells[1].textContent).toBe("Alpha Vault");
+    expect(vaultCells[2].textContent).toBe("Beta Vault");
   });
 
-  it('toggling twice returns to original ascending order', () => {
+  it("toggling twice returns to original ascending order", () => {
     renderPage();
-    fireEvent.click(screen.getByRole('button', { name: /High to Low/i }));
-    fireEvent.click(screen.getByRole('button', { name: /Low to High/i }));
+    fireEvent.click(screen.getByRole("button", { name: /High to Low/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Low to High/i }));
 
-    expect(screen.getByRole('button', { name: /High to Low/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /High to Low/i }),
+    ).toBeInTheDocument();
 
-    // back to ascending: v-2 → v-1 → v-3
     const vaultCells = screen.getAllByText(/Vault$/);
-    expect(vaultCells[0].textContent).toBe('Beta Vault');
-    expect(vaultCells[1].textContent).toBe('Alpha Vault');
-    expect(vaultCells[2].textContent).toBe('Gamma Vault');
+    expect(vaultCells[0].textContent).toBe("Beta Vault");
+    expect(vaultCells[1].textContent).toBe("Alpha Vault");
+    expect(vaultCells[2].textContent).toBe("Gamma Vault");
   });
 
-  it('clicking Review navigates to the correct ValidationDetail route', () => {
+  it("clicking Review navigates to the correct ValidationDetail route", () => {
     renderPage();
-    const reviewButtons = screen.getAllByRole('button', { name: /Review/i });
-    // first row after asc sort is v-2 (daysRemaining: 2)
+    const reviewButtons = screen.getAllByRole("button", { name: /Review/i });
     fireEvent.click(reviewButtons[0]);
-    expect(mockNavigate).toHaveBeenCalledWith('/verifier/queue/v-2');
+    expect(mockNavigate).toHaveBeenCalledWith("/verifier/queue/v-2");
   });
 
-  it('clicking Back navigates to /verifier', () => {
+  it("clicking Back navigates to /verifier", () => {
     renderPage();
     fireEvent.click(screen.getByText(/Back to Dashboard/i));
-    expect(mockNavigate).toHaveBeenCalledWith('/verifier');
+    expect(mockNavigate).toHaveBeenCalledWith("/verifier");
   });
 
-  it('renders a single task without crashing', () => {
-    (useVerifierStore as any).mockReturnValue({
+  it("renders a single task without crashing", () => {
+    (useVerifierStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       pendingValidations: [makeTasks()[0]],
     });
     renderPage();
-    expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
-    expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 row
+    expect(screen.getByText("Alpha Vault")).toBeInTheDocument();
+    expect(screen.getAllByRole("row")).toHaveLength(2);
   });
 
-  it('handles ties in daysRemaining (stable relative order preserved)', () => {
-    (useVerifierStore as any).mockReturnValue({
+  it("handles ties in daysRemaining", () => {
+    (useVerifierStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       pendingValidations: [
-        { ...makeTasks()[0], id: 'v-a', daysRemaining: 5 },
-        { ...makeTasks()[1], id: 'v-b', daysRemaining: 5 },
+        { ...makeTasks()[0], id: "v-a", daysRemaining: 5 },
+        { ...makeTasks()[1], id: "v-b", daysRemaining: 5 },
       ],
     });
     renderPage();
-    const rows = screen.getAllByRole('row').slice(1);
+    const rows = screen.getAllByRole("row").slice(1);
     expect(rows).toHaveLength(2);
-    // both show 5 days left — just assert they render without error
-    expect(screen.getAllByText('5 days left')).toHaveLength(2);
+    expect(screen.getAllByText("5 days left")).toHaveLength(2);
   });
 
-  it('shows daysRemaining in red for tasks with 3 or fewer days', () => {
+  it("marks tasks with 3 or fewer days using the tokenized urgent state", () => {
     renderPage();
-    // v-2 has daysRemaining: 2 — should have red styling
-    const urgentSpan = screen.getByText('2 days left');
-    expect(urgentSpan.className).toContain('text-red-600');
+    expect(screen.getByText("2 days left")).toHaveClass("is-urgent");
   });
 
-  it('shows daysRemaining in green for tasks with more than 3 days', () => {
+  it("keeps non-urgent deadlines on the base tokenized state", () => {
     renderPage();
-    const safeSpan = screen.getByText('10 days left');
-    expect(safeSpan.className).toContain('text-green-600');
+    const safeSpan = screen.getByText("10 days left");
+    expect(safeSpan).toHaveClass("verifier-table__deadline");
+    expect(safeSpan).not.toHaveClass("is-urgent");
+  });
+
+  it("uses tokenized verifier page classes for styling", () => {
+    renderPage();
+
+    expect(screen.getByRole("table")).toHaveClass("verifier-table");
+    expect(screen.getByText("2 days left")).toHaveClass(
+      "verifier-table__deadline",
+    );
+    expect(
+      screen.getByRole("button", { name: /Back to Dashboard/i }),
+    ).toHaveClass("verifier-page__link-button");
   });
 });

--- a/src/pages/__tests__/VerifierDashboard.test.tsx
+++ b/src/pages/__tests__/VerifierDashboard.test.tsx
@@ -1,0 +1,109 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import VerifierDashboard from '../VerifierDashboard';
+import { useVerifierStore } from '../../Zustand/Store';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../../Zustand/Store', () => ({
+  useVerifierStore: vi.fn(),
+}));
+
+const pendingValidations = [
+  {
+    id: 'v-101',
+    vaultName: 'Q3 Development Fund',
+    owner: '0x1234...abcd',
+    amount: '50,000 USDC',
+    deadline: '2026-05-15',
+    daysRemaining: 16,
+    status: 'pending',
+    milestone: 'Beta Release Deployment',
+  },
+  {
+    id: 'v-102',
+    vaultName: 'Community Grant #42',
+    owner: '0x8888...9999',
+    amount: '10,000 USDC',
+    deadline: '2026-05-02',
+    daysRemaining: 3,
+    status: 'pending',
+    milestone: 'Design System Figma Delivery',
+  },
+];
+
+const validationHistory = [
+  {
+    id: 'v-099',
+    vaultName: 'Audit Bounty',
+    owner: '0x7777...4444',
+    amount: '5,000 USDC',
+    deadline: '2026-04-10',
+    daysRemaining: 0,
+    status: 'approved',
+    milestone: 'Smart Contract Security Audit',
+  },
+];
+
+describe('VerifierDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useVerifierStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      pendingValidations,
+      validationHistory,
+    });
+  });
+
+  it('renders verifier stats and urgent pending validations', () => {
+    render(
+      <MemoryRouter>
+        <VerifierDashboard />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Verifier Dashboard' })).toBeInTheDocument();
+    expect(screen.getByText('Total Assigned')).toBeInTheDocument();
+    expect(screen.getByText('Pending Validations')).toBeInTheDocument();
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('Q3 Development Fund')).toBeInTheDocument();
+    expect(screen.getByText('Community Grant #42')).toBeInTheDocument();
+  });
+
+  it('navigates to the verifier queue, history, and task detail pages', () => {
+    render(
+      <MemoryRouter>
+        <VerifierDashboard />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'View Pending Queue' }));
+    fireEvent.click(screen.getByRole('button', { name: 'View History' }));
+    fireEvent.click(screen.getAllByRole('button', { name: /Review Now/i })[0]);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/verifier/queue');
+    expect(mockNavigate).toHaveBeenCalledWith('/verifier/history');
+    expect(mockNavigate).toHaveBeenCalledWith('/verifier/queue/v-101');
+  });
+
+  it('keeps hardcoded Tailwind color utilities out of the dashboard markup', () => {
+    const source = readFileSync(join(process.cwd(), 'src/pages/VerifierDashboard.tsx'), 'utf8');
+
+    expect(source).not.toMatch(/\b(?:bg|text|border|hover:bg|hover:text)-(?:gray|blue|green|red)-\d{2,3}\b/);
+    expect(source).toContain("import './VerifierPages.css'");
+  });
+});


### PR DESCRIPTION
## Summary

- Migrates the verifier dashboard, pending queue, and validation detail pages away from hardcoded Tailwind color utilities and onto semantic CSS variables.
- Adds shared verifier styling in `VerifierPages.css` for surfaces, table states, urgency badges, evidence links, and approve/reject actions.
- Documents the mapping for muted text, surfaces, pending/urgent, completed/approved, info links, and destructive actions.
- Adds regression tests for VerifierDashboard and PendingValidations to keep hardcoded color utilities out of verifier page markup.

## Validation

- `npm run test -- src/pages/__tests__/VerifierDashboard.test.tsx src/pages/__tests__/PendingValidations.test.tsx src/pages/__tests__/ValidationDetail.test.tsx` passed 15/15.
- `git diff --check` passed.
- `rg "\b(?:bg|text|border|hover:bg|hover:text|focus:ring)-(?:gray|blue|green|red)-[0-9]{2,3}\b" src/pages/VerifierDashboard.tsx src/pages/PendingValidations.tsx src/pages/ValidationDetail.tsx` found no matches.

Closes #125.