### PR TITLE
feat: add vault transaction filters

### DIFF
--- a/design-system/documentation/transaction-filters.md
+++ b/design-system/documentation/transaction-filters.md
@@ -1,0 +1,12 @@
+# Transaction Filters
+
+`filterTransactions` in `src/utils/transactionFilter.ts` applies the
+VaultTransactions client-side status, type, and date-range filters outside
+React so the rules are unit-testable.
+
+- `type` accepts `create`, `validate`, `release`, `redirect`, or `all`.
+- `status` accepts `confirmed`, `pending`, `failed`, or `all`.
+- `startDate` and `endDate` use `YYYY-MM-DD` values from date inputs.
+- Date bounds are inclusive for the full local calendar day.
+- Invalid date strings are ignored; an invalid transaction timestamp is excluded.
+- If `startDate` is after `endDate`, the helper returns an empty list.

--- a/src/pages/VaultTransactions.tsx
+++ b/src/pages/VaultTransactions.tsx
@@ -1,8 +1,13 @@
 import { useState, useMemo, useCallback } from "react";
+import {
+  filterTransactions,
+  type TransactionStatus,
+  type TransactionType,
+} from "../utils/transactionFilter";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
-type TxType = "create" | "validate" | "release" | "redirect";
-type TxStatus = "confirmed" | "pending" | "failed";
+type TxType = TransactionType;
+type TxStatus = TransactionStatus;
 
 interface Transaction {
   id: string;
@@ -239,12 +244,12 @@ const VAULTS = [
   "All Vaults",
   ...Array.from(new Set(MOCK_TRANSACTIONS.map((t) => t.vault))),
 ];
-const TYPES: string[] = [
-  "All Types",
-  "create",
-  "validate",
-  "release",
-  "redirect",
+const TYPES: SelectOption[] = [
+  { value: "all", label: "All Types" },
+  { value: "create", label: "Create" },
+  { value: "validate", label: "Validate" },
+  { value: "release", label: "Release" },
+  { value: "redirect", label: "Redirect" },
 ];
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -323,12 +328,14 @@ function exportCSV(txs: Transaction[]): void {
 
 // ── Main Component ────────────────────────────────────────────────────────────
 export default function VaultTransactions() {
-  const [filterType, setFilterType] = useState<string>("All Types");
+  const [filterType, setFilterType] = useState<TxType | "all">("all");
   const [filterVault, setFilterVault] = useState<string>("All Vaults");
-  const [filterStatus, setFilterStatus] = useState<string>("all");
+  const [filterStatus, setFilterStatus] = useState<TxStatus | "all">("all");
   const [searchHash, setSearchHash] = useState<string>("");
   const [amountMin, setAmountMin] = useState<string>("");
   const [amountMax, setAmountMax] = useState<string>("");
+  const [dateStart, setDateStart] = useState<string>("");
+  const [dateEnd, setDateEnd] = useState<string>("");
   const [selectedTx, setSelectedTx] = useState<Transaction | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
@@ -340,13 +347,14 @@ export default function VaultTransactions() {
   }, []);
 
   const filtered = useMemo<Transaction[]>(() => {
-    let list = [...MOCK_TRANSACTIONS];
-    if (filterType !== "All Types")
-      list = list.filter((t) => t.type === filterType);
+    let list = filterTransactions(MOCK_TRANSACTIONS, {
+      type: filterType,
+      status: filterStatus,
+      startDate: dateStart,
+      endDate: dateEnd,
+    });
     if (filterVault !== "All Vaults")
       list = list.filter((t) => t.vault === filterVault);
-    if (filterStatus !== "all")
-      list = list.filter((t) => t.status === filterStatus);
     if (searchHash.trim())
       list = list.filter((t) =>
         t.hash.toLowerCase().includes(searchHash.toLowerCase()),
@@ -368,6 +376,8 @@ export default function VaultTransactions() {
     searchHash,
     amountMin,
     amountMax,
+    dateStart,
+    dateEnd,
     sortDir,
   ]);
 
@@ -385,21 +395,25 @@ export default function VaultTransactions() {
   );
 
   const clearFilters = () => {
-    setFilterType("All Types");
+    setFilterType("all");
     setFilterVault("All Vaults");
     setFilterStatus("all");
     setSearchHash("");
     setAmountMin("");
     setAmountMax("");
+    setDateStart("");
+    setDateEnd("");
   };
 
   const hasFilters =
-    filterType !== "All Types" ||
+    filterType !== "all" ||
     filterVault !== "All Vaults" ||
     filterStatus !== "all" ||
     !!searchHash ||
     !!amountMin ||
-    !!amountMax;
+    !!amountMax ||
+    !!dateStart ||
+    !!dateEnd;
 
   return (
     <>
@@ -461,6 +475,7 @@ export default function VaultTransactions() {
               <SearchIcon className="vt-search-icon" />
               <input
                 className="vt-search"
+                aria-label="Search transactions by hash"
                 placeholder="Search by transaction hash…"
                 value={searchHash}
                 onChange={(e) => setSearchHash(e.target.value)}
@@ -468,18 +483,21 @@ export default function VaultTransactions() {
             </div>
             <div className="vt-filter-row">
               <Select
+                label="Filter transactions by type"
                 value={filterType}
-                onChange={setFilterType}
+                onChange={(value) => setFilterType(value as TxType | "all")}
                 options={TYPES}
               />
               <Select
+                label="Filter transactions by vault"
                 value={filterVault}
                 onChange={setFilterVault}
                 options={VAULTS}
               />
               <Select
+                label="Filter transactions by status"
                 value={filterStatus}
-                onChange={setFilterStatus}
+                onChange={(value) => setFilterStatus(value as TxStatus | "all")}
                 options={[
                   { value: "all", label: "All Statuses" },
                   { value: "confirmed", label: "Confirmed" },
@@ -487,9 +505,27 @@ export default function VaultTransactions() {
                   { value: "failed", label: "Failed" },
                 ]}
               />
+              <div className="vt-date-range">
+                <input
+                  className="vt-date-input"
+                  aria-label="Filter transactions from date"
+                  value={dateStart}
+                  onChange={(e) => setDateStart(e.target.value)}
+                  type="date"
+                />
+                <span className="vt-amount-sep">–</span>
+                <input
+                  className="vt-date-input"
+                  aria-label="Filter transactions to date"
+                  value={dateEnd}
+                  onChange={(e) => setDateEnd(e.target.value)}
+                  type="date"
+                />
+              </div>
               <div className="vt-amount-range">
                 <input
                   className="vt-amount-input"
+                  aria-label="Minimum transaction amount"
                   placeholder="Min XLM"
                   value={amountMin}
                   onChange={(e) => setAmountMin(e.target.value)}
@@ -498,6 +534,7 @@ export default function VaultTransactions() {
                 <span className="vt-amount-sep">–</span>
                 <input
                   className="vt-amount-input"
+                  aria-label="Maximum transaction amount"
                   placeholder="Max XLM"
                   value={amountMax}
                   onChange={(e) => setAmountMax(e.target.value)}
@@ -521,54 +558,60 @@ export default function VaultTransactions() {
             </div>
           </div>
 
-          {/* Pending */}
-          {pending.length > 0 && (
-            <Section title="Pending" accent="#fcd34d" count={pending.length}>
-              {pending.map((tx) => (
-                <TxRow
-                  key={tx.id}
-                  tx={tx}
-                  onSelect={setSelectedTx}
-                  onCopy={copy}
-                  copiedId={copiedId}
-                />
-              ))}
-            </Section>
-          )}
-
-          {/* Failed */}
-          {failed.length > 0 && (
-            <Section title="Failed" accent="#fca5a5" count={failed.length}>
-              {failed.map((tx) => (
-                <TxRow
-                  key={tx.id}
-                  tx={tx}
-                  onSelect={setSelectedTx}
-                  onCopy={copy}
-                  copiedId={copiedId}
-                >
-                  <button className="vt-retry-btn">Retry →</button>
-                </TxRow>
-              ))}
-            </Section>
-          )}
-
-          {/* Confirmed */}
-          <Section title="Confirmed" accent="#6ee7b7" count={rest.length}>
-            {rest.length === 0 ? (
+          {filtered.length === 0 ? (
+            <Section title="Transactions" accent="#64748b" count={0}>
               <EmptyState hasFilters={hasFilters} onClear={clearFilters} />
-            ) : (
-              rest.map((tx) => (
-                <TxRow
-                  key={tx.id}
-                  tx={tx}
-                  onSelect={setSelectedTx}
-                  onCopy={copy}
-                  copiedId={copiedId}
-                />
-              ))
-            )}
-          </Section>
+            </Section>
+          ) : (
+            <>
+              {/* Pending */}
+              {pending.length > 0 && (
+                <Section title="Pending" accent="#fcd34d" count={pending.length}>
+                  {pending.map((tx) => (
+                    <TxRow
+                      key={tx.id}
+                      tx={tx}
+                      onSelect={setSelectedTx}
+                      onCopy={copy}
+                      copiedId={copiedId}
+                    />
+                  ))}
+                </Section>
+              )}
+
+              {/* Failed */}
+              {failed.length > 0 && (
+                <Section title="Failed" accent="#fca5a5" count={failed.length}>
+                  {failed.map((tx) => (
+                    <TxRow
+                      key={tx.id}
+                      tx={tx}
+                      onSelect={setSelectedTx}
+                      onCopy={copy}
+                      copiedId={copiedId}
+                    >
+                      <button className="vt-retry-btn">Retry →</button>
+                    </TxRow>
+                  ))}
+                </Section>
+              )}
+
+              {/* Confirmed */}
+              {rest.length > 0 && (
+                <Section title="Confirmed" accent="#6ee7b7" count={rest.length}>
+                  {rest.map((tx) => (
+                    <TxRow
+                      key={tx.id}
+                      tx={tx}
+                      onSelect={setSelectedTx}
+                      onCopy={copy}
+                      copiedId={copiedId}
+                    />
+                  ))}
+                </Section>
+              )}
+            </>
+          )}
         </div>
 
         {selectedTx && (
@@ -843,12 +886,13 @@ interface SelectOption {
 }
 
 interface SelectProps {
+  label: string;
   value: string;
   onChange: (val: string) => void;
   options: string[] | SelectOption[];
 }
 
-function Select({ value, onChange, options }: SelectProps) {
+function Select({ label, value, onChange, options }: SelectProps) {
   const opts: SelectOption[] = options.map((o) =>
     typeof o === "string" ? { value: o, label: o } : o,
   );
@@ -856,6 +900,7 @@ function Select({ value, onChange, options }: SelectProps) {
     <div className="vt-select-wrap">
       <select
         className="vt-select"
+        aria-label={label}
         value={value}
         onChange={(e) => onChange(e.target.value)}
       >
@@ -1159,12 +1204,14 @@ const CSS = `
   }
   .vt-select:hover, .vt-select:focus { border-color: rgba(110,231,183,0.25); color: #e2e8f0; }
   .vt-amount-range { display: flex; align-items: center; gap: 6px; }
-  .vt-amount-input {
+  .vt-date-range { display: flex; align-items: center; gap: 6px; }
+  .vt-amount-input, .vt-date-input {
     width: 90px; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08);
     color: #94a3b8; font-family: 'JetBrains Mono', monospace; font-size: 12px;
     padding: 8px 10px; border-radius: 7px; outline: none; transition: border-color var(--duration-normal) var(--ease-in-out);
   }
-  .vt-amount-input:focus { border-color: rgba(110,231,183,0.25); }
+  .vt-date-input { width: 132px; color-scheme: dark; }
+  .vt-amount-input:focus, .vt-date-input:focus { border-color: rgba(110,231,183,0.25); }
   .vt-amount-input::placeholder { color: #334155; }
   .vt-amount-sep { color: #334155; font-size: 13px; }
   .vt-sort-btn {
@@ -1302,6 +1349,7 @@ const CSS = `
     .vt-modal-row2 { grid-template-columns: 1fr 1fr; }
     .vt-filter-row { gap: 8px; }
     .vt-amount-range { display: none; }
+    .vt-date-range { flex: 1 1 100%; }
   }
   @media (max-width: 480px) {
     .vt-stats { grid-template-columns: 1fr; }

--- a/src/pages/__tests__/VaultTransactions.test.tsx
+++ b/src/pages/__tests__/VaultTransactions.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function renderTransactions() {
+  const { default: VaultTransactions } = await import('../VaultTransactions');
+  return render(<VaultTransactions />);
+}
+
+describe('VaultTransactions filters', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-24T12:00:00.000Z'));
+    vi.resetModules();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('filters transactions by status without showing an unrelated empty section', async () => {
+    await renderTransactions();
+
+    fireEvent.change(screen.getByLabelText('Filter transactions by status'), {
+      target: { value: 'failed' },
+    });
+
+    expect(screen.getByText('Partial release')).toBeInTheDocument();
+    expect(screen.queryByText('Initial deposit')).not.toBeInTheDocument();
+    expect(screen.queryByText('No matching transactions')).not.toBeInTheDocument();
+    expect(screen.getByText('1 matching')).toBeInTheDocument();
+  });
+
+  it('filters transactions by type', async () => {
+    await renderTransactions();
+
+    fireEvent.change(screen.getByLabelText('Filter transactions by type'), {
+      target: { value: 'redirect' },
+    });
+
+    expect(screen.getByText('Redirect to escrow')).toBeInTheDocument();
+    expect(screen.getByText('Reallocation')).toBeInTheDocument();
+    expect(screen.queryByText('Initial deposit')).not.toBeInTheDocument();
+    expect(screen.getByText('2 matching')).toBeInTheDocument();
+  });
+
+  it('applies date ranges and shows the clearable empty state', async () => {
+    await renderTransactions();
+
+    fireEvent.change(screen.getByLabelText('Filter transactions from date'), {
+      target: { value: '2026-06-25' },
+    });
+
+    expect(screen.getByText('No matching transactions')).toBeInTheDocument();
+    expect(screen.getByText('0 matching')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /clear filters/i }));
+
+    expect(screen.queryByText('No matching transactions')).not.toBeInTheDocument();
+    expect(screen.getByText('10 matching')).toBeInTheDocument();
+  });
+
+  it('returns no rows when the date range starts after it ends', async () => {
+    await renderTransactions();
+
+    fireEvent.change(screen.getByLabelText('Filter transactions from date'), {
+      target: { value: '2026-06-25' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter transactions to date'), {
+      target: { value: '2026-06-20' },
+    });
+
+    expect(screen.getByText('No matching transactions')).toBeInTheDocument();
+    expect(screen.queryByText('Q3 release')).not.toBeInTheDocument();
+  });
+});

--- a/src/utils/__tests__/transactionFilter.test.ts
+++ b/src/utils/__tests__/transactionFilter.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+  filterTransactions,
+  type FilterableTransaction,
+} from '../transactionFilter';
+
+interface TestTransaction extends FilterableTransaction {
+  id: string;
+}
+
+const transactions: TestTransaction[] = [
+  {
+    id: 'create-confirmed',
+    type: 'create',
+    status: 'confirmed',
+    timestamp: new Date(2026, 5, 10, 0, 0, 0, 0),
+  },
+  {
+    id: 'release-failed',
+    type: 'release',
+    status: 'failed',
+    timestamp: new Date(2026, 5, 11, 12, 30, 0, 0),
+  },
+  {
+    id: 'redirect-pending',
+    type: 'redirect',
+    status: 'pending',
+    timestamp: new Date(2026, 5, 12, 23, 59, 59, 0),
+  },
+  {
+    id: 'validate-confirmed',
+    type: 'validate',
+    status: 'confirmed',
+    timestamp: new Date(2026, 5, 13, 8, 0, 0, 0),
+  },
+];
+
+const ids = (items: TestTransaction[]) => items.map((item) => item.id);
+
+describe('filterTransactions', () => {
+  it('filters by status and type', () => {
+    expect(ids(filterTransactions(transactions, { type: 'all', status: 'failed' }))).toEqual([
+      'release-failed',
+    ]);
+    expect(ids(filterTransactions(transactions, { type: 'validate', status: 'all' }))).toEqual([
+      'validate-confirmed',
+    ]);
+  });
+
+  it('combines status and type filters', () => {
+    expect(ids(filterTransactions(transactions, { type: 'release', status: 'failed' }))).toEqual([
+      'release-failed',
+    ]);
+    expect(filterTransactions(transactions, { type: 'release', status: 'pending' })).toEqual([]);
+  });
+
+  it('applies inclusive date range bounds', () => {
+    expect(
+      ids(
+        filterTransactions(transactions, {
+          type: 'all',
+          status: 'all',
+          startDate: '2026-06-10',
+          endDate: '2026-06-12',
+        }),
+      ),
+    ).toEqual(['create-confirmed', 'release-failed', 'redirect-pending']);
+  });
+
+  it('returns no matches when start date is after end date', () => {
+    expect(
+      filterTransactions(transactions, {
+        type: 'all',
+        status: 'all',
+        startDate: '2026-06-14',
+        endDate: '2026-06-10',
+      }),
+    ).toEqual([]);
+  });
+
+  it('ignores invalid filter dates without throwing', () => {
+    expect(
+      ids(
+        filterTransactions(transactions, {
+          type: 'all',
+          status: 'all',
+          startDate: 'not-a-date',
+          endDate: '2026-99-99',
+        }),
+      ),
+    ).toEqual(['create-confirmed', 'release-failed', 'redirect-pending', 'validate-confirmed']);
+  });
+
+  it('excludes transactions with invalid timestamps when date checks run', () => {
+    const withInvalidTimestamp: TestTransaction[] = [
+      ...transactions,
+      {
+        id: 'invalid',
+        type: 'create',
+        status: 'confirmed',
+        timestamp: 'not-a-date',
+      },
+    ];
+
+    expect(ids(filterTransactions(withInvalidTimestamp, { type: 'all', status: 'all' }))).toEqual([
+      'create-confirmed',
+      'release-failed',
+      'redirect-pending',
+      'validate-confirmed',
+    ]);
+  });
+});

--- a/src/utils/transactionFilter.ts
+++ b/src/utils/transactionFilter.ts
@@ -1,0 +1,71 @@
+export type TransactionType = 'create' | 'validate' | 'release' | 'redirect';
+export type TransactionStatus = 'confirmed' | 'pending' | 'failed';
+
+export interface FilterableTransaction {
+  type: TransactionType;
+  status: TransactionStatus;
+  timestamp: Date | string | number;
+}
+
+export interface TransactionFilters {
+  type: TransactionType | 'all';
+  status: TransactionStatus | 'all';
+  startDate?: string;
+  endDate?: string;
+}
+
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+function parseDateBound(value: string | undefined, bound: 'start' | 'end'): Date | null {
+  if (!value?.trim()) return null;
+
+  const match = DATE_ONLY_PATTERN.exec(value.trim());
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  const date =
+    bound === 'start'
+      ? new Date(year, month, day, 0, 0, 0, 0)
+      : new Date(year, month, day, 23, 59, 59, 999);
+
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+}
+
+function toValidDate(value: Date | string | number): Date | null {
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function filterTransactions<T extends FilterableTransaction>(
+  transactions: T[],
+  { type, status, startDate, endDate }: TransactionFilters,
+): T[] {
+  const start = parseDateBound(startDate, 'start');
+  const end = parseDateBound(endDate, 'end');
+
+  if (start && end && start.getTime() > end.getTime()) {
+    return [];
+  }
+
+  return transactions.filter((transaction) => {
+    if (type !== 'all' && transaction.type !== type) return false;
+    if (status !== 'all' && transaction.status !== status) return false;
+
+    const timestamp = toValidDate(transaction.timestamp);
+    if (!timestamp) return false;
+    if (start && timestamp.getTime() < start.getTime()) return false;
+    if (end && timestamp.getTime() > end.getTime()) return false;
+
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary
- add a pure `filterTransactions` helper for status, type, and inclusive date-range filters
- wire accessible status/type/date controls into VaultTransactions and clear date filters with the existing clear action
- show a single clearable no-results state instead of an unrelated empty Confirmed section
- document the transaction filter helper API

Closes #188

## Validation
- `npx tsc --noEmit -p <targeted vault transaction filters tsconfig>`
- `npx eslint src/utils/transactionFilter.ts src/utils/__tests__/transactionFilter.test.ts src/pages/VaultTransactions.tsx src/pages/__tests__/VaultTransactions.test.tsx`
- `git diff --check`
- `npx vitest run src/utils/__tests__/transactionFilter.test.ts src/pages/__tests__/VaultTransactions.test.tsx` (blocked locally by Vite/esbuild startup: `Error: spawn EPERM`)