### PR TITLE
feat: export ValidationHistory CSV

### DIFF
--- a/src/pages/ValidationHistory.tsx
+++ b/src/pages/ValidationHistory.tsx
@@ -2,6 +2,9 @@ import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Text } from '../components/Text';
 import { useVerifierStore } from '../Zustand/Store';
+import type { ValidationTask } from '../Zustand/Store';
+import { toCsv } from '../utils/csv';
+import type { CsvColumn } from '../utils/csv';
 import {
   filterValidationHistory,
   paginate,
@@ -9,6 +12,69 @@ import {
 import type { ValidationHistoryStatusFilter } from '../utils/paginate';
 
 const PAGE_SIZE_OPTIONS = [5, 10, 25];
+const VALIDATION_HISTORY_CSV_FILENAME = 'validation-history.csv';
+
+// Stable audit export order: keep this header sequence append-only unless coordinated.
+const VALIDATION_HISTORY_CSV_COLUMNS: CsvColumn<ValidationTask>[] = [
+  { header: 'ID', value: (task) => task.id },
+  { header: 'Status', value: (task) => task.status },
+  { header: 'Vault Name', value: (task) => task.vaultName },
+  { header: 'Owner', value: (task) => task.owner },
+  { header: 'Amount', value: (task) => task.amount },
+  { header: 'Deadline', value: (task) => task.deadline },
+  { header: 'Milestone', value: (task) => task.milestone },
+  { header: 'Notes', value: (task) => task.notes ?? '' },
+];
+
+interface CsvDownloadAdapter {
+  createBlob: (content: string) => Blob | null;
+  createObjectUrl: (blob: Blob) => string | null;
+  createAnchor: () => HTMLAnchorElement | null;
+  revokeObjectUrl: (url: string) => void;
+}
+
+const browserCsvDownloadAdapter: CsvDownloadAdapter = {
+  createBlob: (content) => (typeof Blob === 'undefined'
+    ? null
+    : new Blob([content], { type: 'text/csv;charset=utf-8' })),
+  createObjectUrl: (blob) => (
+    typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function'
+      ? null
+      : URL.createObjectURL(blob)
+  ),
+  createAnchor: () => (
+    typeof document === 'undefined' || typeof document.createElement !== 'function'
+      ? null
+      : document.createElement('a')
+  ),
+  revokeObjectUrl: (url) => {
+    if (typeof URL !== 'undefined' && typeof URL.revokeObjectURL === 'function') {
+      URL.revokeObjectURL(url);
+    }
+  },
+};
+
+function downloadCsv(content: string, filename: string, adapter = browserCsvDownloadAdapter): boolean {
+  const blob = adapter.createBlob(content);
+  if (!blob) {
+    return false;
+  }
+
+  const url = adapter.createObjectUrl(blob);
+  const anchor = adapter.createAnchor();
+  if (!url || !anchor) {
+    if (url) {
+      adapter.revokeObjectUrl(url);
+    }
+    return false;
+  }
+
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  adapter.revokeObjectUrl(url);
+  return true;
+}
 
 export default function ValidationHistory() {
   const navigate = useNavigate();
@@ -42,6 +108,13 @@ export default function ValidationHistory() {
   const updatePageSize = (size: number) => {
     setPageSize(size);
     setPage(1);
+  };
+
+  const exportFilteredHistory = () => {
+    downloadCsv(
+      toCsv(filteredHistory, VALIDATION_HISTORY_CSV_COLUMNS),
+      VALIDATION_HISTORY_CSV_FILENAME,
+    );
   };
 
   return (
@@ -144,6 +217,22 @@ export default function ValidationHistory() {
             ))}
           </select>
         </label>
+
+        <div className="flex items-end">
+          <button
+            type="button"
+            aria-label="Export filtered validation history as CSV"
+            onClick={exportFilteredHistory}
+            className="px-4 py-2 rounded text-sm font-medium"
+            style={{
+              border: '1px solid var(--border)',
+              color: 'var(--text)',
+              background: 'var(--bg)',
+            }}
+          >
+            Export CSV
+          </button>
+        </div>
       </section>
 
       {/* History Log */}

--- a/src/pages/__tests__/ValidationHistory.test.tsx
+++ b/src/pages/__tests__/ValidationHistory.test.tsx
@@ -178,6 +178,75 @@ describe('ValidationHistory', () => {
     expect(screen.queryByRole('navigation', { name: 'Validation history pagination' })).not.toBeInTheDocument();
   });
 
+  it('exports the full filtered history as CSV instead of only the current page', async () => {
+    let exportedBlob: Blob | null = null;
+    const anchorClick = vi.fn();
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const originalCreateElement = document.createElement.bind(document);
+    const createObjectURL = vi.fn((blob: Blob) => {
+      exportedBlob = blob;
+      return 'blob:validation-history';
+    });
+    const revokeObjectURL = vi.fn();
+    const createElement = vi.spyOn(document, 'createElement').mockImplementation((tagName) => {
+      const element = originalCreateElement(tagName);
+      if (tagName.toLowerCase() === 'a') {
+        Object.defineProperty(element, 'click', { configurable: true, value: anchorClick });
+      }
+      return element;
+    });
+
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL });
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL });
+
+    try {
+      renderHistory();
+
+      fireEvent.change(screen.getByLabelText('Search validation history by vault or owner'), {
+        target: { value: 'gowner' },
+      });
+
+      expect(screen.queryByText('Zeta Treasury')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', {
+        name: 'Export filtered validation history as CSV',
+      }));
+
+      expect(anchorClick).toHaveBeenCalledTimes(1);
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:validation-history');
+      expect(exportedBlob).not.toBeNull();
+
+      const csv = await exportedBlob!.text();
+      expect(csv).toContain('ID,Status,Vault Name,Owner,Amount,Deadline,Milestone,Notes');
+      expect(csv).toContain('Alpha Vault');
+      expect(csv).toContain('Zeta Treasury');
+      expect(csv).toContain('"6,000 USDC"');
+    } finally {
+      createElement.mockRestore();
+      Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL });
+      Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL });
+    }
+  });
+
+  it('does not crash when object URL downloads are unavailable', () => {
+    const originalCreateObjectURL = URL.createObjectURL;
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: undefined });
+
+    try {
+      renderHistory();
+
+      expect(() => {
+        fireEvent.click(screen.getByRole('button', {
+          name: 'Export filtered validation history as CSV',
+        }));
+      }).not.toThrow();
+    } finally {
+      Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL });
+    }
+  });
+
   it('navigates back to the verifier dashboard', () => {
     renderHistory();
 

--- a/src/utils/__tests__/csv.test.ts
+++ b/src/utils/__tests__/csv.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { toCsv } from '../csv';
+import type { CsvColumn } from '../csv';
+
+interface CsvFixture {
+  id: string;
+  name: string;
+  notes?: string;
+}
+
+const columns: CsvColumn<CsvFixture>[] = [
+  { header: 'ID', value: (row) => row.id },
+  { header: 'Name', value: (row) => row.name },
+  { header: 'Notes', value: (row) => row.notes ?? '' },
+];
+
+describe('toCsv', () => {
+  it('returns the stable header row when there are no rows', () => {
+    expect(toCsv([], columns)).toBe('ID,Name,Notes');
+  });
+
+  it('escapes commas, quotes, and newlines in fields', () => {
+    const csv = toCsv([
+      {
+        id: 'v-1',
+        name: 'Alpha, Vault',
+        notes: 'Reviewer said "ship it"\nSecond line',
+      },
+    ], columns);
+
+    expect(csv).toBe('ID,Name,Notes\r\nv-1,"Alpha, Vault","Reviewer said ""ship it""\nSecond line"');
+  });
+
+  it('preserves unicode values without unnecessary quoting', () => {
+    expect(toCsv([
+      {
+        id: 'v-2',
+        name: 'Gamma 基金',
+        notes: 'approved',
+      },
+    ], columns)).toBe('ID,Name,Notes\r\nv-2,Gamma 基金,approved');
+  });
+});

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,25 @@
+export type CsvCell = string | number | boolean | Date | null | undefined;
+
+export interface CsvColumn<T> {
+  header: string;
+  value: (row: T) => CsvCell;
+}
+
+function formatCsvCell(value: CsvCell): string {
+  const text = value instanceof Date ? value.toISOString() : String(value ?? '');
+
+  if (!/[",\r\n]/.test(text)) {
+    return text;
+  }
+
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+export function toCsv<T>(rows: T[], columns: CsvColumn<T>[]): string {
+  const headerRow = columns.map((column) => column.header);
+  const dataRows = rows.map((row) => columns.map((column) => column.value(row)));
+
+  return [headerRow, ...dataRows]
+    .map((row) => row.map(formatCsvCell).join(','))
+    .join('\r\n');
+}


### PR DESCRIPTION
## Summary
- add a reusable `toCsv` helper with RFC-4180 quoting for commas, quotes, and newlines
- add an Export CSV action to ValidationHistory that uses the full active filtered set, not just the current page
- add feature detection around the Blob/object URL/anchor download path so jsdom and unsupported environments do not crash
- cover CSV escaping plus the filtered full-history export behavior

## Validation
- `npx eslint src/pages/ValidationHistory.tsx src/pages/__tests__/ValidationHistory.test.tsx src/utils/csv.ts src/utils/__tests__/csv.test.ts`
- targeted TypeScript check with a temporary tsconfig extending `tsconfig.json` and including only the changed files
- `git diff --cached --check`

## Blocked local checks
- `npx vitest run src/utils/__tests__/csv.test.ts src/pages/__tests__/ValidationHistory.test.tsx` fails before tests run because Vite/esbuild cannot spawn locally: `Error: spawn EPERM`

Closes #179