### PR TITLE
[codex] Add live CountdownDeadline component

### DIFF
--- a/design-system/documentation/countdown-deadline.md
+++ b/design-system/documentation/countdown-deadline.md
@@ -1,0 +1,26 @@
+# CountdownDeadline
+
+`CountdownDeadline` renders a live, accessible countdown for vault deadlines. It exports both the component and a pure `timeRemaining(deadline, now)` helper so vault surfaces can share the same urgency thresholds.
+
+## Thresholds
+
+| State | Threshold | Tone |
+| --- | --- | --- |
+| Normal | More than 24 hours remaining | `--muted` |
+| Urgent | More than 0 and less than 24 hours remaining | `--warning` |
+| Expired | Deadline is now or in the past | `--danger` |
+| Invalid | Deadline cannot be parsed as a date | `--danger` |
+
+The component sets `title` and `aria-label` to include the absolute deadline and uses `aria-live="off"` so the interval updates do not create noisy announcements for assistive technology users.
+
+## Usage
+
+```tsx
+<CountdownDeadline deadline={vault.deadline} />
+```
+
+Use the helper in tests or non-React logic:
+
+```ts
+timeRemaining(vault.deadline, new Date())
+```

--- a/src/components/CountdownDeadline.tsx
+++ b/src/components/CountdownDeadline.tsx
@@ -1,0 +1,113 @@
+import { type CSSProperties, useEffect, useState } from 'react';
+import { Text } from './Text';
+
+export type DeadlineTone = 'normal' | 'urgent' | 'expired' | 'invalid';
+
+export interface TimeRemainingResult {
+  tone: DeadlineTone;
+  label: string;
+  msRemaining: number;
+  absoluteLabel: string;
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+export function timeRemaining(deadline: string, now: Date | number = Date.now()): TimeRemainingResult {
+  const deadlineDate = new Date(deadline);
+  const deadlineMs = deadlineDate.getTime();
+  const nowMs = typeof now === 'number' ? now : now.getTime();
+
+  if (Number.isNaN(deadlineMs)) {
+    return {
+      tone: 'invalid',
+      label: 'Invalid deadline',
+      msRemaining: 0,
+      absoluteLabel: 'Invalid deadline',
+    };
+  }
+
+  const msRemaining = deadlineMs - nowMs;
+  const absoluteLabel = deadlineDate.toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  if (msRemaining <= 0) {
+    return {
+      tone: 'expired',
+      label: 'Expired',
+      msRemaining,
+      absoluteLabel,
+    };
+  }
+
+  const days = Math.floor(msRemaining / DAY_MS);
+  const hours = Math.floor((msRemaining % DAY_MS) / HOUR_MS);
+  const minutes = Math.floor((msRemaining % HOUR_MS) / 60000);
+
+  if (days > 0) {
+    return {
+      tone: 'normal',
+      label: `${days}d ${hours}h remaining`,
+      msRemaining,
+      absoluteLabel,
+    };
+  }
+
+  return {
+    tone: 'urgent',
+    label: hours > 0 ? `${hours}h ${minutes}m remaining` : `${minutes}m remaining`,
+    msRemaining,
+    absoluteLabel,
+  };
+}
+
+interface CountdownDeadlineProps {
+  deadline: string;
+  intervalMs?: number;
+  prefix?: string;
+  style?: CSSProperties;
+}
+
+export function CountdownDeadline({
+  deadline,
+  intervalMs = 60000,
+  prefix,
+  style,
+}: CountdownDeadlineProps) {
+  const [now, setNow] = useState(() => Date.now());
+  const remaining = timeRemaining(deadline, now);
+  const color = {
+    normal: 'var(--muted)',
+    urgent: 'var(--warning)',
+    expired: 'var(--danger)',
+    invalid: 'var(--danger)',
+  }[remaining.tone];
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(timer);
+  }, [intervalMs]);
+
+  return (
+    <Text
+      role="caption"
+      as="span"
+      aria-label={`Deadline ${remaining.absoluteLabel}. ${remaining.label}`}
+      aria-live="off"
+      data-tone={remaining.tone}
+      title={remaining.absoluteLabel}
+      style={{
+        color,
+        fontWeight: 600,
+        ...style,
+      }}
+    >
+      {prefix ? `${prefix} ${remaining.label}` : remaining.label}
+    </Text>
+  );
+}

--- a/src/components/VaultCard.tsx
+++ b/src/components/VaultCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { Text } from './Text';
 import React from 'react';
+import { CountdownDeadline } from './CountdownDeadline';
 
 export type VaultStatus = 'active' | 'pending_validation' | 'completed' | 'failed';
 
@@ -13,10 +14,6 @@ export interface VaultCardProps {
   deadline: string;
   progressPct: number;
   linkTo?: string;
-}
-
-function daysRemaining(deadline: string): number {
-  return Math.max(0, Math.floor((new Date(deadline).getTime() - Date.now()) / 86400000));
 }
 
 function StatusBadge({ status }: { status: VaultStatus }) {
@@ -58,7 +55,6 @@ export default function VaultCard({
   progressPct,
   linkTo,
 }: VaultCardProps) {
-  const days = daysRemaining(deadline);
   const link = linkTo ?? `/vaults/${id}`;
 
   return (
@@ -86,11 +82,8 @@ export default function VaultCard({
             {amount.toLocaleString()} {currency}
           </Text>
           <Text role="caption" as="div" style={{ color: 'var(--muted)' }}>
-            {`Deadline: ${new Date(deadline).toLocaleDateString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-            })} (${days}d left)`}
+            Deadline:{' '}
+            <CountdownDeadline deadline={deadline} />
           </Text>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>

--- a/src/components/__tests__/CountdownDeadline.test.tsx
+++ b/src/components/__tests__/CountdownDeadline.test.tsx
@@ -1,0 +1,84 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CountdownDeadline, timeRemaining } from '../CountdownDeadline';
+
+describe('timeRemaining', () => {
+  const now = new Date('2026-06-18T12:00:00Z');
+
+  it('formats multi-day deadlines as normal', () => {
+    expect(timeRemaining('2026-06-20T15:30:00Z', now)).toMatchObject({
+      tone: 'normal',
+      label: '2d 3h remaining',
+    });
+  });
+
+  it('formats deadlines under 24 hours as urgent', () => {
+    expect(timeRemaining('2026-06-18T23:45:00Z', now)).toMatchObject({
+      tone: 'urgent',
+      label: '11h 45m remaining',
+    });
+  });
+
+  it('marks exactly-now and past deadlines as expired', () => {
+    expect(timeRemaining('2026-06-18T12:00:00Z', now).tone).toBe('expired');
+    expect(timeRemaining('2026-06-18T11:59:00Z', now).label).toBe('Expired');
+  });
+
+  it('handles invalid deadline strings', () => {
+    expect(timeRemaining('not-a-date', now)).toMatchObject({
+      tone: 'invalid',
+      label: 'Invalid deadline',
+    });
+  });
+});
+
+describe('CountdownDeadline', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('renders an accessible absolute deadline without a noisy live region', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-18T12:00:00Z'));
+
+    render(<CountdownDeadline deadline="2026-06-18T23:45:00Z" />);
+
+    const countdown = screen.getByLabelText(/Deadline Jun 19, 2026/);
+    expect(countdown).toHaveTextContent('11h 45m remaining');
+    expect(countdown).toHaveAttribute('aria-live', 'off');
+    expect(countdown).toHaveAttribute('data-tone', 'urgent');
+    expect(countdown).toHaveStyle({ color: 'var(--warning)' });
+  });
+
+  it('renders an optional prefix before the countdown label', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-18T12:00:00Z'));
+
+    render(<CountdownDeadline deadline="2026-06-20T12:00:00Z" prefix="Deadline:" />);
+
+    expect(screen.getByText('Deadline: 2d 0h remaining')).toBeInTheDocument();
+  });
+
+  it('updates on an interval and cleans up when unmounted', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-18T12:00:00Z'));
+    const clearSpy = vi.spyOn(window, 'clearInterval');
+
+    const { unmount } = render(
+      <CountdownDeadline deadline="2026-06-18T12:02:00Z" intervalMs={60000} />
+    );
+
+    expect(screen.getByText('2m remaining')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(60000);
+    });
+
+    expect(screen.getByText('1m remaining')).toBeInTheDocument();
+
+    unmount();
+
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/VaultCard.test.tsx
+++ b/src/components/__tests__/VaultCard.test.tsx
@@ -34,11 +34,9 @@ describe('VaultCard', () => {
     expect(screen.getByText('12,500 USDC')).toBeInTheDocument();
   });
 
-  it('renders formatted deadline with days remaining', () => {
+  it('renders live countdown deadline', () => {
     renderCard();
-    // Expected days remaining from fixedNow (July 1) to July 15 => 14 days
-    const deadlineRegex = /Deadline: Jul 15, 2024 \(14d left\)/;
-    expect(screen.getByText(deadlineRegex)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Deadline Jul 15, 2024/)).toHaveTextContent('14d 10h remaining');
   });
 
   it('displays correct status badge', () => {

--- a/src/pages/PendingValidations.tsx
+++ b/src/pages/PendingValidations.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { CountdownDeadline } from '../components/CountdownDeadline';
 import { Text } from '../components/Text';
 import { useVerifierStore } from '../Zustand/Store';
 
@@ -75,9 +76,7 @@ export default function PendingValidations() {
                   <td className="p-4">
                     <div className="flex flex-col">
                       <Text role="body" as="p" className="text-sm">{task.deadline}</Text>
-                      <span className={`text-xs font-bold mt-1 ${task.daysRemaining <= 3 ? 'text-red-600' : 'text-green-600'}`}>
-                        {task.daysRemaining} days left
-                      </span>
+                      <CountdownDeadline deadline={task.deadline} />
                     </div>
                   </td>
                   <td className="p-4 text-right">

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
+import { CountdownDeadline } from "../components/CountdownDeadline";
 import { Text } from "../components/Text";
 
-// ── Types ─────────────────────────────────────────────────────────────────────
+// ?? Types ?????????????????????????????????????????????????????????????????????
 type VaultStatus =
   | "active"
   | "completed"
@@ -47,7 +48,7 @@ interface Vault {
   transactions: VaultTransaction[];
 }
 
-// ── Mock Data ─────────────────────────────────────────────────────────────────
+// ?? Mock Data ?????????????????????????????????????????????????????????????????
 const MOCK_VAULTS: Record<string, Vault> = {
   "1": {
     id: "1",
@@ -182,7 +183,7 @@ const MOCK_VAULTS: Record<string, Vault> = {
   },
 };
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// ?? Helpers ???????????????????????????????????????????????????????????????????
 const STATUS_CONFIG: Record<
   VaultStatus,
   { label: string; color: string; bg: string }
@@ -256,15 +257,6 @@ function fmtDateTime(iso: string): string {
   });
 }
 
-function timeRemaining(deadline: string): string {
-  const diff = new Date(deadline).getTime() - Date.now();
-  if (diff <= 0) return "Expired";
-  const days = Math.floor(diff / 86400000);
-  const hours = Math.floor((diff % 86400000) / 3600000);
-  if (days > 0) return `${days}d ${hours}h remaining`;
-  return `${hours}h remaining`;
-}
-
 function timelineProgress(created: string, deadline: string): number {
   const start = new Date(created).getTime();
   const end = new Date(deadline).getTime();
@@ -272,7 +264,7 @@ function timelineProgress(created: string, deadline: string): number {
   return Math.min(100, Math.max(0, ((now - start) / (end - start)) * 100));
 }
 
-// ── Copy Button ───────────────────────────────────────────────────────────────
+// ?? Copy Button ???????????????????????????????????????????????????????????????
 function CopyButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
   const copy = () => {
@@ -295,12 +287,12 @@ function CopyButton({ value }: { value: string }) {
         lineHeight: 1,
       }}
     >
-      {copied ? "✓" : "⎘"}
+      {copied ? "?" : "?"}
     </button>
   );
 }
 
-// ── Address Row ───────────────────────────────────────────────────────────────
+// ?? Address Row ???????????????????????????????????????????????????????????????
 function AddrRow({ label, value }: { label: string; value: string }) {
   return (
     <div
@@ -329,7 +321,7 @@ function AddrRow({ label, value }: { label: string; value: string }) {
   );
 }
 
-// ── Section Card ─────────────────────────────────────────────────────────────
+// ?? Section Card ?????????????????????????????????????????????????????????????
 function Card({
   children,
   style,
@@ -352,7 +344,7 @@ function Card({
   );
 }
 
-// ── Main Component ────────────────────────────────────────────────────────────
+// ?? Main Component ????????????????????????????????????????????????????????????
 export default function VaultDetail() {
   const { id } = useParams<{ id: string }>();
   const vault = id ? MOCK_VAULTS[id] : undefined;
@@ -371,7 +363,7 @@ export default function VaultDetail() {
           No vault with ID "{id}" exists.
         </Text>
         <Link to="/vaults" style={{ color: "var(--accent)" }}>
-          ← Back to Vaults
+          ? Back to Vaults
         </Link>
       </div>
     );
@@ -400,10 +392,10 @@ export default function VaultDetail() {
           marginBottom: "1.25rem",
         }}
       >
-        ← Back to Vaults
+        ? Back to Vaults
       </Link>
 
-      {/* ── Header ── */}
+      {/* ?? Header ?? */}
       <Card style={{ marginBottom: "1.25rem" }}>
         <div
           style={{
@@ -476,7 +468,7 @@ export default function VaultDetail() {
         </div>
       </Card>
 
-      {/* ── Timeline ── */}
+      {/* ?? Timeline ?? */}
       <Card style={{ marginBottom: "1.25rem" }}>
         <Text
           role="caption"
@@ -537,13 +529,7 @@ export default function VaultDetail() {
             Created {fmtDate(vault.createdAt)}
           </Text>
           {isActive ? (
-            <Text
-              role="caption"
-              as="span"
-              style={{ color: "var(--accent)", fontWeight: 600 }}
-            >
-              {timeRemaining(vault.deadline)}
-            </Text>
+            <CountdownDeadline deadline={vault.deadline} />
           ) : (
             <Text
               role="caption"
@@ -559,7 +545,7 @@ export default function VaultDetail() {
         </div>
       </Card>
 
-      {/* ── Info + Addresses ── */}
+      {/* ?? Info + Addresses ?? */}
       <div
         style={{
           display: "grid",
@@ -624,7 +610,7 @@ export default function VaultDetail() {
         </Card>
       </div>
 
-      {/* ── Milestones ── */}
+      {/* ?? Milestones ?? */}
       <Card style={{ marginBottom: "1.25rem" }}>
         <Text
           role="caption"
@@ -703,7 +689,7 @@ export default function VaultDetail() {
                     rel="noopener noreferrer"
                     style={{ fontSize: 12, color: "var(--accent)" }}
                   >
-                    View evidence ↗
+                    View evidence ?
                   </a>
                 )}
               </div>
@@ -712,7 +698,7 @@ export default function VaultDetail() {
         </div>
       </Card>
 
-      {/* ── Transactions ── */}
+      {/* ?? Transactions ?? */}
       <Card>
         <Text
           role="caption"
@@ -788,7 +774,7 @@ export default function VaultDetail() {
                     rel="noopener noreferrer"
                     style={{ color: "var(--accent)", fontSize: 11 }}
                   >
-                    ↗
+                    ?
                   </a>
                 </div>
               </div>
@@ -800,7 +786,7 @@ export default function VaultDetail() {
   );
 }
 
-// ── Small helpers ─────────────────────────────────────────────────────────────
+// ?? Small helpers ?????????????????????????????????????????????????????????????
 function InfoRow({ label, value }: { label: string; value: string }) {
   return (
     <div


### PR DESCRIPTION
## Summary

- Adds `CountdownDeadline`, a reusable live countdown component with a pure `timeRemaining(deadline, now)` helper.
- Escalates countdown tone through semantic tokens: normal uses `--muted`, under 24h uses `--warning`, expired/invalid uses `--danger`.
- Exposes the absolute deadline through `title` and `aria-label`, while using `aria-live="off"` to avoid noisy interval announcements.
- Replaces the duplicated `daysRemaining` logic in `VaultCard` and reuses the countdown in `VaultDetail` and `PendingValidations`.
- Documents thresholds and usage in `design-system/documentation/countdown-deadline.md`.

## Validation

- `npx vitest run src/components/__tests__/CountdownDeadline.test.tsx src/components/__tests__/VaultCard.test.tsx --coverage --coverage.include=src/components/CountdownDeadline.tsx` passed 10/10.
- Coverage for `src/components/CountdownDeadline.tsx`: 100% statements, branches, functions, and lines.
- `git diff --check` passed.

Closes #127.