### PR TITLE
fix: document canonical test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Root package scripts:
 | `npm run build` | Run TypeScript build mode and create a Vite production build |
 | `npm run preview` | Preview the production build locally |
 | `npm run lint` | Run ESLint across the frontend |
-| `npm run test` | Run the Vitest suite with coverage |
+| `npm test` | Run the canonical Vitest suite with coverage for CI-style checks |
+| `npm run test:watch` | Run Vitest in interactive watch mode for local development |
 
 Design-system package scripts:
 
@@ -131,7 +132,13 @@ Frontend tests use Vitest, the DOM test setup in `src/setupTests.ts`, and
 Testing Library.
 
 ```bash
-npm run test
+npm test
+```
+
+For local interactive development, use watch mode:
+
+```bash
+npm run test:watch
 ```
 
 For targeted frontend checks during development, run Vitest directly:

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "vitest",
+    "test": "vitest run --coverage",
+    "test:watch": "vitest",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "test": "vitest run --coverage"
+    "preview": "vite preview"
   },
   "dependencies": {
     "@stellar/freighter-api": "^6.0.1",


### PR DESCRIPTION
## Summary
- remove the duplicate root `test` script key and keep `vitest run --coverage` as canonical `npm test`
- add `test:watch` for interactive local Vitest runs
- update README script and testing guidance to distinguish CI-style coverage from watch mode

Closes #214

## Validation
- `npm pkg get scripts`
- `git diff --check`
- `npm test` (blocked locally by Vite/esbuild startup: `Error: spawn EPERM`)
- `npm run test:watch -- --run` (blocked locally by Vite/esbuild startup: `Error: spawn EPERM`)