### PR TITLE
feat: lazy load Analytics PDF export

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -10,13 +10,27 @@ import {
   ArrowUpRight, ArrowDownRight, Zap, Flag, BarChart2,
   Users, Lock, Crown
 } from 'lucide-react'
-import jsPDF from 'jspdf'
 import { useTheme } from '../context/ThemeContext'
 import { buildAnalyticsSeriesColors, getAnalyticsChartTokens } from './analyticsTheme'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type Period = '7d' | '30d' | '90d' | '1y' | 'All'
+type JsPDFModule = typeof import('jspdf')
+type JsPDFConstructor = JsPDFModule['default']
+
+let jsPDFModulePromise: Promise<JsPDFModule> | null = null
+
+function loadJsPDF() {
+  if (!jsPDFModulePromise) {
+    jsPDFModulePromise = import('jspdf').catch(error => {
+      jsPDFModulePromise = null
+      throw error
+    })
+  }
+
+  return jsPDFModulePromise
+}
 
 function useAnalyticsChartTokens() {
   const { theme } = useTheme()
@@ -235,8 +249,8 @@ function exportCSV(data: typeof allData['30d']) {
   URL.revokeObjectURL(url)
 }
 
-function exportPDF(period: Period, data: typeof allData['30d']) {
-  const doc = new jsPDF()
+function exportPDF(period: Period, data: typeof allData['30d'], JsPDF: JsPDFConstructor) {
+  const doc = new JsPDF()
   const accent = [0, 195, 137] as const
 
   // Header bar
@@ -372,6 +386,8 @@ export default function Analytics() {
   const [goalRate, setGoalRate] = useState('90')
   const [goalCapital, setGoalCapital] = useState('5000')
   const [isLoading] = useState(false)
+  const [isPdfExporting, setIsPdfExporting] = useState(false)
+  const [pdfExportError, setPdfExportError] = useState<string | null>(null)
   const hasData = true
 
   const PERIODS: Period[] = ['7d', '30d', '90d', '1y', 'All']
@@ -397,6 +413,25 @@ export default function Analytics() {
     itemStyle: { color: seriesColors.tooltipText },
     labelStyle: { color: seriesColors.tooltipMuted },
   }), [seriesColors])
+
+  const handleExportPDF = async () => {
+    if (isPdfExporting) {
+      return
+    }
+
+    setIsPdfExporting(true)
+    setPdfExportError(null)
+
+    try {
+      const { default: JsPDF } = await loadJsPDF()
+      exportPDF(period, chartData, JsPDF)
+    } catch (error) {
+      console.error('Failed to export analytics PDF', error)
+      setPdfExportError('PDF export could not load. Please try again.')
+    } finally {
+      setIsPdfExporting(false)
+    }
+  }
 
   return (
     <>
@@ -463,6 +498,15 @@ export default function Analytics() {
           transition: all 0.15s;
         }
         .action-btn:hover { border-color: var(--accent); color: var(--accent); }
+        .action-btn:disabled {
+          cursor: not-allowed;
+          opacity: 0.6;
+        }
+        .pdf-export-error {
+          color: var(--danger);
+          font-size: 0.8rem;
+          line-height: 1.3;
+        }
         input[type="date"] {
           background: var(--surface);
           color: var(--text);
@@ -569,9 +613,19 @@ export default function Analytics() {
           <button className="action-btn" onClick={() => exportCSV(chartData)}>
             <Download size={14} /> CSV
           </button>
-          <button className="action-btn" onClick={() => exportPDF(period, chartData)}>
-            <Download size={14} /> PDF Report
+          <button
+            className="action-btn"
+            onClick={handleExportPDF}
+            disabled={isPdfExporting}
+            aria-describedby={pdfExportError ? 'analytics-pdf-export-error' : undefined}
+          >
+            <Download size={14} /> {isPdfExporting ? 'Preparing PDF...' : 'PDF Report'}
           </button>
+          {pdfExportError && (
+            <span id="analytics-pdf-export-error" className="pdf-export-error" role="alert">
+              {pdfExportError}
+            </span>
+          )}
         </div>
 
         {/* ── SECTION 1: Key Metrics Cards ── */}

--- a/src/pages/__tests__/Analytics.test.tsx
+++ b/src/pages/__tests__/Analytics.test.tsx
@@ -1,8 +1,31 @@
 import React, { Suspense, lazy, act } from 'react'
-import { describe, expect, it, vi, beforeAll } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeAll, beforeEach } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { buildAnalyticsSeriesColors } from '../analyticsTheme'
+
+type ChartContainerProps = React.PropsWithChildren
+
+const pdfMocks = vi.hoisted(() => {
+  const doc = {
+    setFillColor: vi.fn(),
+    rect: vi.fn(),
+    setTextColor: vi.fn(),
+    setFontSize: vi.fn(),
+    setFont: vi.fn(),
+    text: vi.fn(),
+    setDrawColor: vi.fn(),
+    setLineWidth: vi.fn(),
+    line: vi.fn(),
+    save: vi.fn(),
+  }
+
+  return {
+    doc,
+    importDelayMs: 0,
+    constructor: vi.fn(() => doc),
+  }
+})
 
 // ── Browser API stubs (jsdom doesn't implement these) ─────────────────────────
 
@@ -22,13 +45,19 @@ beforeAll(() => {
   })
 })
 
+beforeEach(() => {
+  pdfMocks.importDelayMs = 0
+  pdfMocks.constructor.mockClear()
+  Object.values(pdfMocks.doc).forEach(mock => mock.mockClear())
+})
+
 // ── Heavy dep mocks ───────────────────────────────────────────────────────────
 
 vi.mock('recharts', () => ({
-  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
-  AreaChart: ({ children }: any) => <div>{children}</div>,
-  BarChart: ({ children }: any) => <div>{children}</div>,
-  PieChart: ({ children }: any) => <div>{children}</div>,
+  ResponsiveContainer: ({ children }: ChartContainerProps) => <div>{children}</div>,
+  AreaChart: ({ children }: ChartContainerProps) => <div>{children}</div>,
+  BarChart: ({ children }: ChartContainerProps) => <div>{children}</div>,
+  PieChart: ({ children }: ChartContainerProps) => <div>{children}</div>,
   Area: () => null,
   Bar: () => null,
   Pie: () => null,
@@ -38,20 +67,22 @@ vi.mock('recharts', () => ({
   CartesianGrid: () => null,
   Tooltip: () => null,
   Legend: () => null,
-  LineChart: ({ children }: any) => <div>{children}</div>,
+  LineChart: ({ children }: ChartContainerProps) => <div>{children}</div>,
   Line: () => null,
 }))
 
-vi.mock('jspdf', () => ({
-  default: class {
-    text() {}
-    save() {}
-    addImage() {}
-  },
-}))
+vi.mock('jspdf', async () => {
+  if (pdfMocks.importDelayMs > 0) {
+    await new Promise(resolve => setTimeout(resolve, pdfMocks.importDelayMs))
+  }
+
+  return {
+    default: pdfMocks.constructor,
+  }
+})
 
 vi.mock('../../context/WalletContext', () => ({
-  WalletProvider: ({ children }: any) => <>{children}</>,
+  WalletProvider: ({ children }: ChartContainerProps) => <>{children}</>,
   useWallet: () => ({
     address: null,
     network: null,
@@ -65,9 +96,19 @@ vi.mock('../../context/WalletContext', () => ({
 }))
 
 vi.mock('../../context/ThemeContext', () => ({
-  ThemeProvider: ({ children }: any) => <>{children}</>,
+  ThemeProvider: ({ children }: ChartContainerProps) => <>{children}</>,
   useTheme: () => ({ theme: 'light', toggleTheme: () => {} }),
 }))
+
+async function renderAnalytics() {
+  const { default: Analytics } = await import('../Analytics')
+
+  return render(
+    <MemoryRouter>
+      <Analytics />
+    </MemoryRouter>,
+  )
+}
 
 // ── Theme mapping tests ───────────────────────────────────────────────────────
 
@@ -117,6 +158,48 @@ export const analyticsThemeCoverage = [
   'milestone bars map to --accent',
   'axis/grid/tooltip colors map to neutral surface tokens',
 ]
+
+// ── PDF export tests ─────────────────────────────────────────────────────────
+
+describe('Analytics PDF export', () => {
+  it('disables the PDF export button while jsPDF loads and then saves the report', async () => {
+    pdfMocks.importDelayMs = 25
+
+    await renderAnalytics()
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /pdf report/i }))
+    })
+
+    expect(screen.getByRole('button', { name: /preparing pdf/i })).toBeDisabled()
+
+    await waitFor(() => {
+      expect(pdfMocks.doc.save).toHaveBeenCalledWith('disciplr-report-30d.pdf')
+    })
+    expect(screen.getByRole('button', { name: /pdf report/i })).not.toBeDisabled()
+  })
+
+  it('shows an inline error when PDF export fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    pdfMocks.constructor.mockImplementationOnce(() => {
+      throw new Error('jsPDF failed to load')
+    })
+
+    await renderAnalytics()
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /pdf report/i }))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('PDF export could not load. Please try again.')
+    })
+    expect(pdfMocks.constructor).not.toHaveBeenCalled()
+    expect(pdfMocks.doc.save).not.toHaveBeenCalled()
+
+    consoleError.mockRestore()
+  })
+})
 
 // ── Lazy-route / Suspense tests ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- remove the static `jspdf` import from Analytics and load it on demand from the PDF export handler
- add exporting state, button disabling, and inline failure feedback while preserving the report content
- extend Analytics tests to cover delayed PDF loading and export failure feedback

## Validation
- `npx eslint src/pages/Analytics.tsx src/pages/__tests__/Analytics.test.tsx`
- `npx tsc --noEmit --pretty false --skipLibCheck --jsx react-jsx --moduleResolution bundler --module ESNext --target ES2020 --lib ES2020,DOM,DOM.Iterable --types vitest/globals,@testing-library/jest-dom,react,react-dom src/pages/Analytics.tsx src/pages/__tests__/Analytics.test.tsx`
- `git diff --check`

## Blocked local checks
- `npx vitest run src/pages/__tests__/Analytics.test.tsx` fails before tests run because Vite/esbuild cannot spawn locally: `Error: spawn EPERM`
- `npm run build` fails during the existing `tsc -b` step on unrelated repository-wide test typing errors
- `npx vite build` also fails before bundling because Vite cannot load `vite.config.ts`: `Error: spawn EPERM`

## Chunk delta
I could not measure local bundle sizes because the build is blocked before Rollup emits chunks. The static `jspdf` import is removed from `Analytics.tsx`; the dependency now enters through `import('jspdf')` inside the export handler, so it should leave the initial Analytics chunk and be requested only when PDF export is used.

Closes #209