### PR TITLE
feat: add network-aware explorer links

### DIFF
--- a/src/components/ExplorerLink.tsx
+++ b/src/components/ExplorerLink.tsx
@@ -1,0 +1,53 @@
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+import { useWallet, type WalletNetwork } from '../context/WalletContext';
+import { explorerUrl, type ExplorerKind } from '../utils/explorer';
+import { SafeLink } from './SafeLink';
+
+interface ExplorerLinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+  kind: ExplorerKind;
+  id: string;
+  network?: WalletNetwork | null;
+  children: ReactNode;
+}
+
+export function ExplorerLink({
+  kind,
+  id,
+  network,
+  children,
+  className,
+  style,
+  title,
+  ...linkProps
+}: ExplorerLinkProps) {
+  const { network: connectedNetwork } = useWallet();
+  const href = explorerUrl(network ?? connectedNetwork, kind, id);
+
+  if (!href) {
+    return (
+      <span
+        aria-disabled="true"
+        className={className}
+        style={style}
+        title={title ?? 'Explorer link unavailable'}
+      >
+        {children}
+      </span>
+    );
+  }
+
+  const ariaLabel = linkProps['aria-label'] ?? `View ${kind} ${id} on Stellar Expert`;
+
+  return (
+    <SafeLink
+      href={href}
+      className={className}
+      style={style}
+      title={title}
+      {...linkProps}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </SafeLink>
+  );
+}

--- a/src/components/__tests__/ExplorerLink.test.tsx
+++ b/src/components/__tests__/ExplorerLink.test.tsx
@@ -1,0 +1,70 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WalletNetwork } from '../../context/WalletContext';
+import { ExplorerLink } from '../ExplorerLink';
+
+let mockNetwork: WalletNetwork | null = 'TESTNET';
+
+vi.mock('../../context/WalletContext', () => ({
+  useWallet: () => ({ network: mockNetwork }),
+}));
+
+describe('ExplorerLink', () => {
+  beforeEach(() => {
+    mockNetwork = 'TESTNET';
+  });
+
+  it('renders a SafeLink with TESTNET as the default connected network', () => {
+    render(
+      <ExplorerLink kind="account" id="GACCOUNT">
+        GACC...OUNT
+      </ExplorerLink>,
+    );
+
+    const link = screen.getByRole('link', { name: /view account gaccount/i });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://stellar.expert/explorer/testnet/account/GACCOUNT',
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('reflects the connected PUBLIC network from WalletContext', () => {
+    mockNetwork = 'PUBLIC';
+
+    render(
+      <ExplorerLink kind="tx" id="abc123">
+        Explorer
+      </ExplorerLink>,
+    );
+
+    expect(screen.getByRole('link', { name: /view tx abc123/i })).toHaveAttribute(
+      'href',
+      'https://stellar.expert/explorer/public/tx/abc123',
+    );
+  });
+
+  it('allows an explicit network override and renders inert content for empty ids', () => {
+    const { rerender } = render(
+      <ExplorerLink kind="contract" id="CCONTRACT" network="PUBLIC">
+        Contract
+      </ExplorerLink>,
+    );
+
+    expect(screen.getByRole('link', { name: /view contract ccontract/i })).toHaveAttribute(
+      'href',
+      'https://stellar.expert/explorer/public/contract/CCONTRACT',
+    );
+
+    rerender(
+      <ExplorerLink kind="tx" id="   ">
+        Missing hash
+      </ExplorerLink>,
+    );
+
+    expect(screen.queryByRole('link', { name: /missing hash/i })).not.toBeInTheDocument();
+    expect(screen.getByText('Missing hash')).toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -7,7 +7,9 @@ import {
   FundReleaseStatus,
   type FundReleaseStatusProps,
 } from "../components/FundReleaseStatus";
+import { ExplorerLink } from "../components/ExplorerLink";
 import { Text } from "../components/Text";
+import type { ExplorerKind } from "../utils/explorer";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 type VaultStatus =
@@ -321,7 +323,15 @@ function CopyButton({ value }: { value: string }) {
 }
 
 // ── Address Row ───────────────────────────────────────────────────────────────
-function AddrRow({ label, value }: { label: string; value: string }) {
+function AddrRow({
+  label,
+  value,
+  kind = "account",
+}: {
+  label: string;
+  value: string;
+  kind?: ExplorerKind;
+}) {
   return (
     <div
       style={{
@@ -340,9 +350,16 @@ function AddrRow({ label, value }: { label: string; value: string }) {
         {label}
       </Text>
       <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
-        <Text role="mono" as="span" style={{ color: "var(--text)" }}>
-          {truncAddr(value)}
-        </Text>
+        <ExplorerLink
+          kind={kind}
+          id={value}
+          aria-label={`View ${label.toLowerCase()} ${value} on Stellar Expert`}
+          style={{ color: "var(--text)", textDecoration: "none" }}
+        >
+          <Text role="mono" as="span" style={{ color: "inherit" }}>
+            {truncAddr(value)}
+          </Text>
+        </ExplorerLink>
         <CopyButton value={value} />
       </div>
     </div>
@@ -603,7 +620,7 @@ export default function VaultDetail() {
             )}
             <AddrRow label="Success destination" value={vault.successAddress} />
             <AddrRow label="Failure destination" value={vault.failureAddress} />
-            <AddrRow label="Contract" value={vault.contractAddress} />
+            <AddrRow label="Contract" value={vault.contractAddress} kind="contract" />
           </div>
         </Card>
       </div>
@@ -697,14 +714,14 @@ export default function VaultDetail() {
                     {truncHash(tx.hash)}
                   </Text>
                   <CopyButton value={tx.hash} />
-                  <a
-                    href={`https://stellar.expert/explorer/public/tx/${tx.hash}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
+                  <ExplorerLink
+                    kind="tx"
+                    id={tx.hash}
+                    aria-label={`View transaction ${tx.hash} on Stellar Expert`}
                     style={{ color: "var(--accent)", fontSize: 11 }}
                   >
                     ↗
-                  </a>
+                  </ExplorerLink>
                 </div>
               </div>
             </div>

--- a/src/pages/VaultTransactions.tsx
+++ b/src/pages/VaultTransactions.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback } from "react";
+import { ExplorerLink } from "../components/ExplorerLink";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 type TxType = "create" | "validate" | "release" | "redirect";
@@ -647,15 +648,14 @@ function TxRow({ tx, onSelect, onCopy, copiedId, children }: TxRowProps) {
             {copiedId === tx.id + "-hash" ? "Copied!" : truncHash(tx.hash)}
             <CopyIcon small />
           </button>
-          <a
-            href={`https://stellar.expert/explorer/testnet/tx/${tx.hash}`}
-            target="_blank"
-            rel="noopener noreferrer"
+          <ExplorerLink
+            kind="tx"
+            id={tx.hash}
             className="vt-tx-explorer"
             onClick={(e) => e.stopPropagation()}
           >
             Explorer ↗
-          </a>
+          </ExplorerLink>
         </div>
       </div>
 
@@ -809,14 +809,13 @@ function TxModal({ tx, onClose, onCopy, copiedId }: TxModalProps) {
         </div>
 
         <div className="vt-modal-footer">
-          <a
-            href={`https://stellar.expert/explorer/testnet/tx/${tx.hash}`}
-            target="_blank"
-            rel="noopener noreferrer"
+          <ExplorerLink
+            kind="tx"
+            id={tx.hash}
             className="vt-explorer-link"
           >
             View on Stellar Explorer ↗
-          </a>
+          </ExplorerLink>
         </div>
       </div>
     </div>

--- a/src/utils/__tests__/explorer.test.ts
+++ b/src/utils/__tests__/explorer.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { explorerUrl } from '../explorer';
+
+describe('explorerUrl', () => {
+  it('builds account, contract, and transaction URLs for TESTNET', () => {
+    expect(explorerUrl('TESTNET', 'account', 'GACCOUNT')).toBe(
+      'https://stellar.expert/explorer/testnet/account/GACCOUNT',
+    );
+    expect(explorerUrl('TESTNET', 'contract', 'CCONTRACT')).toBe(
+      'https://stellar.expert/explorer/testnet/contract/CCONTRACT',
+    );
+    expect(explorerUrl('TESTNET', 'tx', 'abc123')).toBe(
+      'https://stellar.expert/explorer/testnet/tx/abc123',
+    );
+  });
+
+  it('builds public network URLs and defaults unknown networks to TESTNET', () => {
+    expect(explorerUrl('PUBLIC', 'account', 'GACCOUNT')).toBe(
+      'https://stellar.expert/explorer/public/account/GACCOUNT',
+    );
+    expect(explorerUrl(null, 'tx', 'abc123')).toBe(
+      'https://stellar.expert/explorer/testnet/tx/abc123',
+    );
+    expect(explorerUrl(undefined, 'contract', 'CCONTRACT')).toBe(
+      'https://stellar.expert/explorer/testnet/contract/CCONTRACT',
+    );
+  });
+
+  it('trims and encodes ids while rejecting empty ids', () => {
+    expect(explorerUrl('TESTNET', 'tx', ' hash/with space ')).toBe(
+      'https://stellar.expert/explorer/testnet/tx/hash%2Fwith%20space',
+    );
+    expect(explorerUrl('TESTNET', 'tx', '   ')).toBeNull();
+  });
+});

--- a/src/utils/explorer.ts
+++ b/src/utils/explorer.ts
@@ -1,0 +1,27 @@
+import type { WalletNetwork } from '../context/WalletContext';
+
+export type ExplorerKind = 'account' | 'contract' | 'tx';
+
+export const STELLAR_EXPERT_BASE_BY_NETWORK: Record<WalletNetwork, string> = {
+  TESTNET: 'https://stellar.expert/explorer/testnet',
+  PUBLIC: 'https://stellar.expert/explorer/public',
+};
+
+function explorerBase(network: WalletNetwork | null | undefined): string {
+  return STELLAR_EXPERT_BASE_BY_NETWORK[network ?? 'TESTNET'];
+}
+
+// Stellar Expert paths are /account/:id, /contract/:id, and /tx/:id.
+export function explorerUrl(
+  network: WalletNetwork | null | undefined,
+  kind: ExplorerKind,
+  id: string,
+): string | null {
+  const trimmed = id.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  return `${explorerBase(network)}/${kind}/${encodeURIComponent(trimmed)}`;
+}


### PR DESCRIPTION
## Summary
- Add pure `explorerUrl(network, kind, id)` helper for Stellar Expert account, contract, and tx URLs with TESTNET fallback.
- Add `ExplorerLink` wrapping SafeLink so explorer anchors inherit URL safety, target, and rel handling.
- Wire explorer links into VaultDetail address/transaction rows and VaultTransactions list/modal links while preserving truncated display text.

## Validation
- `npx eslint src/utils/explorer.ts src/utils/__tests__/explorer.test.ts src/components/ExplorerLink.tsx src/components/__tests__/ExplorerLink.test.tsx src/pages/VaultDetail.tsx src/pages/VaultTransactions.tsx`
- Targeted `npx tsc --noEmit -p <temporary tsconfig>` including helper, component, tests, VaultDetail, and VaultTransactions
- `git diff --check`
- `npx vitest run src/utils/__tests__/explorer.test.ts src/components/__tests__/ExplorerLink.test.tsx` (blocked locally: Vite config loading fails when esbuild service spawn returns `EPERM`)

Closes #187
