### PR TITLE
security: harden evidence URL safety checks

### DIFF
--- a/design-system/documentation/link-safety.md
+++ b/design-system/documentation/link-safety.md
@@ -4,8 +4,14 @@ All external URLs provided by users (such as `evidenceUrl` in validation tasks) 
 
 ## Policy
 1.  **Strict Scheme Allowlist:** Only `http:` and `https:` schemes are permitted. All others (e.g., `javascript:`, `data:`, `file:`) are rejected.
-2.  **Safe Attributes:** Any rendered external link MUST include `target="_blank"` and `rel="noopener noreferrer"` to prevent security vulnerabilities like reverse tabnabbing.
-3.  **Inert Fallback:** If a URL fails sanitization, it must be rendered as inert text (`[Invalid Link]`) with an optional `title` attribute explaining the rejection.
+2.  **No Embedded Credentials:** URLs with `username` or `password` userinfo before `@` are rejected because they can hide the real destination host.
+3.  **No Ambiguous Hosts:** Punycode/IDN hosts (`xn--` labels) and IP-literal hosts are rejected. Evidence links should use clear domain names that verifiers can inspect without Unicode or address-encoding ambiguity.
+4.  **Default Ports Only:** Explicit non-default ports are rejected. Default `http:80` and `https:443` normalize as safe; unusual ports are treated as ambiguous evidence destinations.
+5.  **Safe Attributes:** Any rendered external link MUST include `target="_blank"` and `rel="noopener noreferrer"` to prevent security vulnerabilities like reverse tabnabbing.
+6.  **Inert Fallback:** If a URL fails sanitization, it must be rendered as inert text (`[Invalid Link]`) with an optional `title` attribute explaining the rejection.
 
 ## Implementation
-Use the `isSafeEvidenceUrl` utility from `src/utils/url.ts` to validate links, and the `SafeLink` component from `src/components/SafeLink.tsx` to render them.
+Use the `isSafeEvidenceUrl` utility from `src/utils/url.ts` for boolean checks, `getEvidenceUrlSafety` when the UI needs a rejection reason, and the `SafeLink` component from `src/components/SafeLink.tsx` to render evidence links.
+
+## Threat Model
+Evidence URLs are externally sourced and shown to verifiers as clickable links. The URL layer rejects inputs that can mislead the verifier about the real destination: non-web schemes, userinfo, IDN/punycode hostnames, IP literals, and non-default ports. Punycode/IDN hosts are rejected rather than warning-only because the UI cannot reliably prove the visual hostname is safe for every verifier locale and font.

--- a/src/components/SafeLink.tsx
+++ b/src/components/SafeLink.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isSafeEvidenceUrl } from '../utils/url';
+import { getEvidenceUrlRejectionLabel, getEvidenceUrlSafety } from '../utils/url';
 
 interface SafeLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   href: string;
@@ -12,13 +12,16 @@ interface SafeLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
  * If safe, it enforces target="_blank" and rel="noopener noreferrer".
  */
 export const SafeLink: React.FC<SafeLinkProps> = ({ href, children, ...props }) => {
-  if (!isSafeEvidenceUrl(href)) {
-    return <span title={`Rejected URL: ${href}`}>[Invalid Link]</span>;
+  const safety = getEvidenceUrlSafety(href);
+
+  if (!safety.safe) {
+    const reasonLabel = getEvidenceUrlRejectionLabel(safety.reason);
+    return <span title={`Rejected URL (${reasonLabel}): ${href}`}>[Invalid Link]</span>;
   }
 
   return (
     <a
-      href={href}
+      href={safety.normalizedUrl}
       target="_blank"
       rel="noopener noreferrer"
       {...props}

--- a/src/components/__tests__/SafeLink.test.tsx
+++ b/src/components/__tests__/SafeLink.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { SafeLink } from '../SafeLink';
 
 describe('SafeLink component', () => {
-  test('renders as anchor tag for safe URLs', () => {
+  test('renders as anchor tag for safe URLs with external-link protections', () => {
     const url = 'https://example.com';
     render(<SafeLink href={url}>Link</SafeLink>);
     const link = screen.getByRole('link', { name: /link/i });
@@ -13,13 +13,20 @@ describe('SafeLink component', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
-  test('renders as span for unsafe URLs', () => {
-    const url = 'javascript:alert(1)';
+  test.each([
+    ['javascript:alert(1)', 'unsupported protocol'],
+    ['https://user:pass@example.com/evidence', 'embedded credentials'],
+    ['https://xn--pple-43d.com/evidence', 'punycode or IDN host'],
+    ['https://example.com:8443/evidence', 'unexpected port'],
+    ['http://127.0.0.1/evidence', 'IP literal host'],
+  ])('renders %s as inert text with the %s reason', (url, reasonLabel) => {
     render(<SafeLink href={url}>Link</SafeLink>);
+
     const link = screen.queryByRole('link', { name: /link/i });
     expect(link).not.toBeInTheDocument();
+
     const span = screen.getByText('[Invalid Link]');
     expect(span).toBeInTheDocument();
-    expect(span).toHaveAttribute('title', `Rejected URL: ${url}`);
+    expect(span).toHaveAttribute('title', `Rejected URL (${reasonLabel}): ${url}`);
   });
 });

--- a/src/utils/__tests__/url.test.ts
+++ b/src/utils/__tests__/url.test.ts
@@ -1,50 +1,42 @@
 import { describe, expect, it, test } from 'vitest';
-import { isSafeEvidenceUrl, normalizeEvidenceUrl } from '../url';
-
-describe('isSafeEvidenceUrl', () => {
-  test('should return true for valid http URLs', () => {
-    expect(isSafeEvidenceUrl('http://example.com')).toBe(true);
-  });
-
-  test('should return true for valid https URLs', () => {
-    expect(isSafeEvidenceUrl('https://example.com')).toBe(true);
-  });
-
-  test('should return false for javascript: URLs', () => {
-    expect(isSafeEvidenceUrl('javascript:alert(1)')).toBe(false);
-  });
-
-  test('should return false for data: URLs', () => {
-    expect(isSafeEvidenceUrl('data:text/html,test')).toBe(false);
-  });
-
-  test('should return false for invalid URLs', () => {
-    expect(isSafeEvidenceUrl('not-a-url')).toBe(false);
-  });
-
-  test('should handle trailing whitespace', () => {
-    expect(isSafeEvidenceUrl('  https://example.com  ')).toBe(true);
-  });
-
-  test('should handle different casing for https', () => {
-    expect(isSafeEvidenceUrl('HTTPS://example.com')).toBe(true);
-  });
-});
+import { getEvidenceUrlSafety, isSafeEvidenceUrl, normalizeEvidenceUrl } from '../url';
 
 describe('evidence URL validation', () => {
-  it('accepts http and https URLs', () => {
-    expect(isSafeEvidenceUrl('https://github.com/org/repo/pull/42')).toBe(true)
-    expect(isSafeEvidenceUrl('http://example.com/evidence')).toBe(true)
-  })
+  it('accepts plain http and https evidence URLs', () => {
+    expect(isSafeEvidenceUrl('https://github.com/org/repo/pull/42')).toBe(true);
+    expect(isSafeEvidenceUrl('http://example.com/evidence')).toBe(true);
+    expect(getEvidenceUrlSafety('https://example.com/evidence')).toEqual({
+      safe: true,
+      normalizedUrl: 'https://example.com/evidence',
+    });
+  });
 
   it('trims safe URLs before returning them', () => {
-    expect(normalizeEvidenceUrl('  https://example.com/doc  ')).toBe('https://example.com/doc')
-  })
+    expect(normalizeEvidenceUrl('  https://example.com/doc  ')).toBe('https://example.com/doc');
+  });
 
-  it('rejects unsafe and missing schemes', () => {
-    expect(isSafeEvidenceUrl('javascript:alert(1)')).toBe(false)
-    expect(isSafeEvidenceUrl('data:text/html,hello')).toBe(false)
-    expect(isSafeEvidenceUrl('example.com/evidence')).toBe(false)
-    expect(isSafeEvidenceUrl('')).toBe(false)
-  })
-})
+  it('preserves current behavior for mixed-case schemes and default ports', () => {
+    expect(isSafeEvidenceUrl('HTTPS://example.com')).toBe(true);
+    expect(isSafeEvidenceUrl('https://example.com:443/evidence')).toBe(true);
+    expect(isSafeEvidenceUrl('http://example.com:80/evidence')).toBe(true);
+  });
+
+  test.each([
+    ['javascript:alert(1)', 'unsupported-protocol'],
+    ['data:text/html,hello', 'unsupported-protocol'],
+    ['file:///tmp/evidence.txt', 'unsupported-protocol'],
+    ['https://user:pass@example.com/evidence', 'embedded-credentials'],
+    ['https://user@example.com/evidence', 'embedded-credentials'],
+    ['https://xn--pple-43d.com/evidence', 'punycode-host'],
+    ['https://XN--PPLE-43D.com/evidence', 'punycode-host'],
+    ['https://example.com:8443/evidence', 'unexpected-port'],
+    ['http://127.0.0.1/evidence', 'ip-literal-host'],
+    ['http://[::1]/evidence', 'ip-literal-host'],
+    ['example.com/evidence', 'invalid-url'],
+    ['', 'empty'],
+  ])('rejects %s as %s', (url, reason) => {
+    expect(isSafeEvidenceUrl(url)).toBe(false);
+    expect(normalizeEvidenceUrl(url)).toBeNull();
+    expect(getEvidenceUrlSafety(url)).toMatchObject({ safe: false, reason });
+  });
+});

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,23 +1,107 @@
+export type EvidenceUrlRejectionReason =
+  | 'empty'
+  | 'invalid-url'
+  | 'unsupported-protocol'
+  | 'embedded-credentials'
+  | 'punycode-host'
+  | 'unexpected-port'
+  | 'ip-literal-host';
+
+export type EvidenceUrlSafety =
+  | { safe: true; normalizedUrl: string }
+  | { safe: false; reason: EvidenceUrlRejectionReason };
+
+const REJECTION_LABELS: Record<EvidenceUrlRejectionReason, string> = {
+  empty: 'empty URL',
+  'invalid-url': 'invalid URL',
+  'unsupported-protocol': 'unsupported protocol',
+  'embedded-credentials': 'embedded credentials',
+  'punycode-host': 'punycode or IDN host',
+  'unexpected-port': 'unexpected port',
+  'ip-literal-host': 'IP literal host',
+};
+
+function hasPunycodeLabel(hostname: string): boolean {
+  return hostname
+    .toLowerCase()
+    .split('.')
+    .some((label) => label.startsWith('xn--'));
+}
+
+function isIpv4Literal(hostname: string): boolean {
+  const parts = hostname.split('.');
+
+  return (
+    parts.length === 4 &&
+    parts.every((part) => {
+      if (!/^\d{1,3}$/.test(part)) {
+        return false;
+      }
+
+      const value = Number(part);
+      return value >= 0 && value <= 255;
+    })
+  );
+}
+
+function isIpLiteralHost(hostname: string): boolean {
+  return isIpv4Literal(hostname) || hostname.startsWith('[') || hostname.includes(':');
+}
+
+function hasUnexpectedPort(url: URL): boolean {
+  return url.port !== '';
+}
+
+export function getEvidenceUrlRejectionLabel(reason: EvidenceUrlRejectionReason): string {
+  return REJECTION_LABELS[reason];
+}
+
 /**
  * Validates if a URL is safe to render as a link.
- * Only allows http and https schemes.
- * Rejects javascript:, data:, and other potentially dangerous schemes.
+ * Only allows plain http and https URLs with clear hostnames.
+ * Rejects ambiguous externally sourced evidence URLs.
  */
-export function normalizeEvidenceUrl(value: string): string | null {
-  const trimmed = value.trim()
+export function getEvidenceUrlSafety(value: string): EvidenceUrlSafety {
+  const trimmed = value.trim();
 
   if (!trimmed) {
-    return null
+    return { safe: false, reason: 'empty' };
   }
 
   try {
-    const parsed = new URL(trimmed)
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? trimmed : null
+    const parsed = new URL(trimmed);
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return { safe: false, reason: 'unsupported-protocol' };
+    }
+
+    if (parsed.username || parsed.password) {
+      return { safe: false, reason: 'embedded-credentials' };
+    }
+
+    if (hasPunycodeLabel(parsed.hostname)) {
+      return { safe: false, reason: 'punycode-host' };
+    }
+
+    if (hasUnexpectedPort(parsed)) {
+      return { safe: false, reason: 'unexpected-port' };
+    }
+
+    if (isIpLiteralHost(parsed.hostname)) {
+      return { safe: false, reason: 'ip-literal-host' };
+    }
+
+    return { safe: true, normalizedUrl: trimmed };
   } catch {
-    return null
+    return { safe: false, reason: 'invalid-url' };
   }
 }
 
+export function normalizeEvidenceUrl(value: string): string | null {
+  const safety = getEvidenceUrlSafety(value);
+  return safety.safe ? safety.normalizedUrl : null;
+}
+
 export function isSafeEvidenceUrl(value: string): boolean {
-  return normalizeEvidenceUrl(value) !== null
+  return getEvidenceUrlSafety(value).safe;
 }


### PR DESCRIPTION
## Summary
- add structured evidence URL safety results with rejection reasons
- reject embedded credentials, punycode/IDN hosts, explicit non-default ports, IP-literal hosts, and non-http(s) schemes
- surface rejection reasons through SafeLink inert fallback titles
- expand URL and SafeLink attack-string coverage and document the conservative link-safety policy

Closes #205

## Validation
- `npx tsc --noEmit --target ES2020 --lib ES2020,DOM,DOM.Iterable --module ESNext --moduleResolution bundler --jsx react-jsx --strict --skipLibCheck --types vitest/globals,@testing-library/jest-dom src/utils/url.ts src/utils/__tests__/url.test.ts src/components/SafeLink.tsx src/components/__tests__/SafeLink.test.tsx`
- `npx eslint src/utils/url.ts src/utils/__tests__/url.test.ts src/components/SafeLink.tsx src/components/__tests__/SafeLink.test.tsx`
- `git diff --check`

Note: `npx vitest run src/utils/__tests__/url.test.ts src/components/__tests__/SafeLink.test.tsx` is blocked in this Windows sandbox before tests load with `Error: spawn EPERM` while esbuild starts its service process. The tests are included for CI execution in a normal environment.