### PR TITLE
feat: add vault card deadline urgency

### DIFF
--- a/src/components/VaultCard.tsx
+++ b/src/components/VaultCard.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router-dom';
 import { Text } from './Text';
 import { VaultProgressBar } from './VaultProgressBar';
-import React from 'react';
 import { CountdownDeadline } from './CountdownDeadline';
+import { deadlineUrgency, type DeadlineUrgencyTier } from '../utils/deadlineUrgency';
 
 export type VaultStatus = 'active' | 'pending_validation' | 'completed' | 'failed';
 
@@ -46,6 +46,57 @@ function StatusBadge({ status }: { status: VaultStatus }) {
   );
 }
 
+const URGENCY_CONFIG: Record<
+  DeadlineUrgencyTier,
+  { label: string; ariaLabel: string; bg: string; fg: string }
+> = {
+  safe: {
+    label: 'Safe',
+    ariaLabel: 'Deadline urgency: safe',
+    bg: 'var(--accent-transparent)',
+    fg: 'var(--accent)',
+  },
+  soon: {
+    label: 'Due soon',
+    ariaLabel: 'Deadline urgency: soon',
+    bg: 'var(--warning-transparent)',
+    fg: 'var(--warning)',
+  },
+  critical: {
+    label: 'Critical',
+    ariaLabel: 'Deadline urgency: critical',
+    bg: 'var(--danger-transparent)',
+    fg: 'var(--danger)',
+  },
+};
+
+function DeadlineUrgencyBadge({ urgency }: { urgency: DeadlineUrgencyTier }) {
+  const config = URGENCY_CONFIG[urgency];
+
+  return (
+    <span
+      aria-label={config.ariaLabel}
+      data-deadline-urgency={urgency}
+      style={{
+        background: config.bg,
+        color: config.fg,
+        border: `1px solid ${config.fg}`,
+        borderRadius: 'var(--radius-full)',
+        padding: '2px 8px',
+        fontSize: 11,
+        fontWeight: 600,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {config.label}
+    </span>
+  );
+}
+
+function isTerminalStatus(status: VaultStatus) {
+  return status === 'completed' || status === 'failed';
+}
+
 export default function VaultCard({
   id,
   name,
@@ -57,6 +108,8 @@ export default function VaultCard({
   linkTo,
 }: VaultCardProps) {
   const link = linkTo ?? `/vaults/${id}`;
+  const urgency = isTerminalStatus(status) ? null : deadlineUrgency(deadline);
+  const urgencyConfig = urgency ? URGENCY_CONFIG[urgency] : null;
 
   return (
     <Link to={link} style={{ textDecoration: 'none', color: 'inherit' }}>
@@ -64,6 +117,7 @@ export default function VaultCard({
         style={{
           background: 'var(--bg)',
           border: '1px solid var(--border)',
+          borderLeft: urgencyConfig ? `4px solid ${urgencyConfig.fg}` : '1px solid var(--border)',
           borderRadius: 'var(--radius)',
           padding: '0.875rem 1rem',
           display: 'grid',
@@ -86,6 +140,7 @@ export default function VaultCard({
           </Text>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {urgency && <DeadlineUrgencyBadge urgency={urgency} />}
           <StatusBadge status={status} />
         </div>
         <div style={{ gridColumn: '1 / -1' }}>

--- a/src/components/__tests__/VaultCard.test.tsx
+++ b/src/components/__tests__/VaultCard.test.tsx
@@ -1,5 +1,5 @@
 // VaultCard component unit tests
-import React from 'react';
+import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
@@ -45,6 +45,40 @@ describe('VaultCard', () => {
     expect(badge).toBeInTheDocument();
     // Badge should use the accent color variable
     expect(badge).toHaveStyle({ color: 'var(--accent)' });
+  });
+
+  it('labels safe deadlines with an accessible urgency badge', () => {
+    renderCard();
+
+    const badge = screen.getByLabelText('Deadline urgency: safe');
+    expect(badge).toHaveTextContent('Safe');
+    expect(badge).toHaveAttribute('data-deadline-urgency', 'safe');
+    expect(badge).toHaveStyle({ color: 'var(--accent)' });
+  });
+
+  it('labels soon deadlines with the warning token', () => {
+    renderCard({ ...baseProps, deadline: '2024-07-06T00:00:00Z' });
+
+    const badge = screen.getByLabelText('Deadline urgency: soon');
+    expect(badge).toHaveTextContent('Due soon');
+    expect(badge).toHaveAttribute('data-deadline-urgency', 'soon');
+    expect(badge).toHaveStyle({ color: 'var(--warning)' });
+  });
+
+  it('labels critical deadlines with the danger token', () => {
+    renderCard({ ...baseProps, deadline: '2024-07-01T20:00:00Z' });
+
+    const badge = screen.getByLabelText('Deadline urgency: critical');
+    expect(badge).toHaveTextContent('Critical');
+    expect(badge).toHaveAttribute('data-deadline-urgency', 'critical');
+    expect(badge).toHaveStyle({ color: 'var(--danger)' });
+  });
+
+  it('does not add a deadline urgency badge for terminal vaults', () => {
+    renderCard({ ...baseProps, status: 'completed', deadline: '2024-07-01T20:00:00Z' });
+
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Deadline urgency:/)).not.toBeInTheDocument();
   });
 
   it('renders an accessible vault progress bar', () => {

--- a/src/utils/__tests__/deadlineUrgency.test.ts
+++ b/src/utils/__tests__/deadlineUrgency.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CRITICAL_DEADLINE_MS,
+  SOON_DEADLINE_MS,
+  deadlineUrgency,
+} from '../deadlineUrgency';
+
+const now = new Date('2026-06-18T12:00:00Z');
+
+function deadlineAfter(ms: number) {
+  return new Date(now.getTime() + ms).toISOString();
+}
+
+describe('deadlineUrgency', () => {
+  it('classifies deadlines beyond the seven-day threshold as safe', () => {
+    expect(deadlineUrgency(deadlineAfter(SOON_DEADLINE_MS + 1), now)).toBe('safe');
+  });
+
+  it('classifies the seven-day boundary through more than twenty-four hours as soon', () => {
+    expect(deadlineUrgency(deadlineAfter(SOON_DEADLINE_MS), now)).toBe('soon');
+    expect(deadlineUrgency(deadlineAfter(CRITICAL_DEADLINE_MS + 1), now)).toBe('soon');
+  });
+
+  it('classifies the twenty-four-hour boundary, past-due, and invalid deadlines as critical', () => {
+    expect(deadlineUrgency(deadlineAfter(CRITICAL_DEADLINE_MS), now)).toBe('critical');
+    expect(deadlineUrgency(deadlineAfter(-1), now)).toBe('critical');
+    expect(deadlineUrgency('not-a-date', now)).toBe('critical');
+  });
+});

--- a/src/utils/deadlineUrgency.ts
+++ b/src/utils/deadlineUrgency.ts
@@ -1,0 +1,32 @@
+export type DeadlineUrgencyTier = 'safe' | 'soon' | 'critical';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+export const CRITICAL_DEADLINE_MS = DAY_MS;
+export const SOON_DEADLINE_MS = 7 * DAY_MS;
+
+// Thresholds: >7d is safe, 24h-7d is soon, <=24h/past/invalid is critical.
+export function deadlineUrgency(
+  deadline: string,
+  now: Date | number = Date.now(),
+): DeadlineUrgencyTier {
+  const deadlineMs = new Date(deadline).getTime();
+
+  if (Number.isNaN(deadlineMs)) {
+    return 'critical';
+  }
+
+  const nowMs = typeof now === 'number' ? now : now.getTime();
+  const msRemaining = deadlineMs - nowMs;
+
+  if (msRemaining <= CRITICAL_DEADLINE_MS) {
+    return 'critical';
+  }
+
+  if (msRemaining <= SOON_DEADLINE_MS) {
+    return 'soon';
+  }
+
+  return 'safe';
+}


### PR DESCRIPTION
## Summary
- Add a pure `deadlineUrgency(deadline, now)` helper with named 24h and 7d thresholds.
- Render accessible Safe/Due soon/Critical urgency badges on non-terminal VaultCards, with token-driven border accents.
- Extend helper and VaultCard coverage for threshold boundaries, critical/soon/safe badges, and terminal vaults without urgency badges.

## Validation
- `npx eslint src/utils/deadlineUrgency.ts src/utils/__tests__/deadlineUrgency.test.ts src/components/VaultCard.tsx src/components/__tests__/VaultCard.test.tsx`
- Targeted `npx tsc --noEmit -p <temporary tsconfig>` including the helper, VaultCard, and related tests
- `git diff --check`
- `npx vitest run src/utils/__tests__/deadlineUrgency.test.ts src/components/__tests__/VaultCard.test.tsx` (blocked locally: Vite config loading fails when esbuild service spawn returns `EPERM`)

Closes #182
