### PR TITLE
feat: fetch wallet USDC balance from Horizon

### DIFF
--- a/design-system/documentation/wallet-balance.md
+++ b/design-system/documentation/wallet-balance.md
@@ -1,0 +1,10 @@
+# Wallet USDC Balance
+
+Connected wallets display the Circle USDC trustline balance for the active Stellar network.
+
+- `TESTNET` accounts query `https://horizon-testnet.stellar.org`.
+- `PUBLIC` accounts query `https://horizon.stellar.org`.
+- The balance helper only accepts the configured Circle USDC issuer for the active network.
+- Accounts without that USDC trustline show `0.00 USDC` with a no-trustline note.
+- Horizon request failures and missing accounts show a balance-unavailable state instead of a stale or mocked value.
+- The dropdown renders a loading state while the Horizon request is in flight.

--- a/src/components/Wallet/WalletDropdown.tsx
+++ b/src/components/Wallet/WalletDropdown.tsx
@@ -9,7 +9,7 @@ interface WalletDropdownProps {
 }
 
 export function WalletDropdown({ onClose, onSwitch }: WalletDropdownProps) {
-    const { address, balance, network, disconnect } = useWallet();
+    const { address, balance, balanceStatus, balanceError, network, disconnect } = useWallet();
     const [copied, setCopied] = useState(false);
 
     if (!address) return null;
@@ -35,6 +35,43 @@ export function WalletDropdown({ onClose, onSwitch }: WalletDropdownProps) {
         window.open(`${baseUrl}/account/${address}`, '_blank');
     };
 
+    const renderBalance = () => {
+        if (balanceStatus === 'loading') {
+            return (
+                <div className="wallet-dropdown-balance-state" role="status">
+                    <span className="loader" aria-hidden="true" />
+                    Loading USDC balance
+                </div>
+            );
+        }
+
+        if (balanceStatus === 'error') {
+            return (
+                <div className="wallet-dropdown-balance-state error" role="status">
+                    Balance unavailable
+                    {balanceError && <small>{balanceError}</small>}
+                </div>
+            );
+        }
+
+        if (balanceStatus === 'no_trustline') {
+            return (
+                <div>
+                    <div className="wallet-dropdown-balance">
+                        0.00 <span>USDC</span>
+                    </div>
+                    <small className="wallet-dropdown-balance-note">No USDC trustline on this network</small>
+                </div>
+            );
+        }
+
+        return (
+            <div className="wallet-dropdown-balance">
+                {balance !== null ? balance : '-'} <span>USDC</span>
+            </div>
+        );
+    };
+
     return (
         <div className="wallet-dropdown-menu">
             <div className="wallet-dropdown-header">
@@ -44,9 +81,7 @@ export function WalletDropdown({ onClose, onSwitch }: WalletDropdownProps) {
                         {copied ? <Check size={14} color="#10b981" /> : <Copy size={14} />}
                     </button>
                 </div>
-                <div className="wallet-dropdown-balance">
-                    {balance !== null ? balance : '0.00'} <span>USDC</span>
-                </div>
+                {renderBalance()}
             </div>
 
             <div className="wallet-dropdown-actions">

--- a/src/components/Wallet/__tests__/WalletDropdown.test.tsx
+++ b/src/components/Wallet/__tests__/WalletDropdown.test.tsx
@@ -1,0 +1,160 @@
+import { act } from 'react';
+import { render, screen } from '@testing-library/react';
+import { WalletDropdown } from '../WalletDropdown';
+import type { BalanceStatus, WalletNetwork } from '../../../context/WalletContext';
+
+const walletState = vi.hoisted(() => ({
+    address: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
+    balance: '12.0000000' as string | null,
+    balanceStatus: 'success' as BalanceStatus,
+    balanceError: null as string | null,
+    network: 'TESTNET' as WalletNetwork,
+    disconnect: vi.fn(),
+}));
+
+vi.mock('../../../context/WalletContext', () => ({
+    useWallet: () => walletState,
+}));
+
+function renderDropdown() {
+    const onClose = vi.fn();
+    const onSwitch = vi.fn();
+
+    return {
+        onClose,
+        onSwitch,
+        ...render(<WalletDropdown onClose={onClose} onSwitch={onSwitch} />),
+    };
+}
+
+describe('WalletDropdown balance states', () => {
+    beforeEach(() => {
+        walletState.address = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+        walletState.balance = '12.0000000';
+        walletState.balanceStatus = 'success';
+        walletState.balanceError = null;
+        walletState.network = 'TESTNET';
+        walletState.disconnect.mockClear();
+        vi.useRealTimers();
+    });
+
+    test('renders the loaded USDC balance', () => {
+        renderDropdown();
+
+        expect(screen.getByText('12.0000000')).toBeInTheDocument();
+        expect(screen.getByText('USDC')).toBeInTheDocument();
+    });
+
+    test('renders a loading state instead of a stale balance', () => {
+        walletState.balance = null;
+        walletState.balanceStatus = 'loading';
+
+        renderDropdown();
+
+        expect(screen.getByRole('status')).toHaveTextContent('Loading USDC balance');
+        expect(screen.queryByText('12.0000000')).not.toBeInTheDocument();
+    });
+
+    test('renders the no-trustline state explicitly', () => {
+        walletState.balance = '0.00';
+        walletState.balanceStatus = 'no_trustline';
+
+        renderDropdown();
+
+        expect(screen.getByText('0.00')).toBeInTheDocument();
+        expect(screen.getByText('No USDC trustline on this network')).toBeInTheDocument();
+    });
+
+    test('renders the Horizon error state', () => {
+        walletState.balance = null;
+        walletState.balanceStatus = 'error';
+        walletState.balanceError = 'Horizon balance request failed with status 500.';
+
+        renderDropdown();
+
+        expect(screen.getByRole('status')).toHaveTextContent('Balance unavailable');
+        expect(screen.getByText('Horizon balance request failed with status 500.')).toBeInTheDocument();
+    });
+
+    test('renders nothing when no wallet is connected', () => {
+        walletState.address = null as unknown as string;
+
+        const { container } = renderDropdown();
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('copies the address and opens the public explorer', async () => {
+        vi.useFakeTimers();
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.assign(navigator, { clipboard: { writeText } });
+        const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+        walletState.network = 'PUBLIC';
+
+        renderDropdown();
+
+        await act(async () => {
+            screen.getByTitle('Copy Address').click();
+            await Promise.resolve();
+        });
+        act(() => {
+            vi.runOnlyPendingTimers();
+        });
+        expect(writeText).toHaveBeenCalledWith(walletState.address);
+
+        screen.getByRole('button', { name: /view on stellar explorer/i }).click();
+        expect(open).toHaveBeenCalledWith(
+            `https://stellar.expert/explorer/public/account/${walletState.address}`,
+            '_blank',
+        );
+
+        open.mockRestore();
+    });
+
+    test('opens the testnet explorer for testnet wallets', () => {
+        const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+        renderDropdown();
+
+        screen.getByRole('button', { name: /view on stellar explorer/i }).click();
+        expect(open).toHaveBeenCalledWith(
+            `https://stellar.expert/explorer/testnet/account/${walletState.address}`,
+            '_blank',
+        );
+
+        open.mockRestore();
+    });
+
+    test('handles copy failures without closing the dropdown', async () => {
+        Object.assign(navigator, { clipboard: { writeText: vi.fn().mockRejectedValue(new Error('denied')) } });
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        renderDropdown();
+        screen.getByTitle('Copy Address').click();
+
+        await screen.findByText('12.0000000');
+        expect(error).toHaveBeenCalledWith('Failed to copy', expect.any(Error));
+
+        error.mockRestore();
+    });
+
+    test('calls switch and disconnect actions', () => {
+        const { onClose, onSwitch } = renderDropdown();
+
+        screen.getByRole('button', { name: /switch wallet/i }).click();
+        expect(onSwitch).toHaveBeenCalledTimes(1);
+
+        screen.getByRole('button', { name: /disconnect/i }).click();
+        expect(walletState.disconnect).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('renders an empty balance fallback for idle state', () => {
+        walletState.balance = null;
+        walletState.balanceStatus = 'idle';
+
+        renderDropdown();
+
+        expect(screen.getByText('-')).toBeInTheDocument();
+    });
+});

--- a/src/components/Wallet/wallet.css
+++ b/src/components/Wallet/wallet.css
@@ -274,6 +274,30 @@
   font-weight: 400;
 }
 
+.wallet-dropdown-balance-state {
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  min-height: 2rem;
+}
+
+.wallet-dropdown-balance-state.error {
+  align-items: flex-start;
+  color: var(--danger);
+  flex-direction: column;
+}
+
+.wallet-dropdown-balance-state small,
+.wallet-dropdown-balance-note {
+  color: var(--muted);
+  display: block;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  margin-top: 0.25rem;
+}
+
 .wallet-dropdown-actions {
   padding: 0.5rem;
 }

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -1,12 +1,16 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { isAllowed, setAllowed, requestAccess, getAddress, getNetworkDetails } from '@stellar/freighter-api';
+import { fetchUsdcBalance } from '../utils/horizon';
 
 export type WalletNetwork = 'TESTNET' | 'PUBLIC';
+export type BalanceStatus = 'idle' | 'loading' | 'success' | 'no_trustline' | 'error';
 
 interface WalletContextType {
     address: string | null;
     network: WalletNetwork | null;
     balance: string | null;
+    balanceStatus: BalanceStatus;
+    balanceError: string | null;
     isConnecting: boolean;
     error: string | null;
     connect: () => Promise<void>;
@@ -20,18 +24,33 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const [address, setAddress] = useState<string | null>(null);
     const [network, setNetwork] = useState<WalletNetwork | null>(null);
     const [balance, setBalance] = useState<string | null>(null);
+    const [balanceStatus, setBalanceStatus] = useState<BalanceStatus>('idle');
+    const [balanceError, setBalanceError] = useState<string | null>(null);
     const [isConnecting, setIsConnecting] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
-    const fetchNetworkAndBalance = async () => {
+    const normalizeNetwork = (networkName: string): WalletNetwork => {
+        return networkName === 'PUBLIC' ? 'PUBLIC' : 'TESTNET';
+    };
+
+    const fetchNetworkAndBalance = async (pubKey: string) => {
+        setBalanceStatus('loading');
+        setBalanceError(null);
+
         try {
             const netDetails = await getNetworkDetails();
-            setNetwork(netDetails.network as WalletNetwork);
-            // For a real app, you would query the Horizon API here to get the real balance.
-            // For this implementation, we will mock a balance.
-            setBalance('0.00');
+            const activeNetwork = normalizeNetwork(netDetails.network);
+            setNetwork(activeNetwork);
+
+            const usdcBalance = await fetchUsdcBalance(pubKey, activeNetwork);
+            setBalance(usdcBalance.balance);
+            setBalanceStatus(usdcBalance.hasTrustline ? 'success' : 'no_trustline');
         } catch (err) {
             console.error('Failed to get network details', err);
+            const message = err instanceof Error ? err.message : 'Unable to load USDC balance.';
+            setBalance(null);
+            setBalanceStatus('error');
+            setBalanceError(message);
         }
     };
 
@@ -41,7 +60,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
                 const { address: pubKey, error: addrError } = await getAddress();
                 if (pubKey && !addrError) {
                     setAddress(pubKey);
-                    await fetchNetworkAndBalance();
+                    await fetchNetworkAndBalance(pubKey);
                 }
             }
         } catch (err) {
@@ -64,7 +83,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
                 const { address: pubKey, error: addrError } = await getAddress();
                 if (pubKey && !addrError) {
                     setAddress(pubKey);
-                    await fetchNetworkAndBalance();
+                    await fetchNetworkAndBalance(pubKey);
                 } else {
                     setError(addrError || 'Failed to get wallet address.');
                 }
@@ -84,6 +103,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         setAddress(null);
         setNetwork(null);
         setBalance(null);
+        setBalanceStatus('idle');
+        setBalanceError(null);
     };
 
     return (
@@ -92,6 +113,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
                 address,
                 network,
                 balance,
+                balanceStatus,
+                balanceError,
                 isConnecting,
                 error,
                 connect,

--- a/src/context/__tests__/WalletContext.test.tsx
+++ b/src/context/__tests__/WalletContext.test.tsx
@@ -1,0 +1,256 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { WalletProvider, useWallet } from '../WalletContext';
+import { USDC_ISSUERS } from '../../utils/horizon';
+
+const freighterMocks = vi.hoisted(() => ({
+    isAllowed: vi.fn(),
+    setAllowed: vi.fn(),
+    requestAccess: vi.fn(),
+    getAddress: vi.fn(),
+    getNetworkDetails: vi.fn(),
+}));
+
+vi.mock('@stellar/freighter-api', () => freighterMocks);
+
+function mockResponse(status: number, body: unknown) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: vi.fn().mockResolvedValue(body),
+    } as unknown as Response;
+}
+
+function WalletProbe() {
+    const wallet = useWallet();
+
+    return (
+        <div>
+            <button type="button" onClick={wallet.connect}>
+                Connect
+            </button>
+            <button type="button" onClick={wallet.disconnect}>
+                Disconnect
+            </button>
+            <div data-testid="address">{wallet.address ?? ''}</div>
+            <div data-testid="network">{wallet.network ?? ''}</div>
+            <div data-testid="balance">{wallet.balance ?? ''}</div>
+            <div data-testid="balanceStatus">{wallet.balanceStatus}</div>
+            <div data-testid="balanceError">{wallet.balanceError ?? ''}</div>
+            <div data-testid="connectionError">{wallet.error ?? ''}</div>
+        </div>
+    );
+}
+
+function UnsafeProbe() {
+    useWallet();
+    return null;
+}
+
+function renderWallet() {
+    return render(
+        <WalletProvider>
+            <WalletProbe />
+        </WalletProvider>,
+    );
+}
+
+describe('WalletContext Horizon USDC balance path', () => {
+    const originalFetch = globalThis.fetch;
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        freighterMocks.isAllowed.mockResolvedValue(false);
+        freighterMocks.setAllowed.mockResolvedValue(undefined);
+        freighterMocks.requestAccess.mockResolvedValue(true);
+        freighterMocks.getAddress.mockResolvedValue({ address: 'GCONNECTED', error: null });
+        freighterMocks.getNetworkDetails.mockResolvedValue({ network: 'TESTNET' });
+        globalThis.fetch = vi.fn();
+    });
+
+    afterAll(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    test('loads the real USDC balance after connecting', async () => {
+        let resolveFetch: (value: Response) => void = () => undefined;
+        vi.mocked(globalThis.fetch).mockReturnValue(
+            new Promise<Response>((resolve) => {
+                resolveFetch = resolve;
+            }),
+        );
+
+        renderWallet();
+        fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+
+        await waitFor(() => expect(screen.getByTestId('balanceStatus')).toHaveTextContent('loading'));
+
+        resolveFetch(
+            mockResponse(200, {
+                balances: [
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: USDC_ISSUERS.TESTNET,
+                        balance: '42.2500000',
+                    },
+                ],
+            }),
+        );
+
+        await waitFor(() => expect(screen.getByTestId('balanceStatus')).toHaveTextContent('success'));
+        expect(screen.getByTestId('address')).toHaveTextContent('GCONNECTED');
+        expect(screen.getByTestId('network')).toHaveTextContent('TESTNET');
+        expect(screen.getByTestId('balance')).toHaveTextContent('42.2500000');
+        expect(globalThis.fetch).toHaveBeenCalledWith('https://horizon-testnet.stellar.org/accounts/GCONNECTED');
+    });
+
+    test('marks no-trustline when a connected public account has no Circle USDC balance line', async () => {
+        freighterMocks.isAllowed.mockResolvedValue(true);
+        freighterMocks.getNetworkDetails.mockResolvedValue({ network: 'PUBLIC' });
+        vi.mocked(globalThis.fetch).mockResolvedValue(
+            mockResponse(200, {
+                balances: [{ asset_type: 'native', balance: '10.0000000' }],
+            }),
+        );
+
+        renderWallet();
+
+        await waitFor(() => expect(screen.getByTestId('balanceStatus')).toHaveTextContent('no_trustline'));
+        expect(screen.getByTestId('network')).toHaveTextContent('PUBLIC');
+        expect(screen.getByTestId('balance')).toHaveTextContent('0.00');
+    });
+
+    test('surfaces Horizon errors without keeping a stale balance', async () => {
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse(500, {}));
+
+        renderWallet();
+        fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+
+        await waitFor(() => expect(screen.getByTestId('balanceStatus')).toHaveTextContent('error'));
+        expect(screen.getByTestId('balance')).toHaveTextContent('');
+        expect(screen.getByTestId('balanceError')).toHaveTextContent('Horizon balance request failed with status 500.');
+
+        error.mockRestore();
+    });
+
+    test('uses the generic balance error when network details throw a non-Error value', async () => {
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        freighterMocks.getNetworkDetails.mockRejectedValue('offline');
+
+        renderWallet();
+        fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+
+        await waitFor(() => expect(screen.getByTestId('balanceStatus')).toHaveTextContent('error'));
+        expect(screen.getByTestId('balanceError')).toHaveTextContent('Unable to load USDC balance.');
+
+        error.mockRestore();
+    });
+
+    test('surfaces wallet access denial and address errors', async () => {
+        freighterMocks.requestAccess.mockResolvedValueOnce(false);
+
+        const { rerender } = renderWallet();
+        fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+
+        await waitFor(() => expect(screen.getByTestId('connectionError')).toHaveTextContent('Wallet access denied.'));
+
+        freighterMocks.requestAccess.mockResolvedValueOnce(true);
+        freighterMocks.getAddress.mockResolvedValueOnce({ address: null, error: 'Address unavailable.' });
+
+        rerender(
+            <WalletProvider>
+                <WalletProbe />
+            </WalletProvider>,
+        );
+        fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+
+        await waitFor(() => expect(screen.getByTestId('connectionError')).toHaveTextContent('Address unavailable.'));
+    });
+
+    test('uses the fallback address error when Freighter returns no address message', async () => {
+        freighterMocks.getAddress.mockResolvedValueOnce({ address: null, error: null });
+
+        renderWallet();
+        fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+
+        await waitFor(() =>
+            expect(screen.getByTestId('connectionError')).toHaveTextContent('Failed to get wallet address.'),
+        );
+    });
+
+    test('logs automatic connection-check errors without crashing the provider', async () => {
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        freighterMocks.isAllowed.mockRejectedValue(new Error('Freighter unavailable.'));
+
+        renderWallet();
+
+        await waitFor(() => expect(error).toHaveBeenCalledWith('Check connection error', expect.any(Error)));
+        expect(screen.getByTestId('balanceStatus')).toHaveTextContent('idle');
+
+        error.mockRestore();
+    });
+
+    test('uses the generic connection error when Freighter throws a non-Error value', async () => {
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        freighterMocks.setAllowed.mockRejectedValue('locked');
+
+        renderWallet();
+        fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+
+        await waitFor(() =>
+            expect(screen.getByTestId('connectionError')).toHaveTextContent(
+                'Failed to connect wallet. Make sure Freighter is installed and unlocked.',
+            ),
+        );
+
+        error.mockRestore();
+    });
+
+    test('surfaces Freighter Error messages during connect', async () => {
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        freighterMocks.setAllowed.mockRejectedValue(new Error('Freighter is locked.'));
+
+        renderWallet();
+        fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+
+        await waitFor(() => expect(screen.getByTestId('connectionError')).toHaveTextContent('Freighter is locked.'));
+
+        error.mockRestore();
+    });
+
+    test('disconnect resets the loaded balance state', async () => {
+        vi.mocked(globalThis.fetch).mockResolvedValue(
+            mockResponse(200, {
+                balances: [
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: USDC_ISSUERS.TESTNET,
+                        balance: '9.0000000',
+                    },
+                ],
+            }),
+        );
+
+        renderWallet();
+        fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+
+        await waitFor(() => expect(screen.getByTestId('balanceStatus')).toHaveTextContent('success'));
+
+        fireEvent.click(screen.getByRole('button', { name: /disconnect/i }));
+
+        expect(screen.getByTestId('address')).toHaveTextContent('');
+        expect(screen.getByTestId('network')).toHaveTextContent('');
+        expect(screen.getByTestId('balance')).toHaveTextContent('');
+        expect(screen.getByTestId('balanceStatus')).toHaveTextContent('idle');
+    });
+
+    test('throws when useWallet is rendered outside the provider', () => {
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        expect(() => render(<UnsafeProbe />)).toThrow('useWallet must be used within a WalletProvider');
+
+        error.mockRestore();
+    });
+});

--- a/src/utils/__tests__/horizon.test.ts
+++ b/src/utils/__tests__/horizon.test.ts
@@ -1,0 +1,88 @@
+import { fetchUsdcBalance, horizonUrl, HorizonBalanceError, USDC_ISSUERS } from '../horizon';
+
+function mockResponse(status: number, body: unknown) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: vi.fn().mockResolvedValue(body),
+    } as unknown as Response;
+}
+
+describe('horizon wallet balance helpers', () => {
+    test('returns the Horizon URL for each supported network', () => {
+        expect(horizonUrl('TESTNET')).toBe('https://horizon-testnet.stellar.org');
+        expect(horizonUrl('PUBLIC')).toBe('https://horizon.stellar.org');
+    });
+
+    test('fetches the matching testnet USDC trustline balance', async () => {
+        const fetcher = vi.fn().mockResolvedValue(
+            mockResponse(200, {
+                balances: [
+                    { asset_type: 'native', balance: '12.0000000' },
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: USDC_ISSUERS.TESTNET,
+                        balance: '25.5000000',
+                    },
+                ],
+            }),
+        );
+
+        await expect(fetchUsdcBalance('GTEST ACCOUNT', 'TESTNET', fetcher)).resolves.toEqual({
+            balance: '25.5000000',
+            hasTrustline: true,
+            issuer: USDC_ISSUERS.TESTNET,
+            network: 'TESTNET',
+        });
+        expect(fetcher).toHaveBeenCalledWith('https://horizon-testnet.stellar.org/accounts/GTEST%20ACCOUNT');
+    });
+
+    test('returns zero with no trustline when Horizon has no matching USDC issuer', async () => {
+        const fetcher = vi.fn().mockResolvedValue(
+            mockResponse(200, {
+                balances: [
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: 'GDifferentIssuer',
+                        balance: '99.0000000',
+                    },
+                ],
+            }),
+        );
+
+        await expect(fetchUsdcBalance('GPUBLIC', 'PUBLIC', fetcher)).resolves.toEqual({
+            balance: '0.00',
+            hasTrustline: false,
+            issuer: USDC_ISSUERS.PUBLIC,
+            network: 'PUBLIC',
+        });
+    });
+
+    test('throws an account-not-found error for Horizon 404 responses', async () => {
+        const fetcher = vi.fn().mockResolvedValue(mockResponse(404, {}));
+
+        await expect(fetchUsdcBalance('GMISSING', 'TESTNET', fetcher)).rejects.toMatchObject({
+            name: 'HorizonBalanceError',
+            code: 'ACCOUNT_NOT_FOUND',
+        } satisfies Partial<HorizonBalanceError>);
+    });
+
+    test('throws a request error for non-OK Horizon responses', async () => {
+        const fetcher = vi.fn().mockResolvedValue(mockResponse(500, {}));
+
+        await expect(fetchUsdcBalance('GFAIL', 'PUBLIC', fetcher)).rejects.toMatchObject({
+            code: 'REQUEST_FAILED',
+            message: 'Horizon balance request failed with status 500.',
+        });
+    });
+
+    test('throws an invalid-response error when balances are missing', async () => {
+        const fetcher = vi.fn().mockResolvedValue(mockResponse(200, { id: 'GNO_BALANCES' }));
+
+        await expect(fetchUsdcBalance('GNO_BALANCES', 'PUBLIC', fetcher)).rejects.toMatchObject({
+            code: 'INVALID_RESPONSE',
+        });
+    });
+});

--- a/src/utils/horizon.ts
+++ b/src/utils/horizon.ts
@@ -1,0 +1,85 @@
+import type { WalletNetwork } from '../context/WalletContext';
+
+export const HORIZON_URLS: Record<WalletNetwork, string> = {
+    TESTNET: 'https://horizon-testnet.stellar.org',
+    PUBLIC: 'https://horizon.stellar.org',
+};
+
+export const USDC_ISSUERS: Record<WalletNetwork, string> = {
+    TESTNET: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    PUBLIC: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+};
+
+export type HorizonBalanceErrorCode = 'ACCOUNT_NOT_FOUND' | 'REQUEST_FAILED' | 'INVALID_RESPONSE';
+
+export class HorizonBalanceError extends Error {
+    code: HorizonBalanceErrorCode;
+
+    constructor(code: HorizonBalanceErrorCode, message: string) {
+        super(message);
+        this.name = 'HorizonBalanceError';
+        this.code = code;
+    }
+}
+
+interface HorizonBalanceLine {
+    asset_type: string;
+    asset_code?: string;
+    asset_issuer?: string;
+    balance: string;
+}
+
+interface HorizonAccountResponse {
+    balances?: HorizonBalanceLine[];
+}
+
+export interface UsdcBalanceResult {
+    balance: string;
+    hasTrustline: boolean;
+    issuer: string;
+    network: WalletNetwork;
+}
+
+export function horizonUrl(network: WalletNetwork) {
+    return HORIZON_URLS[network];
+}
+
+export async function fetchUsdcBalance(
+    address: string,
+    network: WalletNetwork,
+    fetcher: typeof fetch = fetch,
+): Promise<UsdcBalanceResult> {
+    const issuer = USDC_ISSUERS[network];
+    const response = await fetcher(`${horizonUrl(network)}/accounts/${encodeURIComponent(address)}`);
+
+    if (response.status === 404) {
+        throw new HorizonBalanceError('ACCOUNT_NOT_FOUND', 'Stellar account was not found on Horizon.');
+    }
+
+    if (!response.ok) {
+        throw new HorizonBalanceError(
+            'REQUEST_FAILED',
+            `Horizon balance request failed with status ${response.status}.`,
+        );
+    }
+
+    const account = (await response.json()) as HorizonAccountResponse;
+
+    if (!Array.isArray(account.balances)) {
+        throw new HorizonBalanceError('INVALID_RESPONSE', 'Horizon account response did not include balances.');
+    }
+
+    const usdcBalance = account.balances.find(
+        (balanceLine) =>
+            balanceLine.asset_type !== 'native' &&
+            balanceLine.asset_code === 'USDC' &&
+            balanceLine.asset_issuer === issuer,
+    );
+
+    return {
+        balance: usdcBalance?.balance ?? '0.00',
+        hasTrustline: Boolean(usdcBalance),
+        issuer,
+        network,
+    };
+}


### PR DESCRIPTION
## Summary
- add `src/utils/horizon.ts` with network-aware Horizon URLs, Circle USDC issuers, and `fetchUsdcBalance(address, network)`
- replace the mocked wallet balance in `WalletContext` with real Horizon balance loading for the connected Freighter account
- expose `balanceStatus` / `balanceError` so the wallet dropdown can show loading, no-trustline, and error states instead of stale values
- update `WalletDropdown` UI and wallet docs for the new balance behavior

Closes #126

## Validation
- `npx vitest run src/utils/__tests__/horizon.test.ts src/context/__tests__/WalletContext.test.tsx src/components/Wallet/__tests__/WalletDropdown.test.tsx --coverage --coverage.include=src/utils/horizon.ts --coverage.include=src/context/WalletContext.tsx --coverage.include=src/components/Wallet/WalletDropdown.tsx` ? 27 tests passed; 100% statements / branches / functions / lines on all targeted files
- `git diff --check` ?

## Note
- `npx tsc --noEmit --pretty false` is still blocked by an existing upstream syntax error in `src/components/Field.tsx` at lines 68-69; this PR does not modify that file.