### PR TITLE
[codex] Add FundReleaseStatus settlement panel

### DIFF
--- a/design-system/documentation/fund-release-status.md
+++ b/design-system/documentation/fund-release-status.md
@@ -1,0 +1,27 @@
+# FundReleaseStatus
+
+`FundReleaseStatus` communicates where locked vault funds went after settlement. It gives vault owners and verifiers a single panel for the outcome, destination, amount, settlement timestamp, and Stellar transaction proof.
+
+## Outcomes
+
+| Outcome | Meaning | Token |
+| --- | --- | --- |
+| `released` | Funds were released to the success destination. | `--success` |
+| `redirected` | Funds were redirected to the failure destination. | `--danger` |
+| `pending` | Funds are still locked and no settlement transaction exists yet. | `--warning` |
+
+Each outcome includes both icon and text, so the state is not conveyed by color alone.
+
+## Accessibility
+
+- Long destination addresses and transaction hashes are visually truncated.
+- The full destination is preserved in `title` and `aria-label`.
+- Transaction links include the full hash and the active Stellar network in their accessible label.
+
+## Explorer Links
+
+The component reads `network` from `WalletContext`:
+
+- `TESTNET` links to `https://stellar.expert/explorer/testnet/tx/{hash}`.
+- `PUBLIC` links to `https://stellar.expert/explorer/public/tx/{hash}`.
+- A missing network falls back to TESTNET for safer development defaults.

--- a/src/components/FundReleaseStatus.css
+++ b/src/components/FundReleaseStatus.css
@@ -1,0 +1,92 @@
+.fund-release-status {
+  background: var(--surface);
+  border: var(--border-width-1) solid var(--border);
+  border-left: var(--border-width-4) solid var(--muted);
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+  padding: var(--spacing-4);
+}
+
+.fund-release-status--released {
+  border-left-color: var(--success);
+}
+
+.fund-release-status--redirected {
+  border-left-color: var(--danger);
+}
+
+.fund-release-status--pending {
+  border-left-color: var(--warning);
+}
+
+.fund-release-status__header {
+  align-items: center;
+  display: flex;
+  gap: var(--spacing-3);
+}
+
+.fund-release-status__icon {
+  align-items: center;
+  border-radius: var(--radius-full);
+  display: inline-flex;
+  flex: 0 0 auto;
+  height: var(--touch-target);
+  justify-content: center;
+  width: var(--touch-target);
+}
+
+.fund-release-status__icon--released {
+  background: color-mix(in srgb, var(--success) 14%, transparent);
+  color: var(--success);
+}
+
+.fund-release-status__icon--redirected {
+  background: color-mix(in srgb, var(--danger) 14%, transparent);
+  color: var(--danger);
+}
+
+.fund-release-status__icon--pending {
+  background: color-mix(in srgb, var(--warning) 16%, transparent);
+  color: var(--warning);
+}
+
+.fund-release-status__title {
+  margin: 0;
+}
+
+.fund-release-status__description,
+.fund-release-status__label,
+.fund-release-status__pending-copy {
+  color: var(--muted);
+}
+
+.fund-release-status__grid {
+  display: grid;
+  gap: var(--spacing-3);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.fund-release-status__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.fund-release-status__value,
+.fund-release-status__link {
+  color: var(--text);
+  font-family: var(--font-family-mono);
+  word-break: break-word;
+}
+
+.fund-release-status__link {
+  text-decoration: none;
+}
+
+.fund-release-status__link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}

--- a/src/components/FundReleaseStatus.tsx
+++ b/src/components/FundReleaseStatus.tsx
@@ -1,0 +1,167 @@
+import { AlertTriangle, CheckCircle2, Clock3 } from 'lucide-react';
+import { useWallet } from '../context/WalletContext';
+import { Text } from './Text';
+import './FundReleaseStatus.css';
+
+export type FundReleaseOutcome = 'released' | 'redirected' | 'pending';
+
+export interface SettlementTransaction {
+  hash?: string;
+  timestamp?: string;
+}
+
+export interface FundReleaseStatusProps {
+  outcome: FundReleaseOutcome;
+  destinationAddress?: string;
+  amount: number;
+  currency: string;
+  transaction?: SettlementTransaction;
+}
+
+export function truncateMiddle(value: string, prefixLength = 6, suffixLength = 4): string {
+  if (value.length <= prefixLength + suffixLength + 3) {
+    return value;
+  }
+
+  return `${value.slice(0, prefixLength)}...${value.slice(-suffixLength)}`;
+}
+
+function explorerUrl(hash: string, network: 'TESTNET' | 'PUBLIC' | null): string {
+  const segment = network === 'PUBLIC' ? 'public' : 'testnet';
+  return `https://stellar.expert/explorer/${segment}/tx/${hash}`;
+}
+
+function formatTimestamp(timestamp?: string): string {
+  if (!timestamp) {
+    return 'Pending confirmation';
+  }
+
+  return new Date(timestamp).toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+const OUTCOME_COPY = {
+  released: {
+    title: 'Funds released',
+    description: 'USDC was released to the success destination.',
+    icon: CheckCircle2,
+  },
+  redirected: {
+    title: 'Funds redirected',
+    description: 'USDC was redirected to the failure destination.',
+    icon: AlertTriangle,
+  },
+  pending: {
+    title: 'Settlement pending',
+    description: 'USDC remains locked until validation or deadline settlement completes.',
+    icon: Clock3,
+  },
+} satisfies Record<FundReleaseOutcome, { title: string; description: string; icon: typeof CheckCircle2 }>;
+
+export function FundReleaseStatus({
+  outcome,
+  destinationAddress,
+  amount,
+  currency,
+  transaction,
+}: FundReleaseStatusProps) {
+  const { network } = useWallet();
+  const copy = OUTCOME_COPY[outcome];
+  const Icon = copy.icon;
+  const hash = transaction?.hash;
+
+  return (
+    <section
+      className={`fund-release-status fund-release-status--${outcome}`}
+      aria-label={`Fund settlement status: ${copy.title}`}
+    >
+      <div className="fund-release-status__header">
+        <span
+          className={`fund-release-status__icon fund-release-status__icon--${outcome}`}
+          aria-hidden="true"
+        >
+          <Icon size={22} />
+        </span>
+        <div>
+          <Text role="title" as="h2" className="fund-release-status__title">
+            {copy.title}
+          </Text>
+          <Text role="body" as="p" className="fund-release-status__description">
+            {copy.description}
+          </Text>
+        </div>
+      </div>
+
+      {outcome === 'pending' ? (
+        <Text role="body" as="p" className="fund-release-status__pending-copy">
+          Settlement transaction details will appear after funds are released or redirected.
+        </Text>
+      ) : (
+        <div className="fund-release-status__grid">
+          <div className="fund-release-status__field">
+            <Text role="caption" as="span" className="fund-release-status__label">
+              Destination
+            </Text>
+            {destinationAddress ? (
+              <Text
+                role="mono"
+                as="span"
+                className="fund-release-status__value"
+                title={destinationAddress}
+                aria-label={`Destination address ${destinationAddress}`}
+              >
+                {truncateMiddle(destinationAddress)}
+              </Text>
+            ) : (
+              <Text role="caption" as="span" className="fund-release-status__label">
+                Not available
+              </Text>
+            )}
+          </div>
+          <div className="fund-release-status__field">
+            <Text role="caption" as="span" className="fund-release-status__label">
+              Amount
+            </Text>
+            <Text role="mono" as="span" className="fund-release-status__value">
+              {amount.toLocaleString()} {currency}
+            </Text>
+          </div>
+          <div className="fund-release-status__field">
+            <Text role="caption" as="span" className="fund-release-status__label">
+              Settled
+            </Text>
+            <Text role="caption" as="span" className="fund-release-status__value">
+              {formatTimestamp(transaction?.timestamp)}
+            </Text>
+          </div>
+          <div className="fund-release-status__field">
+            <Text role="caption" as="span" className="fund-release-status__label">
+              Transaction
+            </Text>
+            {hash ? (
+              <a
+                className="fund-release-status__link"
+                href={explorerUrl(hash, network)}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={hash}
+                aria-label={`View transaction ${hash} on Stellar ${network === 'PUBLIC' ? 'Public' : 'Testnet'} explorer`}
+              >
+                {truncateMiddle(hash, 8, 6)}
+              </a>
+            ) : (
+              <Text role="caption" as="span" className="fund-release-status__label">
+                Pending transaction
+              </Text>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/__tests__/FundReleaseStatus.test.tsx
+++ b/src/components/__tests__/FundReleaseStatus.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FundReleaseStatus, truncateMiddle } from '../FundReleaseStatus';
+
+let mockNetwork: 'TESTNET' | 'PUBLIC' | null = 'TESTNET';
+
+vi.mock('../../context/WalletContext', () => ({
+  useWallet: () => ({
+    address: null,
+    network: mockNetwork,
+    balance: null,
+    isConnecting: false,
+    error: null,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    checkConnection: vi.fn(),
+  }),
+}));
+
+describe('truncateMiddle', () => {
+  it('truncates long values and leaves short values untouched', () => {
+    expect(truncateMiddle('GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890')).toBe('GABCDE...7890');
+    expect(truncateMiddle('GSHORT')).toBe('GSHORT');
+  });
+});
+
+describe('FundReleaseStatus', () => {
+  beforeEach(() => {
+    mockNetwork = 'TESTNET';
+  });
+
+  it('renders a released settlement with destination, amount, and testnet explorer link', () => {
+    render(
+      <FundReleaseStatus
+        outcome="released"
+        destinationAddress="GSUCCESSDESTINATION1234567890"
+        amount={4200.5}
+        currency="USDC"
+        transaction={{
+          hash: 'abcdef1234567890abcdef1234567890',
+          timestamp: '2026-06-18T10:30:00Z',
+        }}
+      />
+    );
+
+    expect(screen.getByRole('region', { name: /Fund settlement status: Funds released/i })).toBeInTheDocument();
+    expect(screen.getByText('USDC was released to the success destination.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Destination address GSUCCESSDESTINATION1234567890')).toHaveTextContent('GSUCCE...7890');
+    expect(screen.getByText('4,200.5 USDC')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Stellar Testnet explorer/i })).toHaveAttribute(
+      'href',
+      'https://stellar.expert/explorer/testnet/tx/abcdef1234567890abcdef1234567890'
+    );
+  });
+
+  it('renders redirected settlement with danger semantics and public explorer link', () => {
+    mockNetwork = 'PUBLIC';
+
+    render(
+      <FundReleaseStatus
+        outcome="redirected"
+        destinationAddress="GFAILUREDESTINATION1234567890"
+        amount={8800}
+        currency="USDC"
+        transaction={{
+          hash: 'redirecthash1234567890',
+          timestamp: '2026-06-18T11:00:00Z',
+        }}
+      />
+    );
+
+    const panel = screen.getByRole('region', { name: /Fund settlement status: Funds redirected/i });
+    expect(panel).toHaveClass('fund-release-status--redirected');
+    expect(screen.getByText('USDC was redirected to the failure destination.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Stellar Public explorer/i })).toHaveAttribute(
+      'href',
+      'https://stellar.expert/explorer/public/tx/redirecthash1234567890'
+    );
+  });
+
+  it('renders pending settlement without relying on color alone', () => {
+    render(<FundReleaseStatus outcome="pending" amount={12500} currency="USDC" />);
+
+    const panel = screen.getByRole('region', { name: /Fund settlement status: Settlement pending/i });
+    expect(panel).toHaveClass('fund-release-status--pending');
+    expect(screen.getByText('Settlement pending')).toBeInTheDocument();
+    expect(screen.getByText(/Settlement transaction details will appear/)).toBeInTheDocument();
+  });
+
+  it('handles missing transaction details for final outcomes', () => {
+    render(
+      <FundReleaseStatus
+        outcome="released"
+        destinationAddress="GSUCCESSDESTINATION1234567890"
+        amount={100}
+        currency="USDC"
+      />
+    );
+
+    expect(screen.getByText('Pending confirmation')).toBeInTheDocument();
+    expect(screen.getByText('Pending transaction')).toBeInTheDocument();
+  });
+
+  it('handles a missing destination address for final outcomes', () => {
+    render(
+      <FundReleaseStatus
+        outcome="redirected"
+        amount={50}
+        currency="USDC"
+        transaction={{ hash: 'hashwithdestinationmissing' }}
+      />
+    );
+
+    expect(screen.getByText('Not available')).toBeInTheDocument();
+  });
+});

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -1,5 +1,9 @@
 import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
+import {
+  FundReleaseStatus,
+  type FundReleaseStatusProps,
+} from "../components/FundReleaseStatus";
 import { Text } from "../components/Text";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -272,6 +276,37 @@ function timelineProgress(created: string, deadline: string): number {
   return Math.min(100, Math.max(0, ((now - start) / (end - start)) * 100));
 }
 
+function settlementForVault(vault: Vault): FundReleaseStatusProps {
+  const releaseTx = vault.transactions.find((tx) => tx.type === "release");
+  const redirectTx = vault.transactions.find((tx) => tx.type === "redirect");
+
+  if (vault.status === "completed") {
+    return {
+      outcome: "released",
+      destinationAddress: vault.successAddress,
+      amount: releaseTx?.amount ?? vault.amount,
+      currency: vault.currency,
+      transaction: releaseTx,
+    };
+  }
+
+  if (vault.status === "failed" || vault.status === "cancelled") {
+    return {
+      outcome: "redirected",
+      destinationAddress: vault.failureAddress,
+      amount: redirectTx?.amount ?? vault.amount,
+      currency: vault.currency,
+      transaction: redirectTx,
+    };
+  }
+
+  return {
+    outcome: "pending",
+    amount: vault.amount,
+    currency: vault.currency,
+  };
+}
+
 // ── Copy Button ───────────────────────────────────────────────────────────────
 function CopyButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
@@ -381,6 +416,7 @@ export default function VaultDetail() {
   const progress = timelineProgress(vault.createdAt, vault.deadline);
   const isActive =
     vault.status === "active" || vault.status === "pending_validation";
+  const settlement = settlementForVault(vault);
 
   return (
     <div
@@ -623,6 +659,8 @@ export default function VaultDetail() {
           </div>
         </Card>
       </div>
+
+      <FundReleaseStatus {...settlement} />
 
       {/* ── Milestones ── */}
       <Card style={{ marginBottom: "1.25rem" }}>


### PR DESCRIPTION
## Summary

- Adds `FundReleaseStatus` with released, redirected, and pending settlement outcomes.
- Uses semantic tokens only: `--success` for releases, `--danger` for redirects, and `--warning` for pending settlement.
- Includes icon + text labels so settlement state is not conveyed by color alone.
- Truncates destination addresses and transaction hashes while preserving full values in `title` / `aria-label`.
- Reads `network` from `WalletContext` and switches Stellar expert transaction links between TESTNET and PUBLIC.
- Wires the panel into `VaultDetail` for completed, failed/cancelled, and pending vaults.
- Documents the outcome matrix in `design-system/documentation/fund-release-status.md`.

## Validation

- `npx vitest run src/components/__tests__/FundReleaseStatus.test.tsx --coverage --coverage.include=src/components/FundReleaseStatus.tsx` passed 6/6.
- Coverage for `src/components/FundReleaseStatus.tsx`: 100% statements, branches, functions, and lines.
- `git diff --check` passed.
- Static color scan found no hardcoded hex/rgb color values in `FundReleaseStatus.tsx` or `FundReleaseStatus.css`.

Closes #124.