### PR TITLE
feat: add wallet balance refresh retry

### DIFF
--- a/src/components/Wallet/WalletDropdown.tsx
+++ b/src/components/Wallet/WalletDropdown.tsx
@@ -9,7 +9,7 @@ interface WalletDropdownProps {
 }
 
 export function WalletDropdown({ onClose, onSwitch }: WalletDropdownProps) {
-    const { address, balance, balanceStatus, balanceError, network, disconnect } = useWallet();
+    const { address, balance, balanceStatus, balanceError, network, disconnect, refreshBalance } = useWallet();
     const [copied, setCopied] = useState(false);
 
     if (!address) return null;
@@ -50,6 +50,13 @@ export function WalletDropdown({ onClose, onSwitch }: WalletDropdownProps) {
                 <div className="wallet-dropdown-balance-state error" role="status">
                     Balance unavailable
                     {balanceError && <small>{balanceError}</small>}
+                    <button
+                        type="button"
+                        className="wallet-dropdown-balance-retry"
+                        onClick={refreshBalance}
+                    >
+                        Retry
+                    </button>
                 </div>
             );
         }

--- a/src/components/Wallet/__tests__/WalletDropdown.test.tsx
+++ b/src/components/Wallet/__tests__/WalletDropdown.test.tsx
@@ -1,5 +1,6 @@
 import { act } from 'react';
 import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { WalletDropdown } from '../WalletDropdown';
 import type { BalanceStatus, WalletNetwork } from '../../../context/WalletContext';
 
@@ -10,6 +11,7 @@ const walletState = vi.hoisted(() => ({
     balanceError: null as string | null,
     network: 'TESTNET' as WalletNetwork,
     disconnect: vi.fn(),
+    refreshBalance: vi.fn(),
 }));
 
 vi.mock('../../../context/WalletContext', () => ({
@@ -35,6 +37,7 @@ describe('WalletDropdown balance states', () => {
         walletState.balanceError = null;
         walletState.network = 'TESTNET';
         walletState.disconnect.mockClear();
+        walletState.refreshBalance.mockClear();
         vi.useRealTimers();
     });
 
@@ -74,6 +77,18 @@ describe('WalletDropdown balance states', () => {
 
         expect(screen.getByRole('status')).toHaveTextContent('Balance unavailable');
         expect(screen.getByText('Horizon balance request failed with status 500.')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+
+    test('calls refreshBalance from the Horizon error retry action', () => {
+        walletState.balance = null;
+        walletState.balanceStatus = 'error';
+        walletState.balanceError = 'Horizon balance request failed with status 500.';
+
+        renderDropdown();
+        screen.getByRole('button', { name: /retry/i }).click();
+
+        expect(walletState.refreshBalance).toHaveBeenCalledTimes(1);
     });
 
     test('renders nothing when no wallet is connected', () => {

--- a/src/components/Wallet/wallet.css
+++ b/src/components/Wallet/wallet.css
@@ -298,6 +298,22 @@
   margin-top: 0.25rem;
 }
 
+.wallet-dropdown-balance-retry {
+  background: var(--surface-raised);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-sm);
+  color: var(--danger);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-top: 0.25rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.wallet-dropdown-balance-retry:hover {
+  background: var(--danger-transparent);
+}
+
 .wallet-dropdown-actions {
   padding: 0.5rem;
 }

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useRef, useState, ReactNode } from 'react';
 import { isAllowed, setAllowed, requestAccess, getAddress, getNetworkDetails } from '@stellar/freighter-api';
 import { fetchUsdcBalance } from '../utils/horizon';
 
@@ -16,6 +16,8 @@ interface WalletContextType {
     connect: () => Promise<void>;
     disconnect: () => void;
     checkConnection: () => Promise<void>;
+    /** Retries the current wallet's network and USDC balance lookup; no-ops without an address. */
+    refreshBalance: () => Promise<void>;
 }
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
@@ -28,12 +30,13 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const [balanceError, setBalanceError] = useState<string | null>(null);
     const [isConnecting, setIsConnecting] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const balanceRefreshRef = useRef<Promise<void> | null>(null);
 
     const normalizeNetwork = (networkName: string): WalletNetwork => {
         return networkName === 'PUBLIC' ? 'PUBLIC' : 'TESTNET';
     };
 
-    const fetchNetworkAndBalance = async (pubKey: string) => {
+    const fetchNetworkAndBalance = useCallback(async (pubKey: string) => {
         setBalanceStatus('loading');
         setBalanceError(null);
 
@@ -52,9 +55,9 @@ export function WalletProvider({ children }: { children: ReactNode }) {
             setBalanceStatus('error');
             setBalanceError(message);
         }
-    };
+    }, []);
 
-    const checkConnection = async () => {
+    const checkConnection = useCallback(async () => {
         try {
             if (await isAllowed()) {
                 const { address: pubKey, error: addrError } = await getAddress();
@@ -66,11 +69,24 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         } catch (err) {
             console.error('Check connection error', err);
         }
-    };
+    }, [fetchNetworkAndBalance]);
 
     useEffect(() => {
-        checkConnection();
-    }, []);
+        void checkConnection();
+    }, [checkConnection]);
+
+    const refreshBalance = useCallback(async () => {
+        if (!address) return;
+        if (balanceRefreshRef.current) return balanceRefreshRef.current;
+
+        const refresh = fetchNetworkAndBalance(address).finally(() => {
+            if (balanceRefreshRef.current === refresh) {
+                balanceRefreshRef.current = null;
+            }
+        });
+        balanceRefreshRef.current = refresh;
+        return refresh;
+    }, [address, fetchNetworkAndBalance]);
 
     const connect = async () => {
         setIsConnecting(true);
@@ -100,6 +116,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     };
 
     const disconnect = () => {
+        balanceRefreshRef.current = null;
         setAddress(null);
         setNetwork(null);
         setBalance(null);
@@ -120,6 +137,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
                 connect,
                 disconnect,
                 checkConnection,
+                refreshBalance,
             }}
         >
             {children}

--- a/src/context/__tests__/WalletContext.test.tsx
+++ b/src/context/__tests__/WalletContext.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { WalletProvider, useWallet } from '../WalletContext';
 import { USDC_ISSUERS } from '../../utils/horizon';
 
@@ -30,6 +31,9 @@ function WalletProbe() {
             </button>
             <button type="button" onClick={wallet.disconnect}>
                 Disconnect
+            </button>
+            <button type="button" onClick={wallet.refreshBalance}>
+                Refresh Balance
             </button>
             <div data-testid="address">{wallet.address ?? ''}</div>
             <div data-testid="network">{wallet.network ?? ''}</div>
@@ -132,6 +136,98 @@ describe('WalletContext Horizon USDC balance path', () => {
         expect(screen.getByTestId('balanceError')).toHaveTextContent('Horizon balance request failed with status 500.');
 
         error.mockRestore();
+    });
+
+    test('refreshBalance retries the current address after a Horizon error', async () => {
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        vi.mocked(globalThis.fetch)
+            .mockResolvedValueOnce(mockResponse(500, {}))
+            .mockResolvedValueOnce(
+                mockResponse(200, {
+                    balances: [
+                        {
+                            asset_type: 'credit_alphanum4',
+                            asset_code: 'USDC',
+                            asset_issuer: USDC_ISSUERS.TESTNET,
+                            balance: '18.5000000',
+                        },
+                    ],
+                }),
+            );
+
+        renderWallet();
+        fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+
+        await waitFor(() => expect(screen.getByTestId('balanceStatus')).toHaveTextContent('error'));
+
+        fireEvent.click(screen.getByRole('button', { name: /refresh balance/i }));
+
+        await waitFor(() => expect(screen.getByTestId('balanceStatus')).toHaveTextContent('success'));
+        expect(screen.getByTestId('balance')).toHaveTextContent('18.5000000');
+        expect(globalThis.fetch).toHaveBeenLastCalledWith('https://horizon-testnet.stellar.org/accounts/GCONNECTED');
+
+        error.mockRestore();
+    });
+
+    test('refreshBalance is a no-op without a connected address', async () => {
+        renderWallet();
+
+        fireEvent.click(screen.getByRole('button', { name: /refresh balance/i }));
+        await Promise.resolve();
+
+        expect(freighterMocks.getNetworkDetails).not.toHaveBeenCalled();
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+        expect(screen.getByTestId('balanceStatus')).toHaveTextContent('idle');
+    });
+
+    test('coalesces concurrent refreshBalance calls', async () => {
+        vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+            mockResponse(200, {
+                balances: [
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: USDC_ISSUERS.TESTNET,
+                        balance: '9.0000000',
+                    },
+                ],
+            }),
+        );
+
+        renderWallet();
+        fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+        await waitFor(() => expect(screen.getByTestId('balanceStatus')).toHaveTextContent('success'));
+
+        let resolveFetch: (value: Response) => void = () => undefined;
+        vi.mocked(globalThis.fetch).mockClear();
+        freighterMocks.getNetworkDetails.mockClear();
+        vi.mocked(globalThis.fetch).mockReturnValue(
+            new Promise<Response>((resolve) => {
+                resolveFetch = resolve;
+            }),
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /refresh balance/i }));
+        fireEvent.click(screen.getByRole('button', { name: /refresh balance/i }));
+
+        await waitFor(() => expect(screen.getByTestId('balanceStatus')).toHaveTextContent('loading'));
+        expect(freighterMocks.getNetworkDetails).toHaveBeenCalledTimes(1);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+        resolveFetch(
+            mockResponse(200, {
+                balances: [
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: USDC_ISSUERS.TESTNET,
+                        balance: '11.0000000',
+                    },
+                ],
+            }),
+        );
+
+        await waitFor(() => expect(screen.getByTestId('balance')).toHaveTextContent('11.0000000'));
     });
 
     test('uses the generic balance error when network details throw a non-Error value', async () => {


### PR DESCRIPTION
## Summary
- expose a coalesced `refreshBalance()` action from `WalletContext` for the active wallet address
- add a Retry action to the wallet dropdown balance error state
- cover retry, no-address, and concurrent refresh behavior in WalletContext/WalletDropdown tests

Closes #191

## Validation
- `npx tsc --noEmit -p <targeted wallet refresh tsconfig>`
- `npx eslint src/context/WalletContext.tsx src/context/__tests__/WalletContext.test.tsx src/components/Wallet/WalletDropdown.tsx src/components/Wallet/__tests__/WalletDropdown.test.tsx` (passes with existing `react-refresh/only-export-components` warning in `WalletContext.tsx`)
- `git diff --check`
- `npx vitest run src/context/__tests__/WalletContext.test.tsx src/components/Wallet/__tests__/WalletDropdown.test.tsx` (blocked locally by Vite/esbuild startup: `Error: spawn EPERM`)