### PR TITLE
test: cover analytics page behavior

### DIFF
--- a/src/pages/__tests__/Analytics.test.tsx
+++ b/src/pages/__tests__/Analytics.test.tsx
@@ -1,16 +1,33 @@
-import React, { Suspense, lazy, act } from 'react'
-import { describe, expect, it, vi, beforeAll } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import React, { Suspense, lazy, type ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import Analytics from '../Analytics'
 import { buildAnalyticsSeriesColors } from '../analyticsTheme'
+
+type ChartDatum = { name?: string }
+
+const chartMockState = vi.hoisted(() => ({
+  lineProps: [] as Array<Record<string, unknown>>,
+  areaProps: [] as Array<Record<string, unknown>>,
+  barProps: [] as Array<Record<string, unknown>>,
+  pieProps: [] as Array<Record<string, unknown>>,
+}))
+
+const pdfMockState = vi.hoisted(() => ({
+  instances: [] as Array<Record<string, ReturnType<typeof vi.fn>>>,
+}))
 
 // ── Browser API stubs (jsdom doesn't implement these) ─────────────────────────
 
-beforeAll(() => {
+let prefersReducedMotion = false
+
+function installMatchMedia() {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: (query: string) => ({
-      matches: false,
+      matches: query === '(prefers-reduced-motion: reduce)' ? prefersReducedMotion : false,
       media: query,
       onchange: null,
       addListener: () => {},
@@ -20,38 +37,157 @@ beforeAll(() => {
       dispatchEvent: () => false,
     }),
   })
+}
+
+beforeEach(() => {
+  prefersReducedMotion = false
+  installMatchMedia()
+  chartMockState.lineProps.length = 0
+  chartMockState.areaProps.length = 0
+  chartMockState.barProps.length = 0
+  chartMockState.pieProps.length = 0
+  pdfMockState.instances.length = 0
+  document.documentElement.removeAttribute('data-theme')
+  document.documentElement.removeAttribute('style')
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
 })
 
 // ── Heavy dep mocks ───────────────────────────────────────────────────────────
 
-vi.mock('recharts', () => ({
-  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
-  AreaChart: ({ children }: any) => <div>{children}</div>,
-  BarChart: ({ children }: any) => <div>{children}</div>,
-  PieChart: ({ children }: any) => <div>{children}</div>,
-  Area: () => null,
-  Bar: () => null,
-  Pie: () => null,
-  Cell: () => null,
-  XAxis: () => null,
-  YAxis: () => null,
-  CartesianGrid: () => null,
-  Tooltip: () => null,
-  Legend: () => null,
-  LineChart: ({ children }: any) => <div>{children}</div>,
-  Line: () => null,
-}))
+vi.mock('recharts', () => {
+  function seriesNames(data?: ChartDatum[]) {
+    return data?.map((datum) => datum.name).join(',') ?? ''
+  }
+
+  function ResponsiveContainer({ children }: { children: ReactNode }) {
+    return <div data-testid="responsive-container">{children}</div>
+  }
+
+  function LineChart({ children, data }: { children: ReactNode; data?: ChartDatum[] }) {
+    return <div data-testid="line-chart" data-series={seriesNames(data)}>{children}</div>
+  }
+
+  function AreaChart({ children, data }: { children: ReactNode; data?: ChartDatum[] }) {
+    return <div data-testid="area-chart" data-series={seriesNames(data)}>{children}</div>
+  }
+
+  function BarChart({ children, data }: { children: ReactNode; data?: ChartDatum[] }) {
+    return <div data-testid="bar-chart" data-series={seriesNames(data)}>{children}</div>
+  }
+
+  function PieChart({ children }: { children: ReactNode }) {
+    return <div data-testid="pie-chart">{children}</div>
+  }
+
+  function Line(props: Record<string, unknown>) {
+    chartMockState.lineProps.push(props)
+    const dataKey = String(props.dataKey)
+    return (
+      <div
+        data-testid={`line-${dataKey}`}
+        data-animation={String(props.isAnimationActive)}
+        data-stroke={String(props.stroke)}
+      >
+        {String(props.name)}
+      </div>
+    )
+  }
+
+  function Area(props: Record<string, unknown>) {
+    chartMockState.areaProps.push(props)
+    const dataKey = String(props.dataKey)
+    return (
+      <div
+        data-testid={`area-${dataKey}`}
+        data-animation={String(props.isAnimationActive)}
+        data-stroke={String(props.stroke)}
+      >
+        {String(props.name)}
+      </div>
+    )
+  }
+
+  function Bar(props: Record<string, unknown>) {
+    chartMockState.barProps.push(props)
+    const dataKey = String(props.dataKey)
+    return (
+      <div
+        data-testid={`bar-${dataKey}`}
+        data-animation={String(props.isAnimationActive)}
+        data-fill={String(props.fill)}
+      >
+        {String(props.name ?? dataKey)}
+      </div>
+    )
+  }
+
+  function Pie(props: { children?: ReactNode; data?: ChartDatum[]; isAnimationActive?: boolean }) {
+    chartMockState.pieProps.push(props as Record<string, unknown>)
+    return (
+      <div
+        data-testid="pie"
+        data-series={seriesNames(props.data)}
+        data-animation={String(props.isAnimationActive)}
+      >
+        {props.children}
+      </div>
+    )
+  }
+
+  function Tooltip(props: { contentStyle?: { background?: string; border?: string; color?: string } }) {
+    return (
+      <div
+        data-testid="chart-tooltip"
+        data-background={props.contentStyle?.background ?? ''}
+        data-border={props.contentStyle?.border ?? ''}
+      />
+    )
+  }
+
+  return {
+    ResponsiveContainer,
+    AreaChart,
+    BarChart,
+    PieChart,
+    Area,
+    Bar,
+    Pie,
+    Cell: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip,
+    Legend: () => <div data-testid="chart-legend" />,
+    LineChart,
+    Line,
+  }
+})
 
 vi.mock('jspdf', () => ({
-  default: class {
-    text() {}
-    save() {}
-    addImage() {}
-  },
+  default: vi.fn(() => {
+    const instance = {
+      setFillColor: vi.fn(),
+      rect: vi.fn(),
+      setTextColor: vi.fn(),
+      setFontSize: vi.fn(),
+      setFont: vi.fn(),
+      text: vi.fn(),
+      setDrawColor: vi.fn(),
+      setLineWidth: vi.fn(),
+      line: vi.fn(),
+      save: vi.fn(),
+    }
+    pdfMockState.instances.push(instance)
+    return instance
+  }),
 }))
 
 vi.mock('../../context/WalletContext', () => ({
-  WalletProvider: ({ children }: any) => <>{children}</>,
+  WalletProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
   useWallet: () => ({
     address: null,
     network: null,
@@ -65,9 +201,17 @@ vi.mock('../../context/WalletContext', () => ({
 }))
 
 vi.mock('../../context/ThemeContext', () => ({
-  ThemeProvider: ({ children }: any) => <>{children}</>,
+  ThemeProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
   useTheme: () => ({ theme: 'light', toggleTheme: () => {} }),
 }))
+
+function renderAnalytics() {
+  return render(<Analytics />)
+}
+
+function firstLineChart() {
+  return screen.getAllByTestId('line-chart')[0]
+}
 
 // ── Theme mapping tests ───────────────────────────────────────────────────────
 
@@ -117,6 +261,90 @@ export const analyticsThemeCoverage = [
   'milestone bars map to --accent',
   'axis/grid/tooltip colors map to neutral surface tokens',
 ]
+
+// ── Analytics page behavior ──────────────────────────────────────────────────
+
+describe('Analytics page behavior', () => {
+  it.each([
+    ['7d', 'Mon,Tue,Wed,Thu,Fri,Sat,Sun'],
+    ['30d', 'Wk1,Wk2,Wk3,Wk4'],
+    ['90d', 'Jan,Feb,Mar'],
+    ['1y', 'Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec'],
+    ['All', '2023,2024,2025'],
+  ])('updates rendered chart data when switching to %s', (period, expectedSeries) => {
+    renderAnalytics()
+
+    fireEvent.click(screen.getByRole('button', { name: period }))
+
+    expect(firstLineChart()).toHaveAttribute('data-series', expectedSeries)
+  })
+
+  it('adds previous-period series when comparison mode is enabled', () => {
+    renderAnalytics()
+
+    expect(screen.queryByTestId('line-prevSuccess')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /compare periods/i }))
+
+    expect(screen.getByText(/Comparing with previous period/i)).toBeInTheDocument()
+    expect(screen.getByTestId('line-prevSuccess')).toHaveAttribute('data-animation', 'true')
+    expect(screen.getByTestId('area-prevCapital')).toHaveAttribute('data-animation', 'true')
+  })
+
+  it('disables chart animation when reduced motion is preferred', async () => {
+    prefersReducedMotion = true
+    installMatchMedia()
+
+    renderAnalytics()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('line-success')).toHaveAttribute('data-animation', 'false')
+    })
+    expect(screen.getByTestId('bar-milestones')).toHaveAttribute('data-animation', 'false')
+    expect(screen.getByTestId('pie')).toHaveAttribute('data-animation', 'false')
+  })
+
+  it('runs the jsPDF export pipeline for the selected period', () => {
+    renderAnalytics()
+
+    fireEvent.click(screen.getByRole('button', { name: 'All' }))
+    fireEvent.click(screen.getByRole('button', { name: /pdf report/i }))
+
+    expect(pdfMockState.instances).toHaveLength(1)
+    const [doc] = pdfMockState.instances
+    expect(doc.text).toHaveBeenCalledWith(
+      expect.stringContaining('Period: All'),
+      14,
+      24,
+    )
+    expect(doc.text).toHaveBeenCalledWith('2023', 17, 128)
+    expect(doc.save).toHaveBeenCalledWith('disciplr-report-All.pdf')
+  })
+
+  it('recomputes chart tokens after the document theme attribute changes', async () => {
+    document.documentElement.style.setProperty('--success', 'rgb(1, 2, 3)')
+    renderAnalytics()
+
+    expect(screen.getByTestId('line-success')).toHaveAttribute('data-stroke', 'rgb(1, 2, 3)')
+
+    document.documentElement.style.setProperty('--success', 'rgb(4, 5, 6)')
+    document.documentElement.style.setProperty('--surface', 'rgb(7, 8, 9)')
+    document.documentElement.style.setProperty('--border', 'rgb(10, 11, 12)')
+    document.documentElement.setAttribute('data-theme', 'dark')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('line-success')).toHaveAttribute('data-stroke', 'rgb(4, 5, 6)')
+    })
+    expect(screen.getAllByTestId('chart-tooltip')[0]).toHaveAttribute(
+      'data-background',
+      'rgb(7, 8, 9)',
+    )
+    expect(screen.getAllByTestId('chart-tooltip')[0]).toHaveAttribute(
+      'data-border',
+      '1px solid rgb(10, 11, 12)',
+    )
+  })
+})
 
 // ── Lazy-route / Suspense tests ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- expand Analytics page RTL coverage for period switching across every period option
- mock Recharts with inspectable chart output for comparison, reduced-motion, and theme-token assertions
- mock jsPDF to verify the selected-period export path and generated filename

## Validation
- npx tsc --noEmit -p <targeted analytics test tsconfig>
- npx eslint src/pages/Analytics.tsx src/pages/analyticsTheme.ts src/pages/__tests__/Analytics.test.tsx
- git diff --check
- npx vitest run src/pages/__tests__/Analytics.test.tsx *(blocked locally: Vite config startup fails while esbuild child process spawn returns EPERM)*

Closes #192
