### PR TITLE
feat: add global toast feedback

### DIFF
--- a/design-system/documentation/toast-feedback.md
+++ b/design-system/documentation/toast-feedback.md
@@ -1,0 +1,12 @@
+# Toast Feedback
+
+Transient user feedback is handled by `useToastStore` in `src/Zustand/Store.ts`
+and rendered once by `Toaster` in `Layout`.
+
+- `push({ kind, message })` accepts `success`, `error`, or `info` and returns the toast id.
+- `dismiss(id)` removes a toast and cancels its auto-dismiss timer.
+- The queue keeps the four newest toasts so repeated actions cannot flood the viewport.
+- Toasts auto-dismiss after five seconds; tests should use fake timers instead of real waits.
+- Success and info toasts render with `aria-live="polite"` through `role="status"`.
+- Error toasts render with `aria-live="assertive"` through `role="alert"`.
+- Every toast includes a native button dismissal control, so keyboard users can clear feedback without waiting for the timer.

--- a/src/Zustand/Store.ts
+++ b/src/Zustand/Store.ts
@@ -15,6 +15,76 @@ export const useNotification = create<notificationsType>((set) => ({
     set(() => ({ notification: value })),
 }));
 
+// --- Toast Store ---
+export type ToastKind = 'success' | 'error' | 'info';
+
+export type ToastMessage = {
+  id: string;
+  kind: ToastKind;
+  message: string;
+};
+
+type ToastInput = {
+  kind: ToastKind;
+  message: string;
+};
+
+type ToastStoreType = {
+  toasts: ToastMessage[];
+  push: (toast: ToastInput) => string;
+  dismiss: (id: string) => void;
+  clear: () => void;
+};
+
+export const TOAST_AUTO_DISMISS_MS = 5000;
+export const TOAST_QUEUE_LIMIT = 4;
+
+let toastSequence = 0;
+const toastTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+const clearToastTimer = (id: string) => {
+  const timer = toastTimers.get(id);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    toastTimers.delete(id);
+  }
+};
+
+export const useToastStore = create<ToastStoreType>((set, get) => ({
+  toasts: [],
+  push: (toast) => {
+    const id = `toast-${++toastSequence}`;
+    const nextToast: ToastMessage = { id, ...toast };
+
+    set((state) => {
+      const overflowCount = Math.max(state.toasts.length + 1 - TOAST_QUEUE_LIMIT, 0);
+      const droppedToasts = state.toasts.slice(0, overflowCount);
+      droppedToasts.forEach(({ id: droppedId }) => clearToastTimer(droppedId));
+
+      return {
+        toasts: [...state.toasts.slice(overflowCount), nextToast],
+      };
+    });
+
+    const timer = setTimeout(() => {
+      get().dismiss(id);
+    }, TOAST_AUTO_DISMISS_MS);
+    toastTimers.set(id, timer);
+
+    return id;
+  },
+  dismiss: (id) => {
+    clearToastTimer(id);
+    set((state) => ({
+      toasts: state.toasts.filter((toast) => toast.id !== id),
+    }));
+  },
+  clear: () => {
+    get().toasts.forEach(({ id }) => clearToastTimer(id));
+    set({ toasts: [] });
+  },
+}));
+
 
 // --- New Verifier Store ---
 export type ValidationTask = {

--- a/src/Zustand/__tests__/toastStore.test.ts
+++ b/src/Zustand/__tests__/toastStore.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  TOAST_AUTO_DISMISS_MS,
+  TOAST_QUEUE_LIMIT,
+  useToastStore,
+} from '../Store';
+
+describe('useToastStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useToastStore.getState().clear();
+  });
+
+  afterEach(() => {
+    useToastStore.getState().clear();
+    vi.useRealTimers();
+  });
+
+  test('pushes a toast and auto-dismisses it after the configured timeout', () => {
+    const id = useToastStore.getState().push({ kind: 'success', message: 'Saved.' });
+
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({ id, kind: 'success', message: 'Saved.' }),
+    ]);
+
+    vi.advanceTimersByTime(TOAST_AUTO_DISMISS_MS - 1);
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+
+    vi.advanceTimersByTime(1);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  test('dismiss removes a toast and cancels its auto-dismiss timer', () => {
+    const id = useToastStore.getState().push({ kind: 'info', message: 'Disconnected.' });
+
+    expect(vi.getTimerCount()).toBe(1);
+    useToastStore.getState().dismiss(id);
+
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test('bounds the queue and cancels timers for dropped toasts', () => {
+    const ids = Array.from({ length: TOAST_QUEUE_LIMIT + 1 }, (_, index) =>
+      useToastStore.getState().push({ kind: 'info', message: `Toast ${index}` }),
+    );
+
+    const remainingIds = useToastStore.getState().toasts.map((toast) => toast.id);
+    expect(remainingIds).toEqual(ids.slice(1));
+    expect(vi.getTimerCount()).toBe(TOAST_QUEUE_LIMIT);
+  });
+
+  test('keeps rapid duplicate pushes as separately dismissible toasts', () => {
+    const first = useToastStore.getState().push({ kind: 'error', message: 'Retry failed.' });
+    const second = useToastStore.getState().push({ kind: 'error', message: 'Retry failed.' });
+
+    expect(first).not.toBe(second);
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({ id: first, message: 'Retry failed.' }),
+      expect.objectContaining({ id: second, message: 'Retry failed.' }),
+    ]);
+  });
+});

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import FocusTrap from 'focus-trap-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, AlertTriangle, CheckCircle, XCircle, ExternalLink } from 'lucide-react';

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import { Menu } from "lucide-react";
 import { WalletConnectButton } from "./Wallet/WalletConnectButton";
 import MobileDrawer from "./MobileDrawer";
 import { Text } from "./Text";
+import { Toaster } from "./Toaster";
 import "./Layout.css";
 
 interface LayoutProps {
@@ -120,6 +121,7 @@ export default function Layout({ children }: LayoutProps) {
       >
         {children}
       </main>
+      <Toaster />
     </div>
   );
 }

--- a/src/components/Toaster.css
+++ b/src/components/Toaster.css
@@ -1,0 +1,85 @@
+.toaster {
+  position: fixed;
+  right: var(--spacing-4);
+  top: var(--spacing-4);
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  width: min(24rem, calc(100vw - var(--spacing-8)));
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--info);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
+  color: var(--text);
+  padding: var(--spacing-3);
+}
+
+.toast-success {
+  border-left-color: var(--success);
+}
+
+.toast-error {
+  border-left-color: var(--danger);
+}
+
+.toast-info {
+  border-left-color: var(--info);
+}
+
+.toast-content {
+  min-width: 0;
+}
+
+.toast-kind {
+  display: block;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  margin-bottom: 0.125rem;
+  text-transform: uppercase;
+}
+
+.toast p {
+  margin: 0;
+  line-height: 1.4;
+}
+
+.toast-dismiss {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: center;
+  min-height: var(--touch-target);
+  min-width: var(--touch-target);
+  padding: var(--spacing-1);
+}
+
+.toast-dismiss:hover {
+  color: var(--text);
+}
+
+.toast-dismiss:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+  .toaster {
+    left: var(--spacing-4);
+    right: var(--spacing-4);
+    width: auto;
+  }
+}

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -1,0 +1,46 @@
+import { X } from 'lucide-react';
+import { useToastStore, type ToastKind } from '../Zustand/Store';
+import './Toaster.css';
+
+const toastLabels: Record<ToastKind, string> = {
+  success: 'Success',
+  error: 'Error',
+  info: 'Info',
+};
+
+export function Toaster() {
+  const toasts = useToastStore((state) => state.toasts);
+  const dismiss = useToastStore((state) => state.dismiss);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="toaster" aria-label="Notifications">
+      {toasts.map((toast) => {
+        const isError = toast.kind === 'error';
+
+        return (
+          <div
+            key={toast.id}
+            className={`toast toast-${toast.kind}`}
+            role={isError ? 'alert' : 'status'}
+            aria-live={isError ? 'assertive' : 'polite'}
+          >
+            <div className="toast-content">
+              <span className="toast-kind">{toastLabels[toast.kind]}</span>
+              <p>{toast.message}</p>
+            </div>
+            <button
+              type="button"
+              className="toast-dismiss"
+              aria-label={`Dismiss ${toastLabels[toast.kind]} toast`}
+              onClick={() => dismiss(toast.id)}
+            >
+              <X size={16} aria-hidden="true" />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/__tests__/Toaster.test.tsx
+++ b/src/components/__tests__/Toaster.test.tsx
@@ -1,0 +1,56 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { Toaster } from '../Toaster';
+import { TOAST_AUTO_DISMISS_MS, useToastStore } from '../../Zustand/Store';
+
+describe('Toaster', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useToastStore.getState().clear();
+  });
+
+  afterEach(() => {
+    useToastStore.getState().clear();
+    vi.useRealTimers();
+  });
+
+  test('renders polite status toasts and assertive error toasts', () => {
+    act(() => {
+      useToastStore.getState().push({ kind: 'success', message: 'Wallet connected.' });
+      useToastStore.getState().push({ kind: 'error', message: 'Wallet access denied.' });
+    });
+
+    render(<Toaster />);
+
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByRole('status')).toHaveTextContent('Wallet connected.');
+    expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'assertive');
+    expect(screen.getByRole('alert')).toHaveTextContent('Wallet access denied.');
+  });
+
+  test('dismisses a toast from the keyboard-accessible close button', () => {
+    act(() => {
+      useToastStore.getState().push({ kind: 'info', message: 'Wallet disconnected.' });
+    });
+
+    render(<Toaster />);
+    fireEvent.click(screen.getByRole('button', { name: /dismiss info toast/i }));
+
+    expect(screen.queryByText('Wallet disconnected.')).not.toBeInTheDocument();
+  });
+
+  test('removes toasts when the store auto-dismiss timer fires', () => {
+    act(() => {
+      useToastStore.getState().push({ kind: 'success', message: 'Validation approved.' });
+    });
+
+    render(<Toaster />);
+    expect(screen.getByText('Validation approved.')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(TOAST_AUTO_DISMISS_MS);
+    });
+
+    expect(screen.queryByText('Validation approved.')).not.toBeInTheDocument();
+  });
+});

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { isAllowed, setAllowed, requestAccess, getAddress, getNetworkDetails } from '@stellar/freighter-api';
 import { fetchUsdcBalance } from '../utils/horizon';
+import { useToastStore } from '../Zustand/Store';
 
 export type WalletNetwork = 'TESTNET' | 'PUBLIC';
 export type BalanceStatus = 'idle' | 'loading' | 'success' | 'no_trustline' | 'error';
@@ -28,6 +29,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const [balanceError, setBalanceError] = useState<string | null>(null);
     const [isConnecting, setIsConnecting] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const pushToast = useToastStore((state) => state.push);
 
     const normalizeNetwork = (networkName: string): WalletNetwork => {
         return networkName === 'PUBLIC' ? 'PUBLIC' : 'TESTNET';
@@ -51,6 +53,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
             setBalance(null);
             setBalanceStatus('error');
             setBalanceError(message);
+            pushToast({ kind: 'error', message });
         }
     };
 
@@ -83,23 +86,33 @@ export function WalletProvider({ children }: { children: ReactNode }) {
                 const { address: pubKey, error: addrError } = await getAddress();
                 if (pubKey && !addrError) {
                     setAddress(pubKey);
+                    pushToast({ kind: 'success', message: 'Wallet connected.' });
                     await fetchNetworkAndBalance(pubKey);
                 } else {
-                    setError(addrError || 'Failed to get wallet address.');
+                    const message = addrError || 'Failed to get wallet address.';
+                    setError(message);
+                    pushToast({ kind: 'error', message });
                 }
             } else {
-                setError('Wallet access denied.');
+                const message = 'Wallet access denied.';
+                setError(message);
+                pushToast({ kind: 'error', message });
             }
         } catch (err: unknown) {
             console.error('Connection error', err);
             const message = err instanceof Error ? err.message : undefined;
-            setError(message || 'Failed to connect wallet. Make sure Freighter is installed and unlocked.');
+            const fallback = message || 'Failed to connect wallet. Make sure Freighter is installed and unlocked.';
+            setError(fallback);
+            pushToast({ kind: 'error', message: fallback });
         } finally {
             setIsConnecting(false);
         }
     };
 
     const disconnect = () => {
+        if (address) {
+            pushToast({ kind: 'info', message: 'Wallet disconnected.' });
+        }
         setAddress(null);
         setNetwork(null);
         setBalance(null);

--- a/src/context/__tests__/WalletContext.test.tsx
+++ b/src/context/__tests__/WalletContext.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { WalletProvider, useWallet } from '../WalletContext';
+import { useToastStore } from '../../Zustand/Store';
 import { USDC_ISSUERS } from '../../utils/horizon';
 
 const freighterMocks = vi.hoisted(() => ({
@@ -71,6 +73,10 @@ describe('WalletContext Horizon USDC balance path', () => {
         globalThis.fetch = originalFetch;
     });
 
+    afterEach(() => {
+        useToastStore.getState().clear();
+    });
+
     test('loads the real USDC balance after connecting', async () => {
         let resolveFetch: (value: Response) => void = () => undefined;
         vi.mocked(globalThis.fetch).mockReturnValue(
@@ -102,6 +108,9 @@ describe('WalletContext Horizon USDC balance path', () => {
         expect(screen.getByTestId('network')).toHaveTextContent('TESTNET');
         expect(screen.getByTestId('balance')).toHaveTextContent('42.2500000');
         expect(globalThis.fetch).toHaveBeenCalledWith('https://horizon-testnet.stellar.org/accounts/GCONNECTED');
+        expect(useToastStore.getState().toasts).toContainEqual(
+            expect.objectContaining({ kind: 'success', message: 'Wallet connected.' }),
+        );
     });
 
     test('marks no-trustline when a connected public account has no Circle USDC balance line', async () => {
@@ -130,6 +139,12 @@ describe('WalletContext Horizon USDC balance path', () => {
         await waitFor(() => expect(screen.getByTestId('balanceStatus')).toHaveTextContent('error'));
         expect(screen.getByTestId('balance')).toHaveTextContent('');
         expect(screen.getByTestId('balanceError')).toHaveTextContent('Horizon balance request failed with status 500.');
+        expect(useToastStore.getState().toasts).toContainEqual(
+            expect.objectContaining({
+                kind: 'error',
+                message: 'Horizon balance request failed with status 500.',
+            }),
+        );
 
         error.mockRestore();
     });
@@ -154,6 +169,9 @@ describe('WalletContext Horizon USDC balance path', () => {
         fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
 
         await waitFor(() => expect(screen.getByTestId('connectionError')).toHaveTextContent('Wallet access denied.'));
+        expect(useToastStore.getState().toasts).toContainEqual(
+            expect.objectContaining({ kind: 'error', message: 'Wallet access denied.' }),
+        );
 
         freighterMocks.requestAccess.mockResolvedValueOnce(true);
         freighterMocks.getAddress.mockResolvedValueOnce({ address: null, error: 'Address unavailable.' });
@@ -244,6 +262,9 @@ describe('WalletContext Horizon USDC balance path', () => {
         expect(screen.getByTestId('network')).toHaveTextContent('');
         expect(screen.getByTestId('balance')).toHaveTextContent('');
         expect(screen.getByTestId('balanceStatus')).toHaveTextContent('idle');
+        expect(useToastStore.getState().toasts).toContainEqual(
+            expect.objectContaining({ kind: 'info', message: 'Wallet disconnected.' }),
+        );
     });
 
     test('throws when useWallet is rendered outside the provider', () => {

--- a/src/pages/ValidationDetail.tsx
+++ b/src/pages/ValidationDetail.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Text } from '../components/Text';
-import { useVerifierStore } from '../Zustand/Store';
+import { useToastStore, useVerifierStore } from '../Zustand/Store';
 import { ConfirmationModal } from '../components/ConfirmationModal';
 import { SafeLink } from '../components/SafeLink';
 
@@ -11,6 +11,7 @@ export default function ValidationDetail() {
   
   // Pull data and actions from Zustand
   const { pendingValidations, approveValidation, rejectValidation } = useVerifierStore();
+  const pushToast = useToastStore((state) => state.push);
   
   // Local state for notes and the confirmation modal
   const [notes, setNotes] = useState('');
@@ -46,8 +47,10 @@ export default function ValidationDetail() {
   const executeAction = (decision: 'approve' | 'reject', modalNotes: string) => {
     if (decision === 'approve') {
       approveValidation(task.id, modalNotes);
+      pushToast({ kind: 'success', message: `Validation approved for ${task.vaultName}.` });
     } else if (decision === 'reject') {
       rejectValidation(task.id, modalNotes);
+      pushToast({ kind: 'info', message: `Validation rejected for ${task.vaultName}.` });
     }
     setIsModalOpen(false);
     navigate('/verifier/queue'); // Send them back to the list

--- a/src/pages/__tests__/ValidationDetail.test.tsx
+++ b/src/pages/__tests__/ValidationDetail.test.tsx
@@ -1,8 +1,12 @@
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import ValidationDetail from '../ValidationDetail';
 import { useVerifierStore } from '../../Zustand/Store';
+
+const storeMocks = vi.hoisted(() => ({
+  pushToast: vi.fn(),
+}));
 
 // Mock focus-trap-react as it can be tricky in jsdom
 vi.mock('focus-trap-react', () => ({
@@ -12,6 +16,9 @@ vi.mock('focus-trap-react', () => ({
 // Mock Zustand store
 vi.mock('../../Zustand/Store', () => ({
   useVerifierStore: vi.fn(),
+  useToastStore: vi.fn((selector: (state: { push: typeof storeMocks.pushToast }) => unknown) =>
+    selector({ push: storeMocks.pushToast }),
+  ),
 }));
 
 const mockNavigate = vi.fn();
@@ -36,19 +43,42 @@ const mockPendingValidations = [
     milestone: 'Test Milestone',
     evidenceUrl: 'https://example.com/evidence',
   },
-];
+] satisfies MockValidationTask[];
+
+type MockValidationTask = {
+  id: string;
+  vaultName: string;
+  owner: string;
+  amount: string;
+  deadline: string;
+  daysRemaining: number;
+  status: 'pending';
+  milestone: string;
+  evidenceUrl?: string;
+};
 
 describe('ValidationDetail Page', () => {
   const mockApproveValidation = vi.fn();
   const mockRejectValidation = vi.fn();
+  const setVerifierStore = (pendingValidations: MockValidationTask[]) => {
+    const mockedUseVerifierStore = useVerifierStore as unknown as {
+      mockReturnValue: (value: {
+        pendingValidations: MockValidationTask[];
+        approveValidation: typeof mockApproveValidation;
+        rejectValidation: typeof mockRejectValidation;
+      }) => void;
+    };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    (useVerifierStore as any).mockReturnValue({
-      pendingValidations: mockPendingValidations,
+    mockedUseVerifierStore.mockReturnValue({
+      pendingValidations,
       approveValidation: mockApproveValidation,
       rejectValidation: mockRejectValidation,
     });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setVerifierStore(mockPendingValidations);
   });
 
   it('renders task details correctly', () => {
@@ -65,11 +95,7 @@ describe('ValidationDetail Page', () => {
   });
 
   it('shows "Validation Not Found" if task does not exist', () => {
-    (useVerifierStore as any).mockReturnValue({
-      pendingValidations: [],
-      approveValidation: mockApproveValidation,
-      rejectValidation: mockRejectValidation,
-    });
+    setVerifierStore([]);
 
     render(
       <MemoryRouter initialEntries={['/verifier/v-999']}>
@@ -120,6 +146,10 @@ describe('ValidationDetail Page', () => {
     fireEvent.click(confirmBtn);
 
     expect(mockApproveValidation).toHaveBeenCalledWith('v-101', '');
+    expect(storeMocks.pushToast).toHaveBeenCalledWith({
+      kind: 'success',
+      message: 'Validation approved for Test Vault.',
+    });
     expect(mockNavigate).toHaveBeenCalledWith('/verifier/queue');
   });
 
@@ -144,6 +174,10 @@ describe('ValidationDetail Page', () => {
     fireEvent.click(confirmBtn);
 
     expect(mockRejectValidation).toHaveBeenCalledWith('v-101', 'Evidence is missing details.');
+    expect(storeMocks.pushToast).toHaveBeenCalledWith({
+      kind: 'info',
+      message: 'Validation rejected for Test Vault.',
+    });
     expect(mockNavigate).toHaveBeenCalledWith('/verifier/queue');
   });
 
@@ -166,11 +200,7 @@ describe('ValidationDetail Page', () => {
   });
 
   it('renders "No evidence link provided" when task has no evidenceUrl', () => {
-    (useVerifierStore as any).mockReturnValue({
-      pendingValidations: [{ ...mockPendingValidations[0], evidenceUrl: undefined }],
-      approveValidation: mockApproveValidation,
-      rejectValidation: mockRejectValidation,
-    });
+    setVerifierStore([{ ...mockPendingValidations[0], evidenceUrl: undefined }]);
 
     render(
       <MemoryRouter initialEntries={['/verifier/v-101']}>


### PR DESCRIPTION
## Summary
- add a bounded Zustand-backed toast store with cancellable auto-dismiss timers
- render global toasts from Layout with polite status updates and assertive error alerts
- emit wallet connection/disconnect/error and validation approve/reject feedback without changing navigation
- document the toast API and aria-live behavior

Closes #184

## Validation
- `npx tsc --noEmit -p <targeted toast feedback tsconfig>`
- `npx eslint src/Zustand/Store.ts src/Zustand/__tests__/toastStore.test.ts src/components/Toaster.tsx src/components/__tests__/Toaster.test.tsx src/components/Layout.tsx src/components/ConfirmationModal.tsx src/context/WalletContext.tsx src/context/__tests__/WalletContext.test.tsx src/pages/ValidationDetail.tsx src/pages/__tests__/ValidationDetail.test.tsx` (passes with existing WalletContext warnings for exhaustive-deps and fast-refresh exports)
- `git diff --check`
- `npx vitest run src/Zustand/__tests__/toastStore.test.ts src/components/__tests__/Toaster.test.tsx src/context/__tests__/WalletContext.test.tsx src/pages/__tests__/ValidationDetail.test.tsx` (blocked locally by Vite/esbuild startup: `Error: spawn EPERM`)