### PR TITLE
[codex] Add validated EvidenceUpload field

### DIFF
--- a/design-system/documentation/evidence-upload.md
+++ b/design-system/documentation/evidence-upload.md
@@ -1,0 +1,20 @@
+# Evidence Upload
+
+`EvidenceUpload` lets a vault owner attach a public evidence URL for milestone validation. It builds on the shared `Field` component so label, hint, error, `aria-describedby`, and `aria-invalid` behavior stay consistent with other forms.
+
+## Accepted URLs
+
+- `https://...`
+- `http://...`
+
+The URL is trimmed before being emitted. Missing schemes, `javascript:`, `data:`, and other non-http(s) schemes are rejected so verifier screens do not render unsafe evidence links later.
+
+## States
+
+| State | Behavior |
+| --- | --- |
+| Empty | Shows neutral guidance using `--muted`. |
+| Invalid | Shows a `Field` error using `--danger` after blur or submit. |
+| Valid | Shows accepted evidence feedback using `--success`. |
+
+Use the `onChange` callback to receive the validated URL, or `undefined` when the current input is empty or invalid. Use `onSubmit` when the parent flow needs an explicit attach action.

--- a/src/components/EvidenceUpload.tsx
+++ b/src/components/EvidenceUpload.tsx
@@ -1,0 +1,111 @@
+import { type ChangeEvent, useEffect, useId, useMemo, useState } from 'react'
+import { Field } from './Field'
+import { Text } from './Text'
+import { normalizeEvidenceUrl } from '../utils/url'
+
+type EvidenceUploadStatus = 'empty' | 'invalid' | 'valid'
+
+interface EvidenceUploadProps {
+  id?: string
+  label?: string
+  value?: string
+  required?: boolean
+  onChange?: (evidenceUrl: string | undefined) => void
+  onSubmit?: (evidenceUrl: string) => void
+}
+
+export function EvidenceUpload({
+  id,
+  label = 'Evidence URL',
+  value = '',
+  required = false,
+  onChange,
+  onSubmit,
+}: EvidenceUploadProps) {
+  const generatedId = useId()
+  const fieldId = id || `evidence-upload-${generatedId}`
+  const [rawValue, setRawValue] = useState(value)
+  const [touched, setTouched] = useState(false)
+  const normalizedUrl = useMemo(() => normalizeEvidenceUrl(rawValue), [rawValue])
+  const hasInput = rawValue.trim().length > 0
+  const status: EvidenceUploadStatus = !hasInput ? 'empty' : normalizedUrl ? 'valid' : 'invalid'
+  const error = touched && status === 'invalid'
+    ? 'Enter a safe evidence URL starting with http:// or https://.'
+    : undefined
+
+  useEffect(() => {
+    setRawValue(value)
+  }, [value])
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextValue = event.target.value
+    const nextUrl = normalizeEvidenceUrl(nextValue)
+
+    setRawValue(nextValue)
+    onChange?.(nextUrl ?? undefined)
+  }
+
+  const handleSubmit = () => {
+    setTouched(true)
+
+    if (normalizedUrl) {
+      onSubmit?.(normalizedUrl)
+    }
+  }
+
+  return (
+    <div
+      data-status={status}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--spacing-2)',
+      }}
+    >
+      <Field
+        id={fieldId}
+        label={label}
+        type="url"
+        inputMode="url"
+        value={rawValue}
+        onChange={handleChange}
+        onBlur={() => setTouched(true)}
+        placeholder="https://github.com/org/repo/pull/42"
+        required={required}
+        error={error}
+        hint={status === 'empty' ? 'Attach a public http or https link to milestone evidence.' : undefined}
+      />
+      {status === 'valid' && normalizedUrl && (
+        <Text
+          role="caption"
+          as="span"
+          style={{
+            color: 'var(--success)',
+          }}
+        >
+          Evidence link accepted: {normalizedUrl}
+        </Text>
+      )}
+      {onSubmit && (
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!normalizedUrl}
+          style={{
+            alignSelf: 'flex-start',
+            background: normalizedUrl ? 'var(--accent)' : 'var(--surface-raised)',
+            border: 'var(--border-width-1) solid var(--border)',
+            borderRadius: 'var(--radius)',
+            color: normalizedUrl ? 'var(--bg)' : 'var(--muted)',
+            cursor: normalizedUrl ? 'pointer' : 'not-allowed',
+            fontWeight: 600,
+            minHeight: 'var(--touch-target)',
+            padding: 'var(--spacing-2) var(--spacing-4)',
+          }}
+        >
+          Attach Evidence
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -29,6 +29,7 @@ export const Field = React.forwardRef<HTMLInputElement, FieldProps>(
         ref={ref}
         id={fieldId}
         required={required}
+        aria-label={label}
         aria-describedby={[errorId, hintId].filter(Boolean).join(' ')}
         aria-invalid={!!error}
         style={{
@@ -63,6 +64,6 @@ export const Field = React.forwardRef<HTMLInputElement, FieldProps>(
       )}
     </div>
   )
-}
+})
 
 Field.displayName = 'Field'

--- a/src/components/__tests__/EvidenceUpload.test.tsx
+++ b/src/components/__tests__/EvidenceUpload.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { EvidenceUpload } from '../EvidenceUpload'
+
+describe('EvidenceUpload', () => {
+  it('renders an accessible evidence URL field with empty-state guidance', () => {
+    render(<EvidenceUpload />)
+
+    expect(screen.getByLabelText('Evidence URL')).toBeInTheDocument()
+    expect(screen.getByText(/Attach a public http or https link/)).toBeInTheDocument()
+  })
+
+  it('emits trimmed http or https evidence URLs', () => {
+    const handleChange = vi.fn()
+    render(<EvidenceUpload onChange={handleChange} />)
+
+    fireEvent.change(screen.getByLabelText('Evidence URL'), {
+      target: { value: '  https://github.com/org/repo/pull/42  ' },
+    })
+
+    expect(handleChange).toHaveBeenLastCalledWith('https://github.com/org/repo/pull/42')
+    expect(screen.getByText(/Evidence link accepted/)).toBeInTheDocument()
+  })
+
+  it('rejects unsafe URL schemes and marks the field invalid after blur', () => {
+    const handleChange = vi.fn()
+    render(<EvidenceUpload onChange={handleChange} />)
+
+    const input = screen.getByLabelText('Evidence URL')
+    fireEvent.change(input, { target: { value: 'javascript:alert(1)' } })
+    fireEvent.blur(input)
+
+    expect(handleChange).toHaveBeenLastCalledWith(undefined)
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByText(/starting with http:\/\/ or https:\/\//)).toBeInTheDocument()
+  })
+
+  it('submits only validated evidence URLs', () => {
+    const handleSubmit = vi.fn()
+    render(<EvidenceUpload onSubmit={handleSubmit} />)
+
+    const button = screen.getByRole('button', { name: 'Attach Evidence' })
+    expect(button).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Evidence URL'), {
+      target: { value: 'https://example.com/proof' },
+    })
+    fireEvent.click(button)
+
+    expect(handleSubmit).toHaveBeenCalledWith('https://example.com/proof')
+  })
+})

--- a/src/pages/CreateVault.tsx
+++ b/src/pages/CreateVault.tsx
@@ -1,17 +1,19 @@
 import { useState } from 'react'
 import { Text } from '../components/Text'
 import { Field } from '../components/Field'
+import { EvidenceUpload } from '../components/EvidenceUpload'
 
 export default function CreateVault() {
   const [amount, setAmount] = useState('')
   const [deadline, setDeadline] = useState('')
   const [successAddress, setSuccessAddress] = useState('')
   const [failureAddress, setFailureAddress] = useState('')
+  const [evidenceUrl, setEvidenceUrl] = useState<string | undefined>()
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     // Placeholder: will call backend / contract
-    console.log({ amount, deadline, successAddress, failureAddress })
+    console.log({ amount, deadline, successAddress, failureAddress, evidenceUrl })
   }
 
   return (
@@ -62,6 +64,7 @@ export default function CreateVault() {
           placeholder="G..."
           required
         />
+        <EvidenceUpload onChange={setEvidenceUrl} />
         <button
           type="submit"
           style={{

--- a/src/utils/__tests__/url.test.ts
+++ b/src/utils/__tests__/url.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { isSafeEvidenceUrl, normalizeEvidenceUrl } from '../url'
+
+describe('evidence URL validation', () => {
+  it('accepts http and https URLs', () => {
+    expect(isSafeEvidenceUrl('https://github.com/org/repo/pull/42')).toBe(true)
+    expect(isSafeEvidenceUrl('http://example.com/evidence')).toBe(true)
+  })
+
+  it('trims safe URLs before returning them', () => {
+    expect(normalizeEvidenceUrl('  https://example.com/doc  ')).toBe('https://example.com/doc')
+  })
+
+  it('rejects unsafe and missing schemes', () => {
+    expect(isSafeEvidenceUrl('javascript:alert(1)')).toBe(false)
+    expect(isSafeEvidenceUrl('data:text/html,hello')).toBe(false)
+    expect(isSafeEvidenceUrl('example.com/evidence')).toBe(false)
+    expect(isSafeEvidenceUrl('')).toBe(false)
+  })
+})

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,18 @@
+export function normalizeEvidenceUrl(value: string): string | null {
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    return null
+  }
+
+  try {
+    const parsed = new URL(trimmed)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? trimmed : null
+  } catch {
+    return null
+  }
+}
+
+export function isSafeEvidenceUrl(value: string): boolean {
+  return normalizeEvidenceUrl(value) !== null
+}


### PR DESCRIPTION
## Summary

- Adds `EvidenceUpload`, an accessible evidence URL field built on the existing `Field` component label/error/aria pattern.
- Adds `normalizeEvidenceUrl()` and `isSafeEvidenceUrl()` helpers that accept only `http://` and `https://` links, trim valid values, and reject unsafe schemes like `javascript:` or `data:`.
- Wires the validated evidence URL into the Create Vault placeholder flow so downstream milestone validation data can populate `ValidationTask.evidenceUrl`.
- Documents accepted formats and empty/invalid/valid states in `design-system/documentation/evidence-upload.md`.
- Repairs the existing `Field` `forwardRef` closure and adds a stable input `aria-label`, which is required for the new component and existing Field tests to compile and pass.

## Validation

- `npx vitest run src/utils/__tests__/url.test.ts src/components/__tests__/EvidenceUpload.test.tsx src/components/__tests__/Field.test.tsx --coverage --coverage.include=src/components/EvidenceUpload.tsx --coverage.include=src/utils/url.ts` passed 11/11.
- Coverage for `src/components/EvidenceUpload.tsx` and `src/utils/url.ts`: 100% statements, branches, functions, and lines.
- `git diff --check` passed.

Note: full `npx tsc --noEmit` is still blocked by existing unrelated project-wide TypeScript issues in files such as `src/App.tsx`, existing tests, and `src/components/Layout.tsx`.

Closes #128.