### PR TITLE
docs: add token authoring guide

### DIFF
--- a/design-system/README.md
+++ b/design-system/README.md
@@ -14,6 +14,7 @@ A comprehensive design system for the Disciplr financial platform.
 
 See `documentation/getting-started.md` for setup instructions.
 
+For token authoring conventions, see `documentation/token-authoring.md`.
 For a token-to-component map, see `documentation/token-catalog.md`.
 
 ## Component Documentation

--- a/design-system/documentation/token-authoring.md
+++ b/design-system/documentation/token-authoring.md
@@ -1,0 +1,274 @@
+# Token Authoring Guide
+
+Use this guide when adding or editing JSON tokens under `design-system/tokens/`.
+Disciplr tokens follow the Design Tokens Community Group (DTCG) shape where it
+fits the existing runtime mappings:
+
+- Every token file starts with the DTCG `$schema` URL.
+- Leaf tokens use `$type`, `$value`, and an optional `$description`.
+- Mode-specific colors are grouped as `light` and `dark` leaf tokens.
+- Composite tokens, such as typography, keep each nested value in a
+  `{ "$value": ... }` object so tooling can read the parts independently.
+
+## Naming
+
+Token names should flatten to lowercase kebab-case. For example,
+`color.action.review.light` becomes `color-action-review-light` when validating
+names or generating runtime variables.
+
+The current name validators require one of these flattened prefixes:
+
+| Prefix | Token files |
+| --- | --- |
+| `color-` | `colors.json`, including chart colors |
+| `spacing-` | `spacing.json` |
+| `typography-` | `typography.json` |
+| `shadow-` | `shadows.json` |
+| `radius-` | `borders.json` radius entries |
+| `border-` | `borders.json` width and color entries |
+| `motion-` | `motion.json` |
+
+Valid examples:
+
+- `color-action-review`
+- `color-chart-categorical-step-1`
+- `spacing-container-wide`
+- `typography-title-sm`
+- `shadow-level-2`
+- `radius-md`
+- `border-default`
+- `motion-duration-fast`
+
+Invalid examples:
+
+- `Color-action-review` uses uppercase.
+- `color--action` has an empty segment.
+- `chart-categorical-step-1` is missing the `color-` prefix used by chart
+  color tokens.
+- `color` has no token name after the prefix.
+
+## Color Tokens
+
+Use `$type: "color"` and a supported `$value` string:
+
+- Six-digit hex: `#2563EB`
+- RGB: `rgb(37, 99, 235)`
+- HSL: `hsl(221, 83%, 53%)`
+
+Accessibility metadata is optional, but use it whenever a token is consumed by
+text, icons, focus rings, charts, status badges, or controls. The validator
+currently accepts `wcagLevel` values of `AA` or `AAA`, a boolean
+`colorblindSafe`, and `colorblindSimulation` values for `protanopia`,
+`deuteranopia`, and `tritanopia`.
+
+```json
+{
+  "$schema": "https://design-tokens.github.io/community-group/format.json",
+  "color": {
+    "action": {
+      "review": {
+        "light": {
+          "$type": "color",
+          "$value": "#2563EB",
+          "$description": "Review action color in light mode",
+          "accessibility": {
+            "wcagLevel": "AA",
+            "colorblindSafe": true,
+            "colorblindSimulation": {
+              "protanopia": "#2564EB",
+              "deuteranopia": "#2563EB",
+              "tritanopia": "#2563EC"
+            }
+          }
+        },
+        "dark": {
+          "$type": "color",
+          "$value": "#60A5FA",
+          "$description": "Review action color in dark mode",
+          "accessibility": {
+            "wcagLevel": "AA",
+            "colorblindSafe": true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Chart Tokens
+
+Chart tokens live in `colors.json` under the `color.chart` group and should
+flatten with the `color-` prefix, for example `color-chart-axis-light`.
+
+The chart validator requires these surface keys:
+
+- `axis`
+- `grid`
+- `tooltipBg`
+- `tooltipBorder`
+- `tooltipText`
+- `tooltipLabel`
+
+It also requires `categorical` and `sequential` ramps with at least five steps
+each. Every surface token and ramp step must contain both `light` and `dark`
+color tokens.
+
+```json
+{
+  "axis": {
+    "light": { "$type": "color", "$value": "#334155" },
+    "dark": { "$type": "color", "$value": "#CBD5E1" }
+  },
+  "grid": {
+    "light": { "$type": "color", "$value": "#E2E8F0" },
+    "dark": { "$type": "color", "$value": "#334155" }
+  },
+  "tooltipBg": {
+    "light": { "$type": "color", "$value": "#FFFFFF" },
+    "dark": { "$type": "color", "$value": "#0F172A" }
+  },
+  "tooltipBorder": {
+    "light": { "$type": "color", "$value": "#CBD5E1" },
+    "dark": { "$type": "color", "$value": "#475569" }
+  },
+  "tooltipText": {
+    "light": { "$type": "color", "$value": "#0F172A" },
+    "dark": { "$type": "color", "$value": "#F8FAFC" }
+  },
+  "tooltipLabel": {
+    "light": { "$type": "color", "$value": "#475569" },
+    "dark": { "$type": "color", "$value": "#CBD5E1" }
+  },
+  "categorical": {
+    "step-1": {
+      "light": { "$type": "color", "$value": "#2563EB" },
+      "dark": { "$type": "color", "$value": "#60A5FA" }
+    },
+    "step-2": {
+      "light": { "$type": "color", "$value": "#0D9488" },
+      "dark": { "$type": "color", "$value": "#2DD4BF" }
+    },
+    "step-3": {
+      "light": { "$type": "color", "$value": "#7C3AED" },
+      "dark": { "$type": "color", "$value": "#A78BFA" }
+    },
+    "step-4": {
+      "light": { "$type": "color", "$value": "#EA580C" },
+      "dark": { "$type": "color", "$value": "#FDBA74" }
+    },
+    "step-5": {
+      "light": { "$type": "color", "$value": "#DC2626" },
+      "dark": { "$type": "color", "$value": "#FCA5A5" }
+    }
+  },
+  "sequential": {
+    "step-1": {
+      "light": { "$type": "color", "$value": "#EFF6FF" },
+      "dark": { "$type": "color", "$value": "#172554" }
+    },
+    "step-2": {
+      "light": { "$type": "color", "$value": "#BFDBFE" },
+      "dark": { "$type": "color", "$value": "#1E3A8A" }
+    },
+    "step-3": {
+      "light": { "$type": "color", "$value": "#60A5FA" },
+      "dark": { "$type": "color", "$value": "#1D4ED8" }
+    },
+    "step-4": {
+      "light": { "$type": "color", "$value": "#2563EB" },
+      "dark": { "$type": "color", "$value": "#3B82F6" }
+    },
+    "step-5": {
+      "light": { "$type": "color", "$value": "#1E40AF" },
+      "dark": { "$type": "color", "$value": "#93C5FD" }
+    }
+  }
+}
+```
+
+## Spacing, Breakpoints, Borders, And Radius
+
+Use `$type: "dimension"` for lengths that compile to CSS or Tailwind values.
+Prefer explicit pixel values such as `"16px"` for spacing, radius, border
+widths, breakpoint minimum widths, container widths, gaps, and touch targets.
+
+Keep semantic groups separate:
+
+- `spacing.*` numeric keys and `spacing.base` for reusable spacing increments.
+- `spacing.container.*` for layout max widths.
+- `breakpoint.*` for responsive thresholds.
+- `grid.*` for column, gutter, and margin tokens.
+- `border.radius.*` and `border.width.*` for shape and stroke sizing.
+- `border.color.*` for light/dark border colors.
+
+The current TypeScript validators do not enforce dimension tokens directly.
+They are authoring conventions backed by `tokens/spacing.json`,
+`tokens/borders.json`, runtime CSS variables, and documentation such as
+`breakpoints.md`.
+
+## Typography Tokens
+
+Use the existing DTCG-like typography shape:
+
+- `fontFamily` leaf tokens use `$type: "fontFamily"`.
+- `fontWeight` leaf tokens use `$type: "fontWeight"`.
+- Responsive text styles use `$type: "typography"` and nested values for
+  `fontSize`, `lineHeight`, `fontWeight`, and `letterSpacing`.
+
+Each object key in JSON must be unique. When adding responsive styles, check for
+duplicate keys such as a repeated `display` block because JSON parsers keep only
+the last value.
+
+```json
+{
+  "$type": "typography",
+  "fontSize": { "$value": "20px" },
+  "lineHeight": { "$value": "28px" },
+  "fontWeight": { "$value": 600 },
+  "letterSpacing": { "$value": "0" },
+  "$description": "Compact title text"
+}
+```
+
+## Shadows And Motion
+
+Shadow tokens use `$type: "shadow"` and may set `$value` to `"none"` or to an
+array of shadow layers. Each layer should keep offset, blur, spread, and color
+explicit so downstream CSS generation stays deterministic.
+
+Motion tokens use the existing groups in `motion.json`:
+
+- Duration tokens use `$type: "duration"` and millisecond values such as
+  `"150ms"`.
+- Easing tokens use `$type: "cubicBezier"` and four-number arrays.
+- Reduced-motion preferences use boolean `$value` entries.
+
+The current validators do not enforce shadow or motion shapes directly. Keep
+their JSON structure aligned with the existing files and update runtime utilities
+when the token names or value shapes change.
+
+## Authoring Checklist
+
+- Add or edit tokens in the relevant file under `tokens/`.
+- Keep token names lowercase, kebab-case when flattened, and under a supported
+  prefix.
+- Use `$type`, `$value`, and `$description` on every leaf token.
+- Provide `light` and `dark` variants for color tokens consumed in UI surfaces.
+- Add accessibility metadata for UI colors with contrast or colorblind-safety
+  requirements.
+- Keep chart ramps to at least five `light`/`dark` steps.
+- Update runtime CSS variables or utility maps when token names or value shapes
+  change.
+- Update `documentation/token-catalog.md` and any focused docs that consume the
+  changed token group.
+- Run the design-system Jest tests before opening a PR.
+
+## Current Validation Coverage
+
+`src/utils/validators.ts` currently enforces raw color strings, flattened token
+name syntax, supported token prefixes, color token shape, optional color
+accessibility metadata, and complete chart token groups.
+
+Spacing, typography, border, radius, shadow, and motion sections in this guide
+are authoring conventions until matching validators are added.

--- a/design-system/documentation/token-catalog.md
+++ b/design-system/documentation/token-catalog.md
@@ -4,6 +4,9 @@ This catalog maps token groups to their runtime CSS variables, utility files,
 and component consumers. Keep it current when adding tokens or migrating
 components to the design system.
 
+For JSON authoring conventions, DTCG field usage, naming rules, and worked
+validator examples, see `documentation/token-authoring.md`.
+
 | Token group | Token source | Runtime variables or utilities | Current consumers |
 | --- | --- | --- | --- |
 | Core color surfaces | `tokens/colors.json` | `--bg`, `--surface`, `--surface-raised`, `--border`, `--text`, `--muted`, `--hover` in `src/index.css` | `Layout`, `Dashboard`, `VaultCard`, `Field`, `ConfirmationModal`, wallet components, notification settings |

--- a/design-system/src/__tests__/validators.test.ts
+++ b/design-system/src/__tests__/validators.test.ts
@@ -38,6 +38,11 @@ const validChart = () => ({
   sequential: ramp(5),
 });
 
+const documentedChartTokenGroup = (light: string, dark: string) => ({
+  light: colorToken(light),
+  dark: colorToken(dark),
+});
+
 describe('standalone color string validators', () => {
   it('validates six-digit hex colors case-insensitively', () => {
     expect(isValidHexColor('#ABCDEF')).toBe(true);
@@ -169,6 +174,52 @@ describe('isValidColorToken', () => {
 describe('isValidChartTokens', () => {
   it('accepts a complete chart token set', () => {
     expect(isValidChartTokens(validChart())).toBe(true);
+  });
+
+  it('accepts the token authoring guide examples', () => {
+    const guideColorToken = {
+      $type: 'color',
+      $value: '#2563EB',
+      $description: 'Review action color in light mode',
+      accessibility: {
+        wcagLevel: 'AA',
+        colorblindSafe: true,
+        colorblindSimulation: {
+          protanopia: '#2564EB',
+          deuteranopia: '#2563EB',
+          tritanopia: '#2563EC',
+        },
+      },
+    };
+
+    expect(isKebabCase('color-action-review')).toBe(true);
+    expect(hasValidTokenPrefix('color-action-review')).toBe(true);
+    expect(isValidColorToken(guideColorToken)).toBe(true);
+
+    expect(
+      isValidChartTokens({
+        axis: documentedChartTokenGroup('#334155', '#CBD5E1'),
+        grid: documentedChartTokenGroup('#E2E8F0', '#334155'),
+        tooltipBg: documentedChartTokenGroup('#FFFFFF', '#0F172A'),
+        tooltipBorder: documentedChartTokenGroup('#CBD5E1', '#475569'),
+        tooltipText: documentedChartTokenGroup('#0F172A', '#F8FAFC'),
+        tooltipLabel: documentedChartTokenGroup('#475569', '#CBD5E1'),
+        categorical: {
+          'step-1': documentedChartTokenGroup('#2563EB', '#60A5FA'),
+          'step-2': documentedChartTokenGroup('#0D9488', '#2DD4BF'),
+          'step-3': documentedChartTokenGroup('#7C3AED', '#A78BFA'),
+          'step-4': documentedChartTokenGroup('#EA580C', '#FDBA74'),
+          'step-5': documentedChartTokenGroup('#DC2626', '#FCA5A5'),
+        },
+        sequential: {
+          'step-1': documentedChartTokenGroup('#EFF6FF', '#172554'),
+          'step-2': documentedChartTokenGroup('#BFDBFE', '#1E3A8A'),
+          'step-3': documentedChartTokenGroup('#60A5FA', '#1D4ED8'),
+          'step-4': documentedChartTokenGroup('#2563EB', '#3B82F6'),
+          'step-5': documentedChartTokenGroup('#1E40AF', '#93C5FD'),
+        },
+      }),
+    ).toBe(true);
   });
 
   it('rejects missing or malformed surface tokens', () => {


### PR DESCRIPTION
## Summary
- add a design-system token authoring guide for DTCG-style JSON fields, flattened naming, and supported prefixes
- document color, chart, spacing, border, typography, shadow, and motion token conventions with current validator coverage
- link the guide from the design-system README and token catalog
- add a validator regression test that exercises the guide's color and chart examples

Closes #215

## Validation
- `npm test -- validators.test.ts --runInBand`
- `npm test -- --runInBand`
- `npm run build`

## Notes
- `npm run lint` currently exits before linting because the package script passes `--ext` while the repo uses flat config. Running `npx eslint src` from `design-system/` also depends on the root `eslint.config.js` importing `@eslint/js` from root dependencies, which were not installed for this focused design-system validation.