### PR TITLE
feat: add wrong network guard banner

### DIFF
--- a/design-system/documentation/network-guard.md
+++ b/design-system/documentation/network-guard.md
@@ -1,0 +1,14 @@
+# Network Guard Banner
+
+`NetworkGuardBanner` warns connected-wallet users when Freighter is on a network
+that does not match the deployment network.
+
+- Expected network comes from `VITE_DISCIPLR_NETWORK`.
+- Valid values are `TESTNET` and `PUBLIC`; unset or invalid values default to
+  `TESTNET`.
+- The banner only renders when a wallet address is connected and the connected
+  network differs from the expected network.
+- Users may dismiss the current mismatch for the session; the warning appears
+  again after the wallet returns to a matching state and then mismatches again.
+- The banner uses `role="alert"` and `--warning` token styling so the warning is
+  not communicated by color alone.

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from "react-router-dom";
 import { Menu } from "lucide-react";
 import { WalletConnectButton } from "./Wallet/WalletConnectButton";
 import MobileDrawer from "./MobileDrawer";
+import { NetworkGuardBanner } from "./NetworkGuardBanner";
 import { Text } from "./Text";
 import "./Layout.css";
 
@@ -107,6 +108,10 @@ export default function Layout({ children }: LayoutProps) {
         </button>
         <MobileDrawer isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)} />
       </header>
+
+      <div {...backgroundA11yProps}>
+        <NetworkGuardBanner />
+      </div>
 
       <main
         {...backgroundA11yProps}

--- a/src/components/NetworkGuardBanner.tsx
+++ b/src/components/NetworkGuardBanner.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useWallet, type WalletNetwork } from '../context/WalletContext';
+import { getExpectedNetwork, isNetworkMismatch } from '../utils/network';
+
+interface NetworkGuardBannerProps {
+  expectedNetwork?: WalletNetwork;
+}
+
+export function NetworkGuardBanner({
+  expectedNetwork = getExpectedNetwork(),
+}: NetworkGuardBannerProps) {
+  const { address, network } = useWallet();
+  const [dismissedMismatch, setDismissedMismatch] = useState<string | null>(null);
+  const hasConnectedWallet = Boolean(address);
+  const hasMismatch = hasConnectedWallet && isNetworkMismatch(network, expectedNetwork);
+  const mismatchKey = useMemo(
+    () => `${address ?? 'no-wallet'}:${network ?? 'unknown'}:${expectedNetwork}`,
+    [address, network, expectedNetwork],
+  );
+
+  useEffect(() => {
+    if (!hasMismatch) {
+      setDismissedMismatch(null);
+    }
+  }, [hasMismatch]);
+
+  if (!hasMismatch || dismissedMismatch === mismatchKey) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      style={{
+        background: 'var(--warning-transparent)',
+        border: '1px solid var(--warning)',
+        borderRadius: 'var(--radius)',
+        color: 'var(--text)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: '0.75rem',
+        margin: '0 auto',
+        maxWidth: 'var(--container-standard)',
+        padding: '0.75rem 1rem',
+        width: '100%',
+        boxSizing: 'border-box',
+      }}
+    >
+      <div>
+        <strong style={{ color: 'var(--warning)' }}>Wrong wallet network</strong>
+        <span style={{ marginLeft: 8 }}>
+          Connected to {network}; switch Freighter to {expectedNetwork} before creating or
+          validating vaults.
+        </span>
+      </div>
+      <button
+        type="button"
+        aria-label="Dismiss network warning"
+        onClick={() => setDismissedMismatch(mismatchKey)}
+        style={{
+          background: 'transparent',
+          border: '1px solid var(--warning)',
+          borderRadius: 'var(--radius-full)',
+          color: 'var(--warning)',
+          cursor: 'pointer',
+          fontWeight: 700,
+          minHeight: 32,
+          padding: '0.25rem 0.75rem',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, test, vi } from 'vitest';
 import Layout from '../Layout';
 
 vi.mock('../Wallet/WalletConnectButton', () => ({
   WalletConnectButton: () => <button type="button">Connect wallet</button>,
+}));
+
+vi.mock('../NetworkGuardBanner', () => ({
+  NetworkGuardBanner: () => null,
 }));
 
 describe('Layout component navigation', () => {

--- a/src/components/__tests__/NetworkGuardBanner.test.tsx
+++ b/src/components/__tests__/NetworkGuardBanner.test.tsx
@@ -1,0 +1,62 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WalletNetwork } from '../../context/WalletContext';
+import { NetworkGuardBanner } from '../NetworkGuardBanner';
+
+const walletState = vi.hoisted(() => ({
+  address: null as string | null,
+  network: null as WalletNetwork | null,
+}));
+
+vi.mock('../../context/WalletContext', () => ({
+  useWallet: () => walletState,
+}));
+
+describe('NetworkGuardBanner', () => {
+  beforeEach(() => {
+    walletState.address = null;
+    walletState.network = null;
+  });
+
+  it('stays hidden without a connected wallet or when networks match', () => {
+    const { rerender } = render(<NetworkGuardBanner expectedNetwork="TESTNET" />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    walletState.address = 'GUSER';
+    walletState.network = 'TESTNET';
+    rerender(<NetworkGuardBanner expectedNetwork="TESTNET" />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows an alert when the connected wallet network differs from the expected network', () => {
+    walletState.address = 'GUSER';
+    walletState.network = 'PUBLIC';
+
+    render(<NetworkGuardBanner expectedNetwork="TESTNET" />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Wrong wallet network');
+    expect(alert).toHaveTextContent('Connected to PUBLIC');
+    expect(alert).toHaveTextContent('TESTNET');
+  });
+
+  it('can be dismissed for the current mismatch and reappears for a new mismatch', () => {
+    walletState.address = 'GUSER';
+    walletState.network = 'PUBLIC';
+    const { rerender } = render(<NetworkGuardBanner expectedNetwork="TESTNET" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss network warning/i }));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    walletState.network = 'TESTNET';
+    rerender(<NetworkGuardBanner expectedNetwork="TESTNET" />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    walletState.network = 'PUBLIC';
+    rerender(<NetworkGuardBanner expectedNetwork="TESTNET" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/src/utils/__tests__/network.test.ts
+++ b/src/utils/__tests__/network.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getExpectedNetwork, isNetworkMismatch, parseExpectedNetwork } from '../network';
+
+describe('network helpers', () => {
+  it('parses expected network values and defaults invalid values to TESTNET', () => {
+    expect(parseExpectedNetwork('PUBLIC')).toBe('PUBLIC');
+    expect(parseExpectedNetwork(' public ')).toBe('PUBLIC');
+    expect(parseExpectedNetwork('TESTNET')).toBe('TESTNET');
+    expect(parseExpectedNetwork('invalid')).toBe('TESTNET');
+    expect(parseExpectedNetwork(undefined)).toBe('TESTNET');
+  });
+
+  it('reads the expected network from an explicit env value', () => {
+    expect(getExpectedNetwork('PUBLIC')).toBe('PUBLIC');
+    expect(getExpectedNetwork('')).toBe('TESTNET');
+  });
+
+  it('detects connected-wallet network mismatches', () => {
+    expect(isNetworkMismatch('PUBLIC', 'TESTNET')).toBe(true);
+    expect(isNetworkMismatch('TESTNET', 'TESTNET')).toBe(false);
+    expect(isNetworkMismatch(null, 'TESTNET')).toBe(false);
+  });
+});

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,0 +1,21 @@
+import type { WalletNetwork } from '../context/WalletContext';
+
+export const DEFAULT_EXPECTED_NETWORK: WalletNetwork = 'TESTNET';
+
+export function parseExpectedNetwork(value: unknown): WalletNetwork {
+  const normalized = String(value ?? '').trim().toUpperCase();
+  return normalized === 'PUBLIC' ? 'PUBLIC' : DEFAULT_EXPECTED_NETWORK;
+}
+
+export function getExpectedNetwork(
+  value: unknown = import.meta.env.VITE_DISCIPLR_NETWORK,
+): WalletNetwork {
+  return parseExpectedNetwork(value);
+}
+
+export function isNetworkMismatch(
+  connectedNetwork: WalletNetwork | null | undefined,
+  expectedNetwork: WalletNetwork,
+): boolean {
+  return connectedNetwork != null && connectedNetwork !== expectedNetwork;
+}


### PR DESCRIPTION
## Summary
- Add pure network helpers for `VITE_DISCIPLR_NETWORK` parsing and connected-vs-expected mismatch checks.
- Add a `NetworkGuardBanner` mounted in Layout that warns connected wallets on the wrong network and can be dismissed per mismatch session.
- Cover helper and banner edge cases and document env/default/dismissal behavior.

## Validation
- `npx eslint src/utils/network.ts src/utils/__tests__/network.test.ts src/components/NetworkGuardBanner.tsx src/components/__tests__/NetworkGuardBanner.test.tsx src/components/Layout.tsx src/components/__tests__/Layout.test.tsx`
- Targeted `npx tsc --noEmit -p <temporary tsconfig>` including helper, banner, Layout, and related tests
- `git diff --check`
- `npx vitest run src/utils/__tests__/network.test.ts src/components/__tests__/NetworkGuardBanner.test.tsx` (blocked locally: Vite config loading fails when esbuild service spawn returns `EPERM`)

Closes #185
