### PR TITLE
test: cover vault detail terminal states

### DIFF
--- a/src/pages/__tests__/VaultDetail.test.tsx
+++ b/src/pages/__tests__/VaultDetail.test.tsx
@@ -1,7 +1,23 @@
+import '@testing-library/jest-dom/vitest';
 import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import VaultDetail from '../VaultDetail';
+
+let mockNetwork: 'TESTNET' | 'PUBLIC' | null = 'TESTNET';
+
+vi.mock('../../context/WalletContext', () => ({
+  useWallet: () => ({
+    address: null,
+    network: mockNetwork,
+    balance: null,
+    isConnecting: false,
+    error: null,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    checkConnection: vi.fn(),
+  }),
+}));
 
 function renderVaultDetail(id: string) {
   return render(
@@ -14,6 +30,10 @@ function renderVaultDetail(id: string) {
 }
 
 describe('VaultDetail', () => {
+  beforeEach(() => {
+    mockNetwork = 'TESTNET';
+  });
+
   it('renders active vault status, milestones, transactions, addresses, and deadline', () => {
     renderVaultDetail('1');
 
@@ -24,6 +44,10 @@ describe('VaultDetail', () => {
 
     expect(screen.getByText('Status Timeline')).toBeInTheDocument();
     expect(screen.getByText(/Deadline Jul 15, 2024/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Deadline Jul 15, 2024.*Expired/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('region', { name: /Fund settlement status: Settlement pending/i }),
+    ).toHaveTextContent(/USDC remains locked/i);
 
     const addresses = screen.getByText('Addresses').closest('div')?.parentElement;
     expect(addresses).toBeInTheDocument();
@@ -34,12 +58,13 @@ describe('VaultDetail', () => {
     expect(within(addresses!).getByText('Contract')).toBeInTheDocument();
     expect(within(addresses!).getByText('GBVZ3K...QK7L')).toBeInTheDocument();
 
+    const milestones = screen.getByRole('list', { name: /vault milestone progress/i });
     expect(screen.getByText(/1\. Phase 1 Complete/)).toBeInTheDocument();
     expect(screen.getByText('Complete initial development phase')).toBeInTheDocument();
     expect(screen.getByText(/All unit tests passing, code reviewed/)).toBeInTheDocument();
-    expect(screen.getByText('Validated')).toBeInTheDocument();
+    expect(within(milestones).getByText('Validated')).toBeInTheDocument();
     expect(screen.getByText(/2\. Beta Launch/)).toBeInTheDocument();
-    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(within(milestones).getByText('Pending')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /View evidence/i })).toHaveAttribute(
       'href',
       'https://github.com/org/repo/pull/42',
@@ -58,17 +83,30 @@ describe('VaultDetail', () => {
     expect(screen.getByRole('heading', { name: 'Beta Reserve' })).toBeInTheDocument();
     expect(screen.getAllByText('Completed').length).toBeGreaterThan(0);
     expect(screen.queryByText('Verifier')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Deadline Jan 1, 2024/)).not.toBeInTheDocument();
 
+    const milestones = screen.getByRole('list', { name: /vault milestone progress/i });
     expect(screen.getByText(/1\. Project Delivery/)).toBeInTheDocument();
     expect(screen.getByText(/All deliverables submitted and approved/)).toBeInTheDocument();
+    expect(within(milestones).getByText('Validated')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /View evidence/i })).toHaveAttribute(
       'href',
       'https://docs.example.com/delivery',
     );
 
-    expect(screen.getByText('Funds Released')).toBeInTheDocument();
+    const settlement = screen.getByRole('region', {
+      name: /Fund settlement status: Funds released/i,
+    });
+    expect(within(settlement).getByText('Funds released')).toBeInTheDocument();
+    expect(
+      within(settlement).getByLabelText(
+        'Destination address GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK',
+      ),
+    ).toHaveTextContent('GSUCC3...LKQK');
+    expect(within(settlement).getByRole('link', { name: /Stellar Testnet explorer/i }))
+      .toHaveAttribute('href', 'https://stellar.expert/explorer/testnet/tx/c5f1d3e0a4b96278ch5f1e3d4a0b6f9c');
     expect(screen.getAllByText('4,200.5 USDC').length).toBeGreaterThan(0);
-    expect(screen.getByText('c5f1d3e0...0b6f9c')).toBeInTheDocument();
+    expect(screen.getAllByText('c5f1d3e0...0b6f9c').length).toBeGreaterThan(0);
   });
 
   it('renders failed vault milestone and redirect transaction details', () => {
@@ -76,12 +114,24 @@ describe('VaultDetail', () => {
 
     expect(screen.getByRole('heading', { name: 'Gamma Fund' })).toBeInTheDocument();
     expect(screen.getAllByText('Failed').length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText(/Deadline Dec 1, 2023/)).not.toBeInTheDocument();
+
+    const milestones = screen.getByRole('list', { name: /vault milestone progress/i });
     expect(screen.getByText(/1\. Milestone 1/)).toBeInTheDocument();
     expect(screen.getByText('Criteria not met')).toBeInTheDocument();
+    expect(within(milestones).getByText('Failed')).toBeInTheDocument();
 
-    expect(screen.getByText('Funds Redirected')).toBeInTheDocument();
+    const settlement = screen.getByRole('region', {
+      name: /Fund settlement status: Funds redirected/i,
+    });
+    expect(within(settlement).getByText('Funds redirected')).toBeInTheDocument();
+    expect(
+      within(settlement).getByLabelText(
+        'Destination address GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK',
+      ),
+    ).toHaveTextContent('GFAIL3...LKQK');
     expect(screen.getAllByText('8,800 USDC').length).toBeGreaterThan(0);
-    expect(screen.getByText('d6a2e4f1...1c7a0d')).toBeInTheDocument();
+    expect(screen.getAllByText('d6a2e4f1...1c7a0d').length).toBeGreaterThan(0);
   });
 
   it('renders a not-found state for an unknown vault id', () => {


### PR DESCRIPTION
## Summary
- Mock WalletContext in VaultDetail tests so FundReleaseStatus can render deterministically.
- Extend active/completed/failed assertions for pending settlement, terminal settlement destinations, and terminal countdown replacement.
- Scope milestone status checks to the milestone tracker and avoid duplicate settlement/history hash matches.

## Validation
- `npx eslint src/pages/__tests__/VaultDetail.test.tsx`
- Targeted `npx tsc --noEmit -p <temporary tsconfig>` including `src/vite-env.d.ts`, `src/pages/VaultDetail.tsx`, and `src/pages/__tests__/VaultDetail.test.tsx`
- `git diff --check`
- `npx vitest run src/pages/__tests__/VaultDetail.test.tsx` (blocked locally: Vite config loading fails when esbuild service spawn returns `EPERM`)

Closes #204
