### PR TITLE
feat: add copy button for stellar values

### DIFF
--- a/design-system/documentation/copy-button.md
+++ b/design-system/documentation/copy-button.md
@@ -1,0 +1,12 @@
+# Copy Button
+
+`CopyButton` in `src/components/CopyButton.tsx` copies full addresses and
+transaction hashes while the surrounding UI may keep displaying truncated text.
+
+- Pass the full `value` and a specific accessible `label`, such as `Copy address`.
+- Tests can inject a `ClipboardAdapter` from `src/components/copyClipboard.ts`
+  with `writeText(value)`; production uses `navigator.clipboard.writeText`.
+- Clipboard rejection and missing browser clipboard support show `Copy failed`
+  through an `aria-live="polite"` status instead of throwing.
+- Successful copies announce `Copied` and reset after the configured timeout.
+- Empty values disable the control so no empty clipboard write is attempted.

--- a/src/components/CopyButton.css
+++ b/src/components/CopyButton.css
@@ -1,0 +1,49 @@
+.copy-button {
+  align-items: center;
+  background: none;
+  border: 0;
+  color: var(--muted);
+  cursor: pointer;
+  display: inline-flex;
+  gap: 0.25rem;
+  line-height: 1;
+  padding: 0.125rem 0.25rem;
+}
+
+.copy-button:hover:not(:disabled) {
+  color: var(--text);
+}
+
+.copy-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.copy-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.copy-button-success {
+  color: var(--success);
+}
+
+.copy-button-error {
+  color: var(--danger);
+}
+
+.copy-button-content {
+  display: inline-flex;
+}
+
+.copy-button-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,0 +1,97 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent,
+  type ReactNode,
+} from 'react';
+import { AlertTriangle, Check, Copy } from 'lucide-react';
+import { browserClipboardAdapter, type ClipboardAdapter } from './copyClipboard';
+import './CopyButton.css';
+
+type CopyState = 'idle' | 'success' | 'error';
+
+export interface CopyButtonProps {
+  value: string;
+  label: string;
+  adapter?: ClipboardAdapter;
+  resetMs?: number;
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+  stopPropagation?: boolean;
+}
+
+export function CopyButton({
+  value,
+  label,
+  adapter = browserClipboardAdapter,
+  resetMs = 1500,
+  className = '',
+  style,
+  children,
+  stopPropagation = false,
+}: CopyButtonProps) {
+  const [copyState, setCopyState] = useState<CopyState>('idle');
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimer.current) {
+        clearTimeout(resetTimer.current);
+      }
+    };
+  }, []);
+
+  const scheduleReset = () => {
+    if (resetTimer.current) {
+      clearTimeout(resetTimer.current);
+    }
+
+    resetTimer.current = setTimeout(() => {
+      setCopyState('idle');
+      resetTimer.current = null;
+    }, resetMs);
+  };
+
+  const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
+    if (stopPropagation) {
+      event.stopPropagation();
+    }
+
+    if (!value) return;
+
+    try {
+      await adapter.writeText(value);
+      setCopyState('success');
+    } catch {
+      setCopyState('error');
+    } finally {
+      scheduleReset();
+    }
+  };
+
+  const Icon =
+    copyState === 'success' ? Check : copyState === 'error' ? AlertTriangle : Copy;
+  const statusMessage =
+    copyState === 'success' ? 'Copied' : copyState === 'error' ? 'Copy failed' : '';
+
+  return (
+    <button
+      type="button"
+      className={`copy-button ${copyState !== 'idle' ? `copy-button-${copyState}` : ''} ${className}`.trim()}
+      style={style}
+      aria-label={label}
+      title={label}
+      onClick={handleClick}
+      disabled={!value}
+    >
+      {children && <span className="copy-button-content">{children}</span>}
+      <Icon size={14} aria-hidden="true" />
+      <span className="copy-button-status" aria-live="polite">
+        {statusMessage}
+      </span>
+    </button>
+  );
+}

--- a/src/components/__tests__/CopyButton.test.tsx
+++ b/src/components/__tests__/CopyButton.test.tsx
@@ -1,0 +1,110 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CopyButton } from '../CopyButton';
+import type { ClipboardAdapter } from '../copyClipboard';
+
+describe('CopyButton', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('copies through the injected clipboard adapter and announces success', async () => {
+    const adapter: ClipboardAdapter = {
+      writeText: vi.fn().mockResolvedValue(undefined),
+    };
+
+    render(
+      <CopyButton value="GBVZ3KQK" label="Copy address" adapter={adapter}>
+        GBVZ...QK
+      </CopyButton>,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy address' }));
+    });
+
+    expect(adapter.writeText).toHaveBeenCalledWith('GBVZ3KQK');
+    expect(screen.getByText('Copied')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.queryByText('Copied')).not.toBeInTheDocument();
+  });
+
+  it('shows an error state when clipboard copying rejects', async () => {
+    const adapter: ClipboardAdapter = {
+      writeText: vi.fn().mockRejectedValue(new Error('denied')),
+    };
+
+    render(<CopyButton value="hash" label="Copy hash" adapter={adapter} />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy hash' }));
+    });
+
+    expect(screen.getByText('Copy failed')).toBeInTheDocument();
+    expect(adapter.writeText).toHaveBeenCalledWith('hash');
+  });
+
+  it('handles a missing browser clipboard API without throwing', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+
+    render(<CopyButton value="hash" label="Copy hash" />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy hash' }));
+    });
+
+    expect(screen.getByText('Copy failed')).toBeInTheDocument();
+  });
+
+  it('disables the button for an empty copy value', () => {
+    const adapter: ClipboardAdapter = {
+      writeText: vi.fn().mockResolvedValue(undefined),
+    };
+
+    render(<CopyButton value="" label="Copy empty value" adapter={adapter} />);
+
+    expect(screen.getByRole('button', { name: 'Copy empty value' })).toBeDisabled();
+    expect(adapter.writeText).not.toHaveBeenCalled();
+  });
+
+  it('keeps the latest rapid copy confirmation timer', async () => {
+    const adapter: ClipboardAdapter = {
+      writeText: vi.fn().mockResolvedValue(undefined),
+    };
+
+    render(
+      <CopyButton value="hash" label="Copy hash" adapter={adapter} resetMs={1500} />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy hash' }));
+    });
+    expect(adapter.writeText).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy hash' }));
+    });
+    expect(adapter.writeText).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText('Copied')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(screen.queryByText('Copied')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/copyClipboard.ts
+++ b/src/components/copyClipboard.ts
@@ -1,0 +1,13 @@
+export interface ClipboardAdapter {
+  writeText: (value: string) => Promise<void>;
+}
+
+export const browserClipboardAdapter: ClipboardAdapter = {
+  async writeText(value: string) {
+    if (!navigator.clipboard?.writeText) {
+      throw new Error('Clipboard API unavailable.');
+    }
+
+    await navigator.clipboard.writeText(value);
+  },
+};

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { MilestoneTracker } from "../components/MilestoneTracker";
 import { VaultProgressBar } from "../components/VaultProgressBar";
@@ -8,6 +7,7 @@ import {
   type FundReleaseStatusProps,
 } from "../components/FundReleaseStatus";
 import { Text } from "../components/Text";
+import { CopyButton } from "../components/CopyButton";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 type VaultStatus =
@@ -292,34 +292,6 @@ function settlementForVault(vault: Vault): FundReleaseStatusProps {
   };
 }
 
-// ── Copy Button ───────────────────────────────────────────────────────────────
-function CopyButton({ value }: { value: string }) {
-  const [copied, setCopied] = useState(false);
-  const copy = () => {
-    navigator.clipboard.writeText(value).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
-  };
-  return (
-    <button
-      onClick={copy}
-      title="Copy"
-      style={{
-        background: "none",
-        border: "none",
-        cursor: "pointer",
-        color: copied ? "var(--success)" : "var(--muted)",
-        padding: "0 4px",
-        fontSize: 13,
-        lineHeight: 1,
-      }}
-    >
-      {copied ? "✓" : "⎘"}
-    </button>
-  );
-}
-
 // ── Address Row ───────────────────────────────────────────────────────────────
 function AddrRow({ label, value }: { label: string; value: string }) {
   return (
@@ -343,7 +315,7 @@ function AddrRow({ label, value }: { label: string; value: string }) {
         <Text role="mono" as="span" style={{ color: "var(--text)" }}>
           {truncAddr(value)}
         </Text>
-        <CopyButton value={value} />
+        <CopyButton value={value} label={`Copy ${label.toLowerCase()} address`} />
       </div>
     </div>
   );
@@ -696,7 +668,7 @@ export default function VaultDetail() {
                   >
                     {truncHash(tx.hash)}
                   </Text>
-                  <CopyButton value={tx.hash} />
+                  <CopyButton value={tx.hash} label="Copy transaction hash" />
                   <a
                     href={`https://stellar.expert/explorer/public/tx/${tx.hash}`}
                     target="_blank"

--- a/src/pages/VaultTransactions.tsx
+++ b/src/pages/VaultTransactions.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo } from "react";
+import { CopyButton } from "../components/CopyButton";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 type TxType = "create" | "validate" | "release" | "redirect";
@@ -40,6 +41,10 @@ interface IconProps {
 }
 
 // ── Mock Data ─────────────────────────────────────────────────────────────────
+const USER_ADDRESS = "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L";
+const VAULT_ADDRESS = "GCVAULT3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQM3P";
+const DELTA_ADDRESS = "GDELTA3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQX9K";
+
 const MOCK_TRANSACTIONS: Transaction[] = [
   {
     id: "tx1",
@@ -50,8 +55,8 @@ const MOCK_TRANSACTIONS: Transaction[] = [
     block: 48201933,
     hash: "a3f9d1c8e2b74056af3d9c1b2e8f0a4d7c5e9b3f1a2d4c6e8b0f2a4c6d8e0f2a",
     status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
+    from: USER_ADDRESS,
+    to: VAULT_ADDRESS,
     timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2),
     memo: "Initial deposit",
   },
@@ -64,8 +69,8 @@ const MOCK_TRANSACTIONS: Transaction[] = [
     block: 48202011,
     hash: "b4e0c2d9f3a85167bg4e0d2c3f9a5e8b4c6d0e2f4a6c8e0b2d4f6a8c0e2d4f6a",
     status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
+    from: USER_ADDRESS,
+    to: VAULT_ADDRESS,
     timestamp: new Date(Date.now() - 1000 * 60 * 60 * 1.5),
     memo: "",
   },
@@ -78,8 +83,8 @@ const MOCK_TRANSACTIONS: Transaction[] = [
     block: 48202450,
     hash: "c5f1d3e0a4b96278ch5f1e3d4a0b6f9c5d7e1f3b5d7f9b1d3f5b7d9f1b3d5f7b",
     status: "confirmed",
-    from: "GCVAULT...M3P",
-    to: "GBVZ3...QK7L",
+    from: VAULT_ADDRESS,
+    to: USER_ADDRESS,
     timestamp: new Date(Date.now() - 1000 * 60 * 45),
     memo: "Milestone payout",
   },
@@ -92,8 +97,8 @@ const MOCK_TRANSACTIONS: Transaction[] = [
     block: 48202891,
     hash: "d6a2e4f1b5c07389di6a2f4e5b1c7a0d6e8f2a4c6e8a0c2e4f6a8c0e2f4a6c8e",
     status: "pending",
-    from: "GCVAULT...M3P",
-    to: "GDELTA...X9K",
+    from: VAULT_ADDRESS,
+    to: DELTA_ADDRESS,
     timestamp: new Date(Date.now() - 1000 * 60 * 20),
     memo: "Redirect to escrow",
   },
@@ -106,8 +111,8 @@ const MOCK_TRANSACTIONS: Transaction[] = [
     block: 48201100,
     hash: "e7b3f5a2c6d18490ej7b3a5f6c2d8b1e7f9a3b5d7f9b1d3f5b7d9f1b3d5f7b9d",
     status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
+    from: USER_ADDRESS,
+    to: VAULT_ADDRESS,
     timestamp: new Date(Date.now() - 1000 * 60 * 60 * 5),
     memo: "New vault",
   },
@@ -120,8 +125,8 @@ const MOCK_TRANSACTIONS: Transaction[] = [
     block: 48203100,
     hash: "f8c4a6b3d7e29501fk8c4b6a7d3e9c2f8a0c4b6d8f0b2d4f6a8b0d2f4a6b8d0f",
     status: "failed",
-    from: "GCVAULT...M3P",
-    to: "GBVZ3...QK7L",
+    from: VAULT_ADDRESS,
+    to: USER_ADDRESS,
     timestamp: new Date(Date.now() - 1000 * 60 * 10),
     memo: "Partial release",
   },
@@ -134,8 +139,8 @@ const MOCK_TRANSACTIONS: Transaction[] = [
     block: 48201788,
     hash: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
     status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
+    from: USER_ADDRESS,
+    to: VAULT_ADDRESS,
     timestamp: new Date(Date.now() - 1000 * 60 * 60 * 3.5),
     memo: "",
   },
@@ -148,8 +153,8 @@ const MOCK_TRANSACTIONS: Transaction[] = [
     block: 48203222,
     hash: "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3",
     status: "pending",
-    from: "GCVAULT...M3P",
-    to: "GBVZ3...QK7L",
+    from: VAULT_ADDRESS,
+    to: USER_ADDRESS,
     timestamp: new Date(Date.now() - 1000 * 60 * 5),
     memo: "Reallocation",
   },
@@ -162,8 +167,8 @@ const MOCK_TRANSACTIONS: Transaction[] = [
     block: 48200500,
     hash: "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4",
     status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
+    from: USER_ADDRESS,
+    to: VAULT_ADDRESS,
     timestamp: new Date(Date.now() - 1000 * 60 * 60 * 8),
     memo: "Large vault",
   },
@@ -176,8 +181,8 @@ const MOCK_TRANSACTIONS: Transaction[] = [
     block: 48203400,
     hash: "d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5",
     status: "confirmed",
-    from: "GCVAULT...M3P",
-    to: "GBVZ3...QK7L",
+    from: VAULT_ADDRESS,
+    to: USER_ADDRESS,
     timestamp: new Date(Date.now() - 1000 * 60 * 2),
     memo: "Q3 release",
   },
@@ -251,6 +256,10 @@ const TYPES: string[] = [
 function truncHash(hash: string, head = 8, tail = 6): string {
   if (!hash) return "";
   return `${hash.slice(0, head)}...${hash.slice(-tail)}`;
+}
+
+function truncAddr(addr: string): string {
+  return addr.length > 12 ? `${addr.slice(0, 6)}...${addr.slice(-4)}` : addr;
 }
 
 function fmtTime(date: Date): string {
@@ -330,14 +339,7 @@ export default function VaultTransactions() {
   const [amountMin, setAmountMin] = useState<string>("");
   const [amountMax, setAmountMax] = useState<string>("");
   const [selectedTx, setSelectedTx] = useState<Transaction | null>(null);
-  const [copiedId, setCopiedId] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
-
-  const copy = useCallback((text: string, id: string) => {
-    navigator.clipboard.writeText(text).catch(() => {});
-    setCopiedId(id);
-    setTimeout(() => setCopiedId(null), 1800);
-  }, []);
 
   const filtered = useMemo<Transaction[]>(() => {
     let list = [...MOCK_TRANSACTIONS];
@@ -529,8 +531,6 @@ export default function VaultTransactions() {
                   key={tx.id}
                   tx={tx}
                   onSelect={setSelectedTx}
-                  onCopy={copy}
-                  copiedId={copiedId}
                 />
               ))}
             </Section>
@@ -544,8 +544,6 @@ export default function VaultTransactions() {
                   key={tx.id}
                   tx={tx}
                   onSelect={setSelectedTx}
-                  onCopy={copy}
-                  copiedId={copiedId}
                 >
                   <button className="vt-retry-btn">Retry →</button>
                 </TxRow>
@@ -563,8 +561,6 @@ export default function VaultTransactions() {
                   key={tx.id}
                   tx={tx}
                   onSelect={setSelectedTx}
-                  onCopy={copy}
-                  copiedId={copiedId}
                 />
               ))
             )}
@@ -575,8 +571,6 @@ export default function VaultTransactions() {
           <TxModal
             tx={selectedTx}
             onClose={() => setSelectedTx(null)}
-            onCopy={copy}
-            copiedId={copiedId}
           />
         )}
       </div>
@@ -608,12 +602,10 @@ function Section({ title, accent, count, children }: SectionProps) {
 interface TxRowProps {
   tx: Transaction;
   onSelect: (tx: Transaction) => void;
-  onCopy: (text: string, id: string) => void;
-  copiedId: string | null;
   children?: React.ReactNode;
 }
 
-function TxRow({ tx, onSelect, onCopy, copiedId, children }: TxRowProps) {
+function TxRow({ tx, onSelect, children }: TxRowProps) {
   const meta = TYPE_META[tx.type];
   const status = STATUS_META[tx.status];
   const Icon = meta.icon;
@@ -636,17 +628,14 @@ function TxRow({ tx, onSelect, onCopy, copiedId, children }: TxRowProps) {
           {tx.memo && <span className="vt-tx-memo">"{tx.memo}"</span>}
         </div>
         <div className="vt-tx-bottom">
-          <button
+          <CopyButton
             className="vt-tx-hash"
-            onClick={(e) => {
-              e.stopPropagation();
-              onCopy(tx.hash, tx.id + "-hash");
-            }}
-            title="Copy hash"
+            value={tx.hash}
+            label="Copy transaction hash"
+            stopPropagation
           >
-            {copiedId === tx.id + "-hash" ? "Copied!" : truncHash(tx.hash)}
-            <CopyIcon small />
-          </button>
+            {truncHash(tx.hash)}
+          </CopyButton>
           <a
             href={`https://stellar.expert/explorer/testnet/tx/${tx.hash}`}
             target="_blank"
@@ -688,11 +677,9 @@ function TxRow({ tx, onSelect, onCopy, copiedId, children }: TxRowProps) {
 interface TxModalProps {
   tx: Transaction;
   onClose: () => void;
-  onCopy: (text: string, id: string) => void;
-  copiedId: string | null;
 }
 
-function TxModal({ tx, onClose, onCopy, copiedId }: TxModalProps) {
+function TxModal({ tx, onClose }: TxModalProps) {
   const [rawOpen, setRawOpen] = useState(false);
   const meta = TYPE_META[tx.type];
   const status = STATUS_META[tx.status];
@@ -757,19 +744,32 @@ function TxModal({ tx, onClose, onCopy, copiedId }: TxModalProps) {
           <Field label="Full Hash">
             <div className="vt-modal-hash-row">
               <span className="vt-modal-hash">{tx.hash}</span>
-              <button
+              <CopyButton
+                value={tx.hash}
+                label="Copy transaction hash"
                 className="vt-copy-btn"
-                onClick={() => onCopy(tx.hash, "modal-hash")}
-              >
-                {copiedId === "modal-hash" ? "✓" : <CopyIcon />}
-              </button>
+              />
             </div>
           </Field>
           <Field label="From">
-            <span className="vt-mono">{tx.from}</span>
+            <div className="vt-modal-hash-row">
+              <span className="vt-mono">{truncAddr(tx.from)}</span>
+              <CopyButton
+                value={tx.from}
+                label="Copy from address"
+                className="vt-copy-btn"
+              />
+            </div>
           </Field>
           <Field label="To">
-            <span className="vt-mono">{tx.to}</span>
+            <div className="vt-modal-hash-row">
+              <span className="vt-mono">{truncAddr(tx.to)}</span>
+              <CopyButton
+                value={tx.to}
+                label="Copy to address"
+                className="vt-copy-btn"
+              />
+            </div>
           </Field>
           <div className="vt-modal-row2">
             <Field label="Amount">
@@ -950,37 +950,6 @@ function RedirectIcon({ color = "currentColor", size = 16 }: IconProps) {
   );
 }
 
-interface CopyIconProps {
-  small?: boolean;
-}
-function CopyIcon({ small }: CopyIconProps) {
-  const s = small ? 11 : 14;
-  return (
-    <svg
-      width={s}
-      height={s}
-      viewBox="0 0 16 16"
-      fill="none"
-      style={{ display: "inline", marginLeft: small ? 3 : 0, opacity: 0.6 }}
-    >
-      <rect
-        x="5"
-        y="5"
-        width="9"
-        height="9"
-        rx="1.5"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      />
-      <path
-        d="M3 11V3a1 1 0 011-1h8"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-      />
-    </svg>
-  );
-}
 function SearchIcon({ className }: { className?: string }) {
   return (
     <svg

--- a/src/pages/__tests__/VaultDetail.test.tsx
+++ b/src/pages/__tests__/VaultDetail.test.tsx
@@ -33,6 +33,7 @@ describe('VaultDetail', () => {
     expect(within(addresses!).getByText('Failure destination')).toBeInTheDocument();
     expect(within(addresses!).getByText('Contract')).toBeInTheDocument();
     expect(within(addresses!).getByText('GBVZ3K...QK7L')).toBeInTheDocument();
+    expect(within(addresses!).getByRole('button', { name: 'Copy creator address' })).toBeInTheDocument();
 
     expect(screen.getByText(/1\. Phase 1 Complete/)).toBeInTheDocument();
     expect(screen.getByText('Complete initial development phase')).toBeInTheDocument();
@@ -50,6 +51,7 @@ describe('VaultDetail', () => {
     expect(screen.getByText('Milestone Validated')).toBeInTheDocument();
     expect(screen.getByText('a3f9d1c8...8f0a4d')).toBeInTheDocument();
     expect(screen.getByText('b4e0c2d9...9a5e8b')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Copy transaction hash' }).length).toBeGreaterThan(0);
   });
 
   it('renders completed vault release details without a verifier address', () => {

--- a/src/pages/__tests__/VaultTransactions.test.tsx
+++ b/src/pages/__tests__/VaultTransactions.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import VaultTransactions from '../VaultTransactions';
+
+const userAddress = 'GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L';
+
+describe('VaultTransactions copy actions', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it('copies the full transaction hash from a truncated row hash', async () => {
+    render(<VaultTransactions />);
+
+    const copyHashButton = screen.getAllByRole('button', {
+      name: 'Copy transaction hash',
+    })[0];
+    expect(copyHashButton).toHaveTextContent('a3f9d1c8...');
+
+    fireEvent.click(copyHashButton);
+
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        'a3f9d1c8e2b74056af3d9c1b2e8f0a4d7c5e9b3f1a2d4c6e8b0f2a4c6d8e0f2a',
+      ),
+    );
+  });
+
+  it('copies full from/to addresses from the transaction detail modal', async () => {
+    render(<VaultTransactions />);
+
+    fireEvent.click(screen.getByText('Initial deposit'));
+    expect(screen.getByText('GBVZ3K...QK7L')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy from address' }));
+
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(userAddress),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable `CopyButton` with injectable clipboard adapter, success/error aria-live feedback, and empty-value guard
- replace VaultDetail's local copy control and wire CopyButton to address and transaction hash displays
- use full Stellar address values in VaultTransactions while keeping truncated display and copying full hash/from/to values
- document the clipboard adapter and a11y behavior

Closes #186

## Validation
- `npx tsc --noEmit -p <targeted copy button tsconfig>`
- `npx eslint src/components/copyClipboard.ts src/components/CopyButton.tsx src/components/__tests__/CopyButton.test.tsx src/pages/VaultDetail.tsx src/pages/__tests__/VaultDetail.test.tsx src/pages/VaultTransactions.tsx src/pages/__tests__/VaultTransactions.test.tsx`
- `git diff --check`
- `npx vitest run src/components/__tests__/CopyButton.test.tsx src/pages/__tests__/VaultDetail.test.tsx src/pages/__tests__/VaultTransactions.test.tsx` (blocked locally by Vite/esbuild startup: `Error: spawn EPERM`)