### PR TITLE
feat: add shared USDC formatting utilities

### DIFF
--- a/src/components/FundReleaseStatus.tsx
+++ b/src/components/FundReleaseStatus.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, CheckCircle2, Clock3 } from 'lucide-react';
 import { useWallet } from '../context/WalletContext';
 import { Text } from './Text';
+import { formatAddress, formatUsdc } from '../utils/format';
 import './FundReleaseStatus.css';
 
 export type FundReleaseOutcome = 'released' | 'redirected' | 'pending';
@@ -18,12 +19,8 @@ export interface FundReleaseStatusProps {
   transaction?: SettlementTransaction;
 }
 
-export function truncateMiddle(value: string, prefixLength = 6, suffixLength = 4): string {
-  if (value.length <= prefixLength + suffixLength + 3) {
-    return value;
-  }
-
-  return `${value.slice(0, prefixLength)}...${value.slice(-suffixLength)}`;
+function truncateMiddle(value: string, prefixLength = 6, suffixLength = 4): string {
+  return formatAddress(value, { prefixLength, suffixLength });
 }
 
 function explorerUrl(hash: string, network: 'TESTNET' | 'PUBLIC' | null): string {
@@ -115,7 +112,7 @@ export function FundReleaseStatus({
                 title={destinationAddress}
                 aria-label={`Destination address ${destinationAddress}`}
               >
-                {truncateMiddle(destinationAddress)}
+                {formatAddress(destinationAddress)}
               </Text>
             ) : (
               <Text role="caption" as="span" className="fund-release-status__label">
@@ -128,7 +125,7 @@ export function FundReleaseStatus({
               Amount
             </Text>
             <Text role="mono" as="span" className="fund-release-status__value">
-              {amount.toLocaleString()} {currency}
+              {formatUsdc(amount, { currency })}
             </Text>
           </div>
           <div className="fund-release-status__field">

--- a/src/components/VaultCard.tsx
+++ b/src/components/VaultCard.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router-dom';
 import { Text } from './Text';
 import { VaultProgressBar } from './VaultProgressBar';
-import React from 'react';
 import { CountdownDeadline } from './CountdownDeadline';
+import { formatUsdc } from '../utils/format';
 
 export type VaultStatus = 'active' | 'pending_validation' | 'completed' | 'failed';
 
@@ -78,7 +78,7 @@ export default function VaultCard({
             {name}
           </Text>
           <Text role="caption" as="div" style={{ color: 'var(--accent)', fontWeight: 700 }}>
-            {amount.toLocaleString()} {currency}
+            {formatUsdc(amount, { currency })}
           </Text>
           <Text role="caption" as="div" style={{ color: 'var(--muted)' }}>
             Deadline:{' '}

--- a/src/components/__tests__/FundReleaseStatus.test.tsx
+++ b/src/components/__tests__/FundReleaseStatus.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { FundReleaseStatus, truncateMiddle } from '../FundReleaseStatus';
+import { FundReleaseStatus } from '../FundReleaseStatus';
 
 let mockNetwork: 'TESTNET' | 'PUBLIC' | null = 'TESTNET';
 
@@ -16,13 +16,6 @@ vi.mock('../../context/WalletContext', () => ({
     checkConnection: vi.fn(),
   }),
 }));
-
-describe('truncateMiddle', () => {
-  it('truncates long values and leaves short values untouched', () => {
-    expect(truncateMiddle('GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890')).toBe('GABCDE...7890');
-    expect(truncateMiddle('GSHORT')).toBe('GSHORT');
-  });
-});
 
 describe('FundReleaseStatus', () => {
   beforeEach(() => {

--- a/src/components/__tests__/VaultCard.test.tsx
+++ b/src/components/__tests__/VaultCard.test.tsx
@@ -1,5 +1,4 @@
 // VaultCard component unit tests
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import { Text } from '../components/Text';
 import VaultCard from '../components/VaultCard';
+import { formatUsdc } from '../utils/format';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 type VaultStatus = "active" | "pending_validation" | "completed" | "failed";
@@ -114,32 +115,6 @@ const DEADLINES: Deadline[] = [
 ];
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-const STATUS_CFG: Record<
-  VaultStatus,
-  { label: string; color: string; bg: string }
-> = {
-  active: {
-    label: "Active",
-    color: "var(--accent)",
-    bg: "var(--accent-transparent)",
-  },
-  pending_validation: {
-    label: "Pending Validation",
-    color: "var(--warning)",
-    bg: "rgba(245,158,11,0.1)",
-  },
-  completed: {
-    label: "Completed",
-    color: "var(--success)",
-    bg: "rgba(16,185,129,0.1)",
-  },
-  failed: {
-    label: "Failed",
-    color: "var(--danger)",
-    bg: "rgba(239,68,68,0.1)",
-  },
-};
-
 const ACTIVITY_CFG: Record<
   Activity["type"],
   { label: string; icon: string; color: string }
@@ -233,26 +208,6 @@ function SummaryCard({
   );
 }
 
-function StatusBadge({ status }: { status: VaultStatus }) {
-  const cfg = STATUS_CFG[status];
-  return (
-    <span
-      style={{
-        background: cfg.bg,
-        color: cfg.color,
-        border: `var(--border-width-1) solid ${cfg.color}`,
-        borderRadius: "var(--radius-full)",
-        padding: "2px 10px",
-        fontSize: 11,
-        fontWeight: 600,
-        whiteSpace: "nowrap",
-      }}
-    >
-      {cfg.label}
-    </span>
-  );
-}
-
 function SectionHeader({
   title,
   action,
@@ -316,7 +271,7 @@ export default function Dashboard() {
       >
         <SummaryCard
           label="Total Locked"
-          value={`$${SUMMARY.totalLocked.toLocaleString()}`}
+          value={formatUsdc(SUMMARY.totalLocked, { includeCurrency: false })}
           sub="USDC"
           accent
         />
@@ -533,7 +488,7 @@ export default function Dashboard() {
                           as="div"
                           style={{ color: "var(--muted)" }}
                         >
-                          {a.amount.toLocaleString()} USDC
+                          {formatUsdc(a.amount)}
                         </Text>
                       )}
                     </div>
@@ -622,7 +577,7 @@ export default function Dashboard() {
                         as="div"
                         style={{ color: "var(--muted)", marginTop: 2 }}
                       >
-                        {d.amount.toLocaleString()} USDC ·{" "}
+                        {formatUsdc(d.amount)} ·{" "}
                         {new Date(d.deadline).toLocaleDateString("en-US", {
                           month: "short",
                           day: "numeric",

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -8,6 +8,7 @@ import {
   type FundReleaseStatusProps,
 } from "../components/FundReleaseStatus";
 import { Text } from "../components/Text";
+import { formatAddress, formatUsdc } from "../utils/format";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 type VaultStatus =
@@ -228,10 +229,6 @@ const TX_LABELS: Record<string, string> = {
   redirect: "Funds Redirected",
 };
 
-function truncAddr(addr: string): string {
-  return addr.length > 12 ? `${addr.slice(0, 6)}...${addr.slice(-4)}` : addr;
-}
-
 function truncHash(hash: string): string {
   return hash.length > 12 ? `${hash.slice(0, 8)}...${hash.slice(-6)}` : hash;
 }
@@ -341,7 +338,7 @@ function AddrRow({ label, value }: { label: string; value: string }) {
       </Text>
       <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
         <Text role="mono" as="span" style={{ color: "var(--text)" }}>
-          {truncAddr(value)}
+          {formatAddress(value)}
         </Text>
         <CopyButton value={value} />
       </div>
@@ -467,7 +464,10 @@ export default function VaultDetail() {
               as="div"
               style={{ color: "var(--accent)", lineHeight: 1.1 }}
             >
-              {vault.amount.toLocaleString()}{" "}
+              {formatUsdc(vault.amount, {
+                currency: vault.currency,
+                includeCurrency: false,
+              })}{" "}
               <span
                 style={{
                   fontSize: "0.45em",
@@ -576,7 +576,7 @@ export default function VaultDetail() {
             />
             <InfoRow
               label="Amount"
-              value={`${vault.amount.toLocaleString()} ${vault.currency}`}
+              value={formatUsdc(vault.amount, { currency: vault.currency })}
             />
           </div>
         </Card>
@@ -685,7 +685,7 @@ export default function VaultDetail() {
                     as="span"
                     style={{ color: "var(--text)", fontWeight: 600 }}
                   >
-                    {tx.amount.toLocaleString()} {vault.currency}
+                    {formatUsdc(tx.amount, { currency: vault.currency })}
                   </Text>
                 )}
                 <div style={{ display: "flex", alignItems: "center", gap: 4 }}>

--- a/src/pages/VaultTransactions.tsx
+++ b/src/pages/VaultTransactions.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback } from "react";
+import { formatAddress, formatUsdc } from "../utils/format";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 type TxType = "create" | "validate" | "release" | "redirect";
@@ -272,11 +273,12 @@ function fmtFullTime(date: Date): string {
   });
 }
 
-function fmtAmount(n: number): string {
+function fmtTransactionAmount(n: number): string {
   if (n === 0) return "—";
-  return n.toLocaleString("en-US", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+  return formatUsdc(n, {
+    includeCurrency: false,
+    minFractionDigits: 2,
+    maxFractionDigits: 2,
   });
 }
 
@@ -285,7 +287,7 @@ function exportCSV(txs: Transaction[]): void {
     "ID",
     "Type",
     "Vault",
-    "Amount (XLM)",
+    "Amount (USDC)",
     "Fee (XLM)",
     "Status",
     "Timestamp",
@@ -443,7 +445,10 @@ export default function VaultTransactions() {
               },
               {
                 label: "Capital Moved",
-                value: `${fmtAmount(stats.capital)} XLM`,
+                value: formatUsdc(stats.capital, {
+                  minFractionDigits: 2,
+                  maxFractionDigits: 2,
+                }),
                 sub: "Across all vaults",
               },
             ].map((s, i) => (
@@ -490,7 +495,7 @@ export default function VaultTransactions() {
               <div className="vt-amount-range">
                 <input
                   className="vt-amount-input"
-                  placeholder="Min XLM"
+                  placeholder="Min USDC"
                   value={amountMin}
                   onChange={(e) => setAmountMin(e.target.value)}
                   type="number"
@@ -498,7 +503,7 @@ export default function VaultTransactions() {
                 <span className="vt-amount-sep">–</span>
                 <input
                   className="vt-amount-input"
-                  placeholder="Max XLM"
+                  placeholder="Max USDC"
                   value={amountMax}
                   onChange={(e) => setAmountMax(e.target.value)}
                   type="number"
@@ -662,8 +667,8 @@ function TxRow({ tx, onSelect, onCopy, copiedId, children }: TxRowProps) {
       <div className="vt-tx-amount">
         {tx.amount > 0 && (
           <span className="vt-tx-amount-val">
-            {fmtAmount(tx.amount)}
-            <span className="vt-tx-xlm">XLM</span>
+            {fmtTransactionAmount(tx.amount)}
+            <span className="vt-tx-currency">USDC</span>
           </span>
         )}
         <span className="vt-tx-fee">Fee: {tx.fee.toFixed(5)}</span>
@@ -766,16 +771,16 @@ function TxModal({ tx, onClose, onCopy, copiedId }: TxModalProps) {
             </div>
           </Field>
           <Field label="From">
-            <span className="vt-mono">{tx.from}</span>
+            <span className="vt-mono">{formatAddress(tx.from)}</span>
           </Field>
           <Field label="To">
-            <span className="vt-mono">{tx.to}</span>
+            <span className="vt-mono">{formatAddress(tx.to)}</span>
           </Field>
           <div className="vt-modal-row2">
             <Field label="Amount">
               <span className="vt-modal-amount">
-                {fmtAmount(tx.amount)}{" "}
-                <span style={{ opacity: 0.5, fontSize: "0.85em" }}>XLM</span>
+                {fmtTransactionAmount(tx.amount)}{" "}
+                <span style={{ opacity: 0.5, fontSize: "0.85em" }}>USDC</span>
               </span>
             </Field>
             <Field label="Fee Paid">
@@ -1217,7 +1222,7 @@ const CSS = `
   .vt-tx-explorer:hover { color: #6ee7b7; }
   .vt-tx-amount { text-align: right; flex-shrink: 0; }
   .vt-tx-amount-val { display: block; font-family: 'JetBrains Mono', monospace; font-size: 14px; font-weight: 500; color: #f1f5f9; }
-  .vt-tx-xlm { font-size: 10px; color: #475569; margin-left: 4px; }
+  .vt-tx-currency { font-size: 10px; color: #475569; margin-left: 4px; }
   .vt-tx-fee { display: block; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: #334155; margin-top: 3px; }
   .vt-tx-right { text-align: right; flex-shrink: 0; display: flex; flex-direction: column; align-items: flex-end; gap: 5px; }
   .vt-tx-status {

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import { Text } from '../components/Text'
+import { formatUsdc } from '../utils/format'
 
 type VaultStatus = 'active' | 'completed' | 'failed' | 'cancelled' | 'pending_validation'
 
@@ -68,7 +69,7 @@ export default function Vaults() {
                 </div>
                 <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
                   <Text role="body" as="span" style={{ fontWeight: 700, color: 'var(--accent)' }}>
-                    {vault.amount.toLocaleString()} {vault.currency}
+                    {formatUsdc(vault.amount, { currency: vault.currency })}
                   </Text>
                   <span style={{
                     background: cfg.bg, color: cfg.color,

--- a/src/pages/__tests__/VaultDetail.test.tsx
+++ b/src/pages/__tests__/VaultDetail.test.tsx
@@ -19,7 +19,7 @@ describe('VaultDetail', () => {
 
     expect(screen.getByRole('heading', { name: 'Alpha Vault' })).toBeInTheDocument();
     expect(screen.getByText('Active')).toBeInTheDocument();
-    expect(screen.getByText('12,500')).toBeInTheDocument();
+    expect(screen.getAllByText(/12,500/).length).toBeGreaterThan(0);
     expect(screen.getAllByText('USDC').length).toBeGreaterThan(0);
 
     expect(screen.getByText('Status Timeline')).toBeInTheDocument();

--- a/src/pages/__tests__/VaultTransactions.test.tsx
+++ b/src/pages/__tests__/VaultTransactions.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import VaultTransactions from "../VaultTransactions";
+
+describe("VaultTransactions formatting", () => {
+  it("formats moved capital and amount filters as USDC while preserving XLM fees", () => {
+    render(<VaultTransactions />);
+
+    expect(screen.getByText("172,201.25 USDC")).toBeInTheDocument();
+    expect(screen.getByText("0.00121 XLM")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Min USDC")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Max USDC")).toBeInTheDocument();
+  });
+});

--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { formatAddress, formatUsdc } from "../format";
+
+describe("formatUsdc", () => {
+  it("groups whole USDC amounts and includes the currency by default", () => {
+    expect(formatUsdc(0)).toBe("0 USDC");
+    expect(formatUsdc(12500)).toBe("12,500 USDC");
+    expect(formatUsdc("1234567890")).toBe("1,234,567,890 USDC");
+  });
+
+  it("preserves up to the 7-decimal USDC precision without locale drift", () => {
+    expect(formatUsdc("0.0000001")).toBe("0.0000001 USDC");
+    expect(formatUsdc("4200.5000000")).toBe("4,200.5 USDC");
+    expect(formatUsdc("999999999999.1234567")).toBe("999,999,999,999.1234567 USDC");
+  });
+
+  it("respects configured fraction digits", () => {
+    expect(formatUsdc("4200.5", { minFractionDigits: 2 })).toBe("4,200.50 USDC");
+    expect(formatUsdc("4200.567", { maxFractionDigits: 2 })).toBe("4,200.57 USDC");
+    expect(formatUsdc("999.995", { maxFractionDigits: 2 })).toBe("1,000 USDC");
+    expect(formatUsdc("12500", { includeCurrency: false })).toBe("12,500");
+  });
+
+  it("rejects invalid and negative values", () => {
+    expect(() => formatUsdc(-1)).toThrow(/cannot be negative/i);
+    expect(() => formatUsdc("1.12345678")).toThrow(/at most 7 decimal/i);
+    expect(() => formatUsdc("abc")).toThrow(/decimal value/i);
+    expect(() => formatUsdc("1", { minFractionDigits: 3, maxFractionDigits: 2 })).toThrow(
+      /cannot exceed/i,
+    );
+  });
+});
+
+describe("formatAddress", () => {
+  it("truncates long addresses with configurable visible lengths", () => {
+    expect(formatAddress("GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")).toBe("GABCDE...7890");
+    expect(
+      formatAddress("GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890", {
+        prefixLength: 1,
+        suffixLength: 4,
+      }),
+    ).toBe("G...7890");
+  });
+
+  it("handles short and empty values gracefully", () => {
+    expect(formatAddress("GSHORT")).toBe("GSHORT");
+    expect(formatAddress("")).toBe("");
+    expect(formatAddress("   ")).toBe("");
+  });
+});

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,165 @@
+export interface FormatUsdcOptions {
+  /** Currency suffix to append when includeCurrency is true. Defaults to USDC. */
+  currency?: string;
+  /** Include the currency suffix in the returned label. Defaults to true. */
+  includeCurrency?: boolean;
+  /** Maximum displayed decimals, capped to Stellar USDC's 7-decimal precision. */
+  maxFractionDigits?: number;
+  /** Minimum displayed decimals, padded with trailing zeroes. Defaults to 0. */
+  minFractionDigits?: number;
+}
+
+export interface FormatAddressOptions {
+  /** Leading characters to keep before the separator. Defaults to 6. */
+  prefixLength?: number;
+  /** Trailing characters to keep after the separator. Defaults to 4. */
+  suffixLength?: number;
+  /** Separator inserted between visible address segments. Defaults to "...". */
+  separator?: string;
+}
+
+const USDC_DECIMALS = 7;
+
+function assertFractionDigits(name: string, value: number) {
+  if (!Number.isInteger(value) || value < 0 || value > USDC_DECIMALS) {
+    throw new RangeError(`${name} must be an integer between 0 and ${USDC_DECIMALS}.`);
+  }
+}
+
+function incrementDecimalString(value: string) {
+  const digits = value.split("");
+  let carry = 1;
+
+  for (let index = digits.length - 1; index >= 0; index -= 1) {
+    const next = Number(digits[index]) + carry;
+    if (next === 10) {
+      digits[index] = "0";
+      carry = 1;
+    } else {
+      digits[index] = String(next);
+      carry = 0;
+      break;
+    }
+  }
+
+  if (carry === 1) {
+    digits.unshift("1");
+  }
+
+  return digits.join("");
+}
+
+function normalizeAmount(amount: number | string) {
+  const raw =
+    typeof amount === "number"
+      ? amount.toFixed(USDC_DECIMALS)
+      : amount.trim().replace(/,/g, "").replace(/\s*USDC$/i, "");
+
+  if (raw === "") {
+    throw new RangeError("amount is required.");
+  }
+
+  if (raw.startsWith("-")) {
+    throw new RangeError("USDC amounts cannot be negative.");
+  }
+
+  if (!/^\d+(?:\.\d+)?$/.test(raw)) {
+    throw new RangeError("amount must be a non-negative decimal value.");
+  }
+
+  const [integerPart, fractionPart = ""] = raw.split(".");
+  if (fractionPart.length > USDC_DECIMALS) {
+    throw new RangeError(`USDC amounts support at most ${USDC_DECIMALS} decimal places.`);
+  }
+
+  return {
+    integerPart: integerPart.replace(/^0+(?=\d)/, "") || "0",
+    fractionPart,
+  };
+}
+
+function roundAmountParts(integerPart: string, fractionPart: string, maxFractionDigits: number) {
+  if (fractionPart.length <= maxFractionDigits) {
+    return { integerPart, fractionPart };
+  }
+
+  const keptFraction = fractionPart.slice(0, maxFractionDigits);
+  const nextDigit = Number(fractionPart[maxFractionDigits]);
+  if (nextDigit < 5) {
+    return { integerPart, fractionPart: keptFraction };
+  }
+
+  if (maxFractionDigits === 0) {
+    return {
+      integerPart: incrementDecimalString(integerPart),
+      fractionPart: "",
+    };
+  }
+
+  const expectedLength = integerPart.length + maxFractionDigits;
+  const incremented = incrementDecimalString(`${integerPart}${keptFraction}`).padStart(
+    expectedLength,
+    "0",
+  );
+
+  return {
+    integerPart: incremented.slice(0, -maxFractionDigits) || "0",
+    fractionPart: incremented.slice(-maxFractionDigits),
+  };
+}
+
+function groupThousands(integerPart: string) {
+  return integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+export function formatUsdc(amount: number | string, options: FormatUsdcOptions = {}) {
+  const {
+    currency = "USDC",
+    includeCurrency = true,
+    maxFractionDigits = USDC_DECIMALS,
+    minFractionDigits = 0,
+  } = options;
+
+  assertFractionDigits("maxFractionDigits", maxFractionDigits);
+  assertFractionDigits("minFractionDigits", minFractionDigits);
+
+  if (minFractionDigits > maxFractionDigits) {
+    throw new RangeError("minFractionDigits cannot exceed maxFractionDigits.");
+  }
+
+  const normalized = normalizeAmount(amount);
+  const rounded = roundAmountParts(
+    normalized.integerPart,
+    normalized.fractionPart,
+    maxFractionDigits,
+  );
+  const trimmedFraction = rounded.fractionPart.replace(/0+$/, "");
+  const fraction = trimmedFraction.padEnd(
+    Math.max(minFractionDigits, trimmedFraction.length),
+    "0",
+  );
+  const formattedAmount = fraction
+    ? `${groupThousands(rounded.integerPart)}.${fraction}`
+    : groupThousands(rounded.integerPart);
+
+  return includeCurrency ? `${formattedAmount} ${currency}` : formattedAmount;
+}
+
+export function formatAddress(value: string, options: FormatAddressOptions = {}) {
+  const {
+    prefixLength = 6,
+    suffixLength = 4,
+    separator = "...",
+  } = options;
+  const address = value.trim();
+
+  if (!address) {
+    return "";
+  }
+
+  if (address.length <= prefixLength + suffixLength + separator.length) {
+    return address;
+  }
+
+  return `${address.slice(0, prefixLength)}${separator}${address.slice(-suffixLength)}`;
+}


### PR DESCRIPTION
## Summary
- add shared `formatUsdc` and `formatAddress` utilities with documented defaults and deterministic string formatting
- apply USDC formatting across Dashboard, Vaults, VaultDetail, VaultTransactions, VaultCard, and FundReleaseStatus display paths
- add formatter tests plus coverage for VaultTransactions USDC labels and affected component/page assertions

## Validation
- npx tsc --noEmit -p <targeted format test tsconfig>
- npx eslint src/utils/format.ts src/utils/__tests__/format.test.ts src/components/VaultCard.tsx src/components/__tests__/VaultCard.test.tsx src/components/FundReleaseStatus.tsx src/components/__tests__/FundReleaseStatus.test.tsx src/pages/Dashboard.tsx src/pages/Vaults.tsx src/pages/VaultDetail.tsx src/pages/__tests__/VaultDetail.test.tsx src/pages/VaultTransactions.tsx src/pages/__tests__/VaultTransactions.test.tsx
- git diff --check
- npx vitest run src/utils/__tests__/format.test.ts src/components/__tests__/VaultCard.test.tsx src/components/__tests__/FundReleaseStatus.test.tsx src/pages/__tests__/VaultDetail.test.tsx src/pages/__tests__/VaultTransactions.test.tsx *(blocked locally: Vite config startup fails while esbuild child process spawn returns EPERM)*

Closes #189
