### PR TITLE
fix: harden MobileDrawer accessibility

### DIFF
--- a/design-system/documentation/mobile-drawer-accessibility.md
+++ b/design-system/documentation/mobile-drawer-accessibility.md
@@ -1,0 +1,10 @@
+# Mobile Drawer Accessibility
+
+The mobile navigation drawer is treated as a modal navigation surface.
+
+- The drawer uses `focus-trap-react` while open so keyboard focus stays inside the drawer.
+- `Escape`, the close button, backdrop clicks, and drawer navigation links close the drawer.
+- When the drawer closes, focus returns to the menu trigger that opened it.
+- The drawer exposes `role="dialog"`, `aria-modal="true"`, and `aria-labelledby="mobile-drawer-title"` for assistive technology.
+- Layout background regions are marked `inert` and `aria-hidden` while the drawer is open.
+- Drawer controls and navigation links keep at least the shared `--touch-target` size of 44 px.

--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -55,6 +55,10 @@
   outline: 2px solid var(--accent);
 }
 
+.header-link.active {
+  color: var(--accent);
+}
+
 /* ─── "Create Vault" pill ─────────────────────────────────────────────────── */
 .header-cta {
   color: var(--surface);
@@ -155,6 +159,18 @@
   animation: slideIn 0.25s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
+.mobile-drawer-title {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .mobile-drawer-close {
   align-self: flex-end;
   background: none;
@@ -180,13 +196,21 @@
   text-decoration: none;
   font-size: 1.125rem;
   font-weight: 500;
-  padding: var(--spacing-3) 0;
+  min-height: var(--touch-target);
+  padding: var(--spacing-3) var(--spacing-2);
   border-bottom: 1px solid var(--border);
-  display: block;
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius);
 }
 
 .mobile-drawer-link:hover {
   color: var(--accent);
+}
+
+.mobile-drawer-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 @keyframes slideIn {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,10 @@
+import { useState, type HTMLAttributes } from "react";
 import { Link, useLocation } from "react-router-dom";
+import { Menu } from "lucide-react";
 import { WalletConnectButton } from "./Wallet/WalletConnectButton";
+import MobileDrawer from "./MobileDrawer";
 import { Text } from "./Text";
+import "./Layout.css";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -10,13 +14,17 @@ export default function Layout({ children }: LayoutProps) {
   const [isDrawerOpen, setDrawerOpen] = useState(false);
   const toggleDrawer = () => setDrawerOpen(prev => !prev);
   const location = useLocation();
+  const isTransactionsActive = location.pathname === "/transactions";
+  const backgroundA11yProps = isDrawerOpen
+    ? ({ "aria-hidden": true, inert: "" } as HTMLAttributes<HTMLElement> & { inert: "" })
+    : {};
 
   return (
     <div
       style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
     >
       <header className="site-header">
-        <div className="header-brand">
+        <div className="header-brand" {...backgroundA11yProps}>
           <Link to="/" className="header-link" aria-label="Disciplr home">
             <Text role="title" as="span">
               Disciplr
@@ -24,17 +32,14 @@ export default function Layout({ children }: LayoutProps) {
           </Link>
           <Link
             to="/transactions"
-            className="header-link"
+            className={`header-link${isTransactionsActive ? " active" : ""}`}
             style={{
-              color:
-                location.pathname === "/transactions"
-                  ? "var(--accent)"
-                  : "var(--muted)",
+              color: isTransactionsActive ? "var(--accent)" : "var(--muted)",
             }}
             aria-label="Transactions"
+            aria-current={isTransactionsActive ? "page" : undefined}
           >
             <span className="header-transactions-label">Transactions</span>
-            {/* Icon fallback on very small screens */}
             <span
               aria-hidden="true"
               className="header-transactions-icon"
@@ -45,7 +50,7 @@ export default function Layout({ children }: LayoutProps) {
           </Link>
         </div>
 
-        <nav style={{ display: "flex", gap: "1.5rem", alignItems: "center" }}>
+        <nav className="desktop-nav" {...backgroundA11yProps}>
           <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
             <Link
               to="/"
@@ -90,10 +95,21 @@ export default function Layout({ children }: LayoutProps) {
             <WalletConnectButton />
           </div>
         </nav>
+        <button
+          type="button"
+          className="mobile-hamburger"
+          aria-label="Open navigation menu"
+          aria-controls="mobile-drawer"
+          aria-expanded={isDrawerOpen}
+          onClick={toggleDrawer}
+        >
+          <Menu size={24} aria-hidden="true" />
+        </button>
         <MobileDrawer isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)} />
       </header>
 
       <main
+        {...backgroundA11yProps}
         style={{
           flex: 1,
           padding: "var(--spacing-8)",

--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -11,44 +11,69 @@ interface MobileDrawerProps {
 
 export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
   const drawerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
 
-  // Close on Escape key
   useEffect(() => {
+    if (!isOpen) return;
+
+    triggerRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        e.preventDefault();
         onClose();
       }
     };
-    if (isOpen) {
-      document.addEventListener('keydown', handleKey);
-    }
+
+    document.addEventListener('keydown', handleKey);
+
     return () => {
       document.removeEventListener('keydown', handleKey);
+      triggerRef.current?.focus();
     };
   }, [isOpen, onClose]);
 
-  // Prevent background scroll when drawer is open
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
     }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
   }, [isOpen]);
 
   if (!isOpen) return null;
 
   return (
-    <div className="mobile-drawer-backdrop" onClick={onClose} aria-hidden="true">
-      <FocusTrap>
+    <FocusTrap
+      focusTrapOptions={{
+        allowOutsideClick: true,
+        clickOutsideDeactivates: false,
+        escapeDeactivates: false,
+        fallbackFocus: () => drawerRef.current ?? document.body,
+        initialFocus: () =>
+          drawerRef.current?.querySelector<HTMLElement>(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+          ) ?? drawerRef.current ?? document.body,
+        returnFocusOnDeactivate: false,
+      }}
+    >
+      <div className="mobile-drawer-backdrop" onClick={onClose}>
         <nav
           className="mobile-drawer"
           role="dialog"
           aria-modal="true"
+          aria-labelledby="mobile-drawer-title"
           id="mobile-drawer"
           ref={drawerRef}
+          tabIndex={-1}
           onClick={(e) => e.stopPropagation()}
         >
+          <h2 id="mobile-drawer-title" className="mobile-drawer-title">
+            Navigation
+          </h2>
           <button className="mobile-drawer-close" onClick={onClose} aria-label="Close navigation drawer">
             <X size={24} />
           </button>
@@ -66,7 +91,7 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
           </Link>
           <WalletConnectButton />
         </nav>
-      </FocusTrap>
-    </div>
+      </div>
+    </FocusTrap>
   );
 }

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import Layout from '../../Layout';
+import Layout from '../Layout';
+
+vi.mock('../Wallet/WalletConnectButton', () => ({
+  WalletConnectButton: () => <button type="button">Connect wallet</button>,
+}));
 
 describe('Layout component navigation', () => {
   test('transactions link receives active class and aria-current when on /transactions', () => {

--- a/src/components/__tests__/MobileDrawer.test.tsx
+++ b/src/components/__tests__/MobileDrawer.test.tsx
@@ -1,0 +1,167 @@
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Layout from '../Layout';
+import MobileDrawer from '../MobileDrawer';
+
+const focusTrapState = vi.hoisted(() => ({
+  options: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock('focus-trap-react', () => ({
+  default: ({ children, focusTrapOptions }: { children: ReactNode; focusTrapOptions: Record<string, unknown> }) => {
+    focusTrapState.options.push(focusTrapOptions);
+    return <div data-testid="focus-trap">{children}</div>;
+  },
+}));
+
+vi.mock('../Wallet/WalletConnectButton', () => ({
+  WalletConnectButton: () => <button type="button">Connect wallet</button>,
+}));
+
+function renderOpenDrawer(onClose = vi.fn()) {
+  render(
+    <MemoryRouter>
+      <MobileDrawer isOpen onClose={onClose} />
+    </MemoryRouter>,
+  );
+
+  return onClose;
+}
+
+function DrawerHarness() {
+  const [isOpen, setOpen] = useState(false);
+
+  return (
+    <MemoryRouter>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open navigation menu
+      </button>
+      <MobileDrawer isOpen={isOpen} onClose={() => setOpen(false)} />
+    </MemoryRouter>
+  );
+}
+
+describe('MobileDrawer accessibility', () => {
+  beforeEach(() => {
+    focusTrapState.options = [];
+    document.body.style.overflow = '';
+  });
+
+  test('renders as a labelled modal dialog inside a focus trap', () => {
+    renderOpenDrawer();
+
+    const dialog = screen.getByRole('dialog', { name: /navigation/i });
+    expect(screen.getByTestId('focus-trap')).toBeInTheDocument();
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'mobile-drawer-title');
+    expect(dialog).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByText('Navigation')).toHaveAttribute('id', 'mobile-drawer-title');
+
+    expect(focusTrapState.options[0]).toMatchObject({
+      allowOutsideClick: true,
+      clickOutsideDeactivates: false,
+      escapeDeactivates: false,
+      returnFocusOnDeactivate: false,
+    });
+    expect(focusTrapState.options[0].initialFocus).toEqual(expect.any(Function));
+    expect(focusTrapState.options[0].fallbackFocus).toEqual(expect.any(Function));
+    expect((focusTrapState.options[0].initialFocus as () => HTMLElement)()).toBe(
+      screen.getByRole('button', { name: /close navigation drawer/i }),
+    );
+    expect((focusTrapState.options[0].fallbackFocus as () => HTMLElement)()).toBe(dialog);
+  });
+
+  test('closes on Escape and restores focus to the trigger', async () => {
+    render(<DrawerHarness />);
+
+    const trigger = screen.getByRole('button', { name: /open navigation menu/i });
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    expect(screen.getByRole('dialog', { name: /navigation/i })).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(trigger).toHaveFocus();
+  });
+
+  test('keeps drawer clicks contained and closes from navigation links', () => {
+    const onClose = renderOpenDrawer();
+    const dialog = screen.getByRole('dialog', { name: /navigation/i });
+
+    fireEvent.click(dialog);
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('link', { name: /home/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('falls back safely when focus targets are unavailable', () => {
+    const activeElementDescriptor = Object.getOwnPropertyDescriptor(document, 'activeElement');
+
+    Object.defineProperty(document, 'activeElement', {
+      configurable: true,
+      get: () => null,
+    });
+
+    const { unmount } = render(
+      <MemoryRouter>
+        <MobileDrawer isOpen onClose={vi.fn()} />
+      </MemoryRouter>,
+    );
+    const options = focusTrapState.options[0];
+
+    unmount();
+
+    expect((options.initialFocus as () => HTMLElement)()).toBe(document.body);
+    expect((options.fallbackFocus as () => HTMLElement)()).toBe(document.body);
+
+    if (activeElementDescriptor) {
+      Object.defineProperty(document, 'activeElement', activeElementDescriptor);
+    } else {
+      delete (document as Document & { activeElement?: Element | null }).activeElement;
+    }
+  });
+
+  test('closes from the backdrop and close button', () => {
+    const onClose = renderOpenDrawer();
+
+    fireEvent.click(screen.getByRole('button', { name: /close navigation drawer/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('dialog', { name: /navigation/i }).parentElement as HTMLElement);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Layout drawer integration', () => {
+  beforeEach(() => {
+    focusTrapState.options = [];
+  });
+
+  test('marks background content inert while the drawer is open', () => {
+    render(
+      <MemoryRouter>
+        <Layout>
+          <p>Page content</p>
+        </Layout>
+      </MemoryRouter>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /open navigation menu/i });
+    const main = screen.getByRole('main');
+
+    expect(main).not.toHaveAttribute('aria-hidden');
+    expect(main).not.toHaveAttribute('inert');
+
+    fireEvent.click(trigger);
+
+    const hiddenMain = screen.getByRole('main', { hidden: true });
+    expect(hiddenMain).toHaveAttribute('aria-hidden', 'true');
+    expect(hiddenMain).toHaveAttribute('inert');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+});


### PR DESCRIPTION
## Summary
- harden `MobileDrawer` with explicit focus-trap options, Escape handling, trigger focus restoration, and labelled dialog semantics
- mark background layout regions `inert` / `aria-hidden` while the drawer is open and restore the mobile trigger wiring
- ensure drawer nav links meet the shared 44px touch target and document the accessibility contract
- add RTL coverage for dialog ARIA, focus-trap configuration, Escape close, focus restoration, backdrop/link close, and Layout background inert behavior

Closes #137

## Validation
- `npx vitest run src/components/__tests__/MobileDrawer.test.tsx --coverage --coverage.include=src/components/MobileDrawer.tsx` ? 6 tests passed; MobileDrawer coverage 100% statements / branches / functions / lines
- `npx vitest run src/components/__tests__/Layout.test.tsx src/components/__tests__/MobileDrawer.test.tsx` ? 8 tests passed
- `git diff --check` ?

## Note
- `npx tsc --noEmit --pretty false` is currently blocked by an existing syntax error in `src/components/Field.tsx` at lines 68-69 on upstream main; this PR does not modify that file.