### PR TITLE
feat: add notification read state store

### DIFF
--- a/src/Zustand/Store.ts
+++ b/src/Zustand/Store.ts
@@ -4,15 +4,53 @@ import { create } from "zustand";
 // --- Existing Notification Store ---
 const n = getNotifications();
 
+export type NotificationList = typeof n;
+
+export const getUnreadCount = (notifications: NotificationList) =>
+  notifications.filter((item) => !item.isRead).length;
+
 type notificationsType = {
-  notification: typeof n;
-  setNotification: (value: typeof n) => void;
+  notification: NotificationList;
+  /** Derived from notification so badges and pages share one unread source. */
+  unreadCount: number;
+  setNotification: (value: NotificationList) => void;
+  /** Marks one notification read without mutating the existing list. */
+  markRead: (id: string) => void;
+  /** Marks every unread notification read without changing the data shape. */
+  markAllRead: () => void;
 };
 
 export const useNotification = create<notificationsType>((set) => ({
   notification: n,
-  setNotification: (value: typeof n) =>
-    set(() => ({ notification: value })),
+  unreadCount: getUnreadCount(n),
+  setNotification: (value: NotificationList) =>
+    set(() => ({ notification: value, unreadCount: getUnreadCount(value) })),
+  markRead: (id: string) =>
+    set((state) => {
+      let changed = false;
+      const notification = state.notification.map((item) => {
+        if (item.id !== id || item.isRead) return item;
+        changed = true;
+        return { ...item, isRead: true };
+      });
+
+      if (!changed) return state;
+
+      return {
+        notification,
+        unreadCount: getUnreadCount(notification),
+      };
+    }),
+  markAllRead: () =>
+    set((state) => {
+      if (state.unreadCount === 0) return state;
+
+      const notification = state.notification.map((item) =>
+        item.isRead ? item : { ...item, isRead: true },
+      );
+
+      return { notification, unreadCount: 0 };
+    }),
 }));
 
 

--- a/src/Zustand/__tests__/notificationStore.test.ts
+++ b/src/Zustand/__tests__/notificationStore.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getUnreadCount,
+  type NotificationList,
+  useNotification,
+} from "../Store";
+
+const seedNotifications: NotificationList = [
+  {
+    id: "unread-vault",
+    type: "vault_deadline_approaching",
+    isUrgent: true,
+    title: "Unread Vault",
+    message: "Vault deadline is approaching.",
+    timestamp: "2026-04-24T08:00:00Z",
+    timeAgo: "2m ago",
+    isRead: false,
+    category: "vault",
+  },
+  {
+    id: "read-funds",
+    type: "funds_released",
+    isUrgent: false,
+    title: "Read Funds",
+    message: "Funds were released.",
+    timestamp: "2026-04-24T07:45:00Z",
+    timeAgo: "17m ago",
+    isRead: true,
+    category: "funds",
+  },
+  {
+    id: "unread-system",
+    type: "system_announcement",
+    isUrgent: false,
+    title: "Unread System",
+    message: "A new feature is available.",
+    timestamp: "2026-04-23T20:00:00Z",
+    timeAgo: "Yesterday",
+    isRead: false,
+    category: "system",
+  },
+];
+
+function cloneNotifications(notifications: NotificationList = seedNotifications) {
+  return notifications.map((item) => ({ ...item }));
+}
+
+function resetNotificationStore(notifications: NotificationList = seedNotifications) {
+  const notification = cloneNotifications(notifications);
+  useNotification.setState({
+    notification,
+    unreadCount: getUnreadCount(notification),
+  });
+}
+
+describe("useNotification read state", () => {
+  beforeEach(() => {
+    resetNotificationStore();
+  });
+
+  it("derives unreadCount from the notification list when replacing data", () => {
+    const nextNotifications = cloneNotifications([
+      { ...seedNotifications[0], id: "unread-a", isRead: false },
+      { ...seedNotifications[1], id: "unread-b", isRead: false },
+      { ...seedNotifications[2], id: "read-c", isRead: true },
+    ]);
+
+    useNotification.getState().setNotification(nextNotifications);
+
+    expect(useNotification.getState().notification).toEqual(nextNotifications);
+    expect(useNotification.getState().unreadCount).toBe(2);
+  });
+
+  it("marks one unread notification read without mutating the existing list", () => {
+    const previousState = useNotification.getState();
+    const previousList = previousState.notification;
+    const untouchedItem = previousList[1];
+
+    previousState.markRead("unread-vault");
+
+    const nextState = useNotification.getState();
+    expect(nextState.notification).not.toBe(previousList);
+    expect(nextState.notification[0]).toMatchObject({
+      id: "unread-vault",
+      isRead: true,
+    });
+    expect(nextState.notification[1]).toBe(untouchedItem);
+    expect(nextState.unreadCount).toBe(1);
+  });
+
+  it("keeps state stable when marking an unknown or already-read id", () => {
+    const beforeUnknown = useNotification.getState();
+    beforeUnknown.markRead("missing-id");
+    expect(useNotification.getState()).toBe(beforeUnknown);
+
+    const beforeAlreadyRead = useNotification.getState();
+    beforeAlreadyRead.markRead("read-funds");
+    expect(useNotification.getState()).toBe(beforeAlreadyRead);
+    expect(useNotification.getState().unreadCount).toBe(2);
+  });
+
+  it("marks every unread notification read and clears unreadCount", () => {
+    useNotification.getState().markAllRead();
+
+    const state = useNotification.getState();
+    expect(state.notification.every((item) => item.isRead)).toBe(true);
+    expect(state.unreadCount).toBe(0);
+  });
+
+  it("handles empty notification lists", () => {
+    resetNotificationStore([]);
+
+    useNotification.getState().markAllRead();
+    useNotification.getState().markRead("missing-id");
+
+    expect(useNotification.getState().notification).toEqual([]);
+    expect(useNotification.getState().unreadCount).toBe(0);
+  });
+});

--- a/src/components/Notification/NotificationIcon.tsx
+++ b/src/components/Notification/NotificationIcon.tsx
@@ -10,48 +10,10 @@ import { useNotification } from "@/Zustand/Store";
 export default function NotificationIcon() {
   const [isOpen, setIsOpen] = useState(false);
   const notifications = useNotification((state) => state.notification);
-  const setNotifications = useNotification((state) => state.setNotification);
-  const [unread, setUnread] = useState(0);
-  const [recentNotifications, setRecentNotifications] = useState<
-    typeof notifications
-  >([]);
-  const getNotificationStatus = () => {
-    const recent = notifications.slice(0, 5);
-    setRecentNotifications(recent);
-
-    // FIX: Unread should be where isRead is FALSE
-    const unreadCount = notifications.filter((n) => !n.isRead).length;
-    setUnread(unreadCount);
-  };
-  useEffect(() => {
-    if (notifications.length <= 0) return;
-    getNotificationStatus();
-  }, [notifications]);
-
-  const markAllAsRead = () => {
-    console.log("marked all as read");
-
-    // FIX: Create a NEW array with updated objects
-    const updatedNotifications = notifications.map((n) => ({
-      ...n,
-      isRead: true,
-    }));
-
-    // Set the new state
-    setNotifications(updatedNotifications);
-
-    // getNotificationStatus will run automatically via your useEffect
-    // because [notifications] is in the dependency array.
-  };
-
-  const setRead = (id: string) => {
-    setNotifications(
-      notifications.map((n) =>
-        // If this is the one we clicked, update isRead. Otherwise, return as is.
-        n.id === id ? { ...n, isRead: true } : n,
-      ),
-    );
-  };
+  const unreadCount = useNotification((state) => state.unreadCount);
+  const markRead = useNotification((state) => state.markRead);
+  const markAllRead = useNotification((state) => state.markAllRead);
+  const recentNotifications = notifications.slice(0, 5);
 
   const containerRef = useRef<HTMLDivElement | null>(null); // 1. Create a reference to the container
 
@@ -78,23 +40,30 @@ export default function NotificationIcon() {
   return (
     <>
       <div ref={containerRef} className="relative inline-block">
-        <div
+        <button
+          type="button"
+          aria-label={
+            unreadCount > 0
+              ? `Open notifications, ${unreadCount} unread`
+              : "Open notifications, no unread"
+          }
           onClick={() => {
             setIsOpen((prev) => !prev);
           }}
+          className="relative border-0 bg-transparent p-0 text-inherit cursor-pointer"
         >
-          {notifications.filter((n) => !n.isRead).length > 0 ? (
+          {unreadCount > 0 ? (
             <CiBellOn size="2rem" />
           ) : (
             <CiBellOff size="2rem" />
           )}
 
-          {notifications.length > 0 && (
+          {unreadCount > 0 && (
             <div className="absolute top-0 right-0 h-5 w-5 bg-red-500 text-white flex items-center justify-center rounded-full text-[10px] font-bold transform translate-x-1/2 -translate-y-1/2">
-              {unread}
+              {unreadCount}
             </div>
           )}
-        </div>
+        </button>
 
         <AnimatePresence>
           {isOpen && (
@@ -112,7 +81,8 @@ export default function NotificationIcon() {
                       Notifications
                     </h2>
                     <button
-                      onClick={markAllAsRead}
+                      onClick={markAllRead}
+                      disabled={unreadCount === 0}
                       className="bg-white text-[#00c389] px-3 rounded-lg shadow-lg"
                     >
                       Mark All As Read
@@ -129,7 +99,7 @@ export default function NotificationIcon() {
                           type={items.type}
                           read={items.isRead}
                           isFullPage={false}
-                          setRead={setRead}
+                          setRead={markRead}
                         />
                       </div>
                     ))}

--- a/src/pages/Notification.tsx
+++ b/src/pages/Notification.tsx
@@ -1,5 +1,5 @@
 import Message from "@/components/Notification/Messages";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { transitionEnter } from "../utils/motion";
 import { useNotification } from "@/Zustand/Store";
@@ -8,7 +8,9 @@ import { Link } from "react-router-dom";
 
 export default function Notification() {
   const notifications = useNotification((state) => state.notification);
-  const setNotifications = useNotification((state) => state.setNotification);
+  const unreadCount = useNotification((state) => state.unreadCount);
+  const markRead = useNotification((state) => state.markRead);
+  const markAllRead = useNotification((state) => state.markAllRead);
   const [currentNotification, setCurrentNotification] = useState(notifications);
   const [currentFilterReadSeletion, setCurrentFilterReadSeletion] =
     useState("all");
@@ -49,7 +51,7 @@ export default function Notification() {
     };
   }, []);
 
-  const filterNotification = () => {
+  const filterNotification = useCallback(() => {
     let filtered = notifications;
 
     if (!filtered) return;
@@ -67,32 +69,31 @@ export default function Notification() {
     }
     setCurrentNotification(filtered);
     setCurrentPage(1);
-  };
-  useEffect(() => {
-    filterNotification();
   }, [currentFilterReadSeletion, currentFilterTypeSeletion, notifications]);
 
+  useEffect(() => {
+    filterNotification();
+  }, [filterNotification]);
+
   // 2. Calculate total pages
-  const totalPages = Math.ceil(currentNotification.length / itemsPerPage);
-  const setRead = (id: string) => {
-    setNotifications(
-      notifications.map((n) =>
-        // If this is the one we clicked, update isRead. Otherwise, return as is.
-        n.id === id ? { ...n, isRead: true } : n,
-      ),
-    );
-    setCurrentNotification((prev) =>
-      prev.map((n) =>
-        // If this is the one we clicked, update isRead. Otherwise, return as is.
-        n.id === id ? { ...n, isRead: true } : n,
-      ),
-    );
-  };
+  const totalPages = Math.max(
+    1,
+    Math.ceil(currentNotification.length / itemsPerPage),
+  );
+
   return (
     <>
       <div ref={containerRef} className="flex justify-between items-center">
         <div className="text-xl font-bold">Notification Page </div>
         <div className="flex gap-5 items-center justify-center">
+          <button
+            type="button"
+            onClick={markAllRead}
+            disabled={unreadCount === 0}
+            className="bg-[#00c389] px-3 py-2 rounded-md disabled:opacity-50"
+          >
+            Mark All As Read
+          </button>
           <div className="relative">
             <Link
               to="/notification/settings"
@@ -132,6 +133,7 @@ export default function Notification() {
                   <h2>Filter By : </h2>
                   <div className="flex justify-between">
                     <select
+                      aria-label="Filter by read status"
                       onChange={(e) => {
                         setCurrentFilterReadSeletion(e.target.value);
                       }}
@@ -144,6 +146,7 @@ export default function Notification() {
                       <option value="1">Read</option>
                     </select>
                     <select
+                      aria-label="Filter by notification type"
                       onChange={(e) => {
                         setCurrentFilterTypeSeletion(e.target.value);
                       }}
@@ -181,7 +184,7 @@ export default function Notification() {
                 type={items.type}
                 read={items.isRead}
                 isFullPage={true}
-                setRead={setRead}
+                setRead={markRead}
               />
             </div>
           ))

--- a/src/pages/__tests__/Notification.test.tsx
+++ b/src/pages/__tests__/Notification.test.tsx
@@ -1,0 +1,189 @@
+import { type ComponentPropsWithoutRef, type ReactNode } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import NotificationIcon from "../../components/Notification/NotificationIcon";
+import {
+  getUnreadCount,
+  type NotificationList,
+  useNotification,
+} from "../../Zustand/Store";
+import Notification from "../Notification";
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({
+      children,
+      initial: _initial,
+      animate: _animate,
+      exit: _exit,
+      transition: _transition,
+      ...props
+    }: ComponentPropsWithoutRef<"div"> & {
+      initial?: unknown;
+      animate?: unknown;
+      exit?: unknown;
+      transition?: unknown;
+    }) => {
+      void _initial;
+      void _animate;
+      void _exit;
+      void _transition;
+
+      return <div {...props}>{children}</div>;
+    },
+  },
+}));
+
+const seedNotifications: NotificationList = [
+  {
+    id: "unread-vault",
+    type: "vault_deadline_approaching",
+    isUrgent: true,
+    title: "Unread Vault",
+    message: "Vault deadline is approaching.",
+    timestamp: "2026-04-24T08:00:00Z",
+    timeAgo: "2m ago",
+    isRead: false,
+    category: "vault",
+  },
+  {
+    id: "read-funds",
+    type: "funds_released",
+    isUrgent: false,
+    title: "Read Funds",
+    message: "Funds were released.",
+    timestamp: "2026-04-24T07:45:00Z",
+    timeAgo: "17m ago",
+    isRead: true,
+    category: "funds",
+  },
+  {
+    id: "unread-system",
+    type: "system_announcement",
+    isUrgent: false,
+    title: "Unread System",
+    message: "A new feature is available.",
+    timestamp: "2026-04-23T20:00:00Z",
+    timeAgo: "Yesterday",
+    isRead: false,
+    category: "system",
+  },
+];
+
+function cloneNotifications(notifications: NotificationList = seedNotifications) {
+  return notifications.map((item) => ({ ...item }));
+}
+
+function resetNotificationStore(notifications: NotificationList = seedNotifications) {
+  const notification = cloneNotifications(notifications);
+  useNotification.setState({
+    notification,
+    unreadCount: getUnreadCount(notification),
+  });
+}
+
+function renderNotificationPage() {
+  return render(
+    <MemoryRouter>
+      <Notification />
+    </MemoryRouter>,
+  );
+}
+
+function openFilterMenu() {
+  fireEvent.click(screen.getByRole("button", { name: /filter/i }));
+}
+
+describe("Notification page read state", () => {
+  beforeEach(() => {
+    resetNotificationStore();
+  });
+
+  it("keeps read and unread filtering backed by the store list", () => {
+    renderNotificationPage();
+
+    expect(screen.getByText("Unread Vault")).toBeInTheDocument();
+    expect(screen.getByText("Read Funds")).toBeInTheDocument();
+
+    openFilterMenu();
+    fireEvent.change(screen.getByLabelText(/filter by read status/i), {
+      target: { value: "0" },
+    });
+
+    expect(screen.getByText("Unread Vault")).toBeInTheDocument();
+    expect(screen.getByText("Unread System")).toBeInTheDocument();
+    expect(screen.queryByText("Read Funds")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/filter by read status/i), {
+      target: { value: "1" },
+    });
+
+    expect(screen.getByText("Read Funds")).toBeInTheDocument();
+    expect(screen.queryByText("Unread Vault")).not.toBeInTheDocument();
+  });
+
+  it("marks all notifications read from the page and leaves unread filtering empty", async () => {
+    renderNotificationPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /mark all as read/i }));
+
+    await waitFor(() => {
+      expect(useNotification.getState().unreadCount).toBe(0);
+    });
+
+    openFilterMenu();
+    fireEvent.change(screen.getByLabelText(/filter by read status/i), {
+      target: { value: "0" },
+    });
+
+    expect(screen.getByText(/no notifications found/i)).toBeInTheDocument();
+  });
+
+  it("marks a clicked notification read through the shared store", async () => {
+    renderNotificationPage();
+
+    fireEvent.click(screen.getByText("Unread Vault"));
+
+    await waitFor(() => {
+      const marked = useNotification
+        .getState()
+        .notification.find((item) => item.id === "unread-vault");
+      expect(marked?.isRead).toBe(true);
+    });
+    expect(useNotification.getState().unreadCount).toBe(1);
+  });
+});
+
+describe("NotificationIcon badge", () => {
+  beforeEach(() => {
+    resetNotificationStore();
+  });
+
+  it("reacts to unreadCount when all notifications are marked read", async () => {
+    render(
+      <MemoryRouter>
+        <NotificationIcon />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /open notifications, 2 unread/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /open notifications, 2 unread/i }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /mark all as read/i }));
+
+    await waitFor(() => {
+      expect(useNotification.getState().unreadCount).toBe(0);
+    });
+    expect(screen.queryByText("2")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /open notifications, no unread/i }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- move notification read-state into the Zustand store with immutable `markRead`, `markAllRead`, and derived `unreadCount`
- update the Notification page and bell badge to consume the shared store API
- add store and RTL coverage for unread filtering, mark-all-read, clicked-read state, and reactive badge updates

## Validation
- npx tsc --noEmit -p <targeted notification test tsconfig>
- npx eslint src/Zustand/Store.ts src/Zustand/__tests__/notificationStore.test.ts src/components/Notification/NotificationIcon.tsx src/components/Notification/Messages.tsx src/pages/Notification.tsx src/pages/__tests__/Notification.test.tsx
- git diff --check
- npx vitest run src/Zustand/__tests__/notificationStore.test.ts src/pages/__tests__/Notification.test.tsx *(blocked locally: Vite config startup fails while esbuild child process spawn returns EPERM)*

Closes #190
