### PR TITLE
feat: add VerifierMetrics panel

### DIFF
--- a/design-system/documentation/verifier-metrics.md
+++ b/design-system/documentation/verifier-metrics.md
@@ -1,0 +1,28 @@
+# Verifier Metrics
+
+`VerifierMetrics` summarizes verifier workload and outcomes from the existing
+`useVerifierStore` pending and history arrays.
+
+## Metric Definitions
+
+- Approval Rate: approved resolved validations divided by all approved or
+  rejected resolved validations. Empty history returns `0%`.
+- Total Resolved: count of approved plus rejected history records.
+- Urgent Pending: pending validations with `daysRemaining <= 3`.
+- Overdue Pending: pending validations with `daysRemaining <= 0`.
+
+Overdue validations are also urgent by threshold. The current store does not
+include assignment or resolution timestamps, so turnaround time should be added
+only after those fields exist.
+
+## Token Usage
+
+- Cards use `--surface` for background and `--border` for outlines.
+- Approval rate uses `--success`.
+- Total resolved uses `--info`.
+- Urgent pending uses `--warning`.
+- Overdue pending uses `--danger`.
+- Supporting labels use `--muted`.
+
+Each card exposes an `aria-label` with the metric value and detail text so
+screen readers announce the KPI without relying on color alone.

--- a/src/components/VerifierMetrics.tsx
+++ b/src/components/VerifierMetrics.tsx
@@ -1,0 +1,71 @@
+import { Text } from './Text';
+import type { ValidationTask } from '../Zustand/Store';
+import { computeVerifierMetrics } from '../utils/verifierMetrics';
+
+interface VerifierMetricsProps {
+  pendingValidations: ValidationTask[];
+  validationHistory: ValidationTask[];
+}
+
+export function VerifierMetrics({
+  pendingValidations,
+  validationHistory,
+}: VerifierMetricsProps) {
+  const metrics = computeVerifierMetrics(pendingValidations, validationHistory);
+  const cards = [
+    {
+      label: 'Approval Rate',
+      value: `${metrics.approvalRate}%`,
+      detail: `${metrics.approvedResolved} approved of ${metrics.totalResolved} resolved`,
+      color: 'var(--success)',
+    },
+    {
+      label: 'Total Resolved',
+      value: metrics.totalResolved.toString(),
+      detail: `${metrics.rejectedResolved} rejected validations included`,
+      color: 'var(--info)',
+    },
+    {
+      label: 'Urgent Pending',
+      value: metrics.urgentPending.toString(),
+      detail: 'Pending validations due in 3 days or less',
+      color: 'var(--warning)',
+    },
+    {
+      label: 'Overdue Pending',
+      value: metrics.overduePending.toString(),
+      detail: 'Pending validations due today or already past due',
+      color: 'var(--danger)',
+    },
+  ];
+
+  return (
+    <section
+      aria-label="Verifier performance metrics"
+      className="grid grid-cols-1 md:grid-cols-4 gap-4"
+    >
+      {cards.map((card) => (
+        <article
+          key={card.label}
+          aria-label={`${card.label}: ${card.value}. ${card.detail}`}
+          className="p-5 border rounded-lg shadow-sm"
+          style={{
+            background: 'var(--surface)',
+            borderColor: 'var(--border)',
+            borderLeft: `var(--border-width-4) solid ${card.color}`,
+          }}
+        >
+          <Text role="body" as="p" className="mb-2" style={{ color: 'var(--muted)' }}>
+            {card.label}
+          </Text>
+          <Text role="display" as="h2" style={{ color: card.color }}>
+            {card.value}
+          </Text>
+          <Text role="caption" as="p" className="mt-2" style={{ color: 'var(--muted)' }}>
+            {card.detail}
+          </Text>
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/src/components/__tests__/VerifierMetrics.test.tsx
+++ b/src/components/__tests__/VerifierMetrics.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { ValidationTask } from '../../Zustand/Store';
+import { VerifierMetrics } from '../VerifierMetrics';
+
+function task(overrides: Partial<ValidationTask>): ValidationTask {
+  return {
+    id: overrides.id ?? 'v-1',
+    vaultName: overrides.vaultName ?? 'Vault',
+    owner: overrides.owner ?? 'GOWNER',
+    amount: overrides.amount ?? '1,000 USDC',
+    deadline: overrides.deadline ?? '2026-01-01',
+    daysRemaining: overrides.daysRemaining ?? 7,
+    status: overrides.status ?? 'pending',
+    milestone: overrides.milestone ?? 'Milestone',
+    notes: overrides.notes,
+  };
+}
+
+describe('VerifierMetrics', () => {
+  it('renders verifier KPI values with accessible metric labels', () => {
+    render(
+      <VerifierMetrics
+        pendingValidations={[
+          task({ id: 'overdue', daysRemaining: 0 }),
+          task({ id: 'urgent', daysRemaining: 3 }),
+          task({ id: 'later', daysRemaining: 5 }),
+        ]}
+        validationHistory={[
+          task({ id: 'approved-1', status: 'approved' }),
+          task({ id: 'approved-2', status: 'approved' }),
+          task({ id: 'rejected-1', status: 'rejected' }),
+        ]}
+      />,
+    );
+
+    const region = screen.getByRole('region', { name: 'Verifier performance metrics' });
+    expect(within(region).getByLabelText('Approval Rate: 67%. 2 approved of 3 resolved')).toBeInTheDocument();
+    expect(within(region).getByLabelText('Total Resolved: 3. 1 rejected validations included')).toBeInTheDocument();
+    expect(within(region).getByLabelText('Urgent Pending: 2. Pending validations due in 3 days or less')).toBeInTheDocument();
+    expect(within(region).getByLabelText('Overdue Pending: 1. Pending validations due today or already past due')).toBeInTheDocument();
+  });
+
+  it('renders 0% approval rate for empty history', () => {
+    render(<VerifierMetrics pendingValidations={[]} validationHistory={[]} />);
+
+    expect(screen.getByLabelText('Approval Rate: 0%. 0 approved of 0 resolved')).toBeInTheDocument();
+  });
+});

--- a/src/pages/VerifierDashboard.tsx
+++ b/src/pages/VerifierDashboard.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { Text } from '../components/Text';
+import { VerifierMetrics } from '../components/VerifierMetrics';
 import { useVerifierStore } from '../Zustand/Store';
 
 export default function VerifierDashboard() {
@@ -21,6 +22,11 @@ export default function VerifierDashboard() {
           Overview of your assigned vaults and validation activity.
         </Text>
       </header>
+
+      <VerifierMetrics
+        pendingValidations={pendingValidations}
+        validationHistory={validationHistory}
+      />
 
       {/* Overview Stats Cards */}
       <section className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/src/utils/__tests__/verifierMetrics.test.ts
+++ b/src/utils/__tests__/verifierMetrics.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { ValidationTask } from '../../Zustand/Store';
+import { computeVerifierMetrics } from '../verifierMetrics';
+
+function task(overrides: Partial<ValidationTask>): ValidationTask {
+  return {
+    id: overrides.id ?? 'v-1',
+    vaultName: overrides.vaultName ?? 'Vault',
+    owner: overrides.owner ?? 'GOWNER',
+    amount: overrides.amount ?? '1,000 USDC',
+    deadline: overrides.deadline ?? '2026-01-01',
+    daysRemaining: overrides.daysRemaining ?? 7,
+    status: overrides.status ?? 'pending',
+    milestone: overrides.milestone ?? 'Milestone',
+    notes: overrides.notes,
+  };
+}
+
+describe('computeVerifierMetrics', () => {
+  it('returns zero approval rate when there is no resolved history', () => {
+    expect(computeVerifierMetrics([], [])).toMatchObject({
+      approvalRate: 0,
+      totalResolved: 0,
+      approvedResolved: 0,
+      rejectedResolved: 0,
+    });
+  });
+
+  it('returns 100% approval rate when every resolved validation is approved', () => {
+    const history = [
+      task({ id: 'approved-1', status: 'approved' }),
+      task({ id: 'approved-2', status: 'approved' }),
+    ];
+
+    expect(computeVerifierMetrics([], history)).toMatchObject({
+      approvalRate: 100,
+      totalResolved: 2,
+      approvedResolved: 2,
+      rejectedResolved: 0,
+    });
+  });
+
+  it('rounds mixed approval rates from approved and rejected history', () => {
+    const history = [
+      task({ id: 'approved-1', status: 'approved' }),
+      task({ id: 'approved-2', status: 'approved' }),
+      task({ id: 'rejected-1', status: 'rejected' }),
+    ];
+
+    expect(computeVerifierMetrics([], history)).toMatchObject({
+      approvalRate: 67,
+      totalResolved: 3,
+      approvedResolved: 2,
+      rejectedResolved: 1,
+    });
+  });
+
+  it('counts urgent and overdue pending threshold boundaries', () => {
+    const pending = [
+      task({ id: 'overdue', daysRemaining: -1 }),
+      task({ id: 'due-today', daysRemaining: 0 }),
+      task({ id: 'urgent', daysRemaining: 3 }),
+      task({ id: 'normal', daysRemaining: 4 }),
+    ];
+
+    expect(computeVerifierMetrics(pending, [])).toMatchObject({
+      urgentPending: 3,
+      overduePending: 2,
+    });
+  });
+});

--- a/src/utils/verifierMetrics.ts
+++ b/src/utils/verifierMetrics.ts
@@ -1,0 +1,31 @@
+import type { ValidationTask } from '../Zustand/Store';
+
+export interface VerifierMetricsSummary {
+  approvalRate: number;
+  approvedResolved: number;
+  rejectedResolved: number;
+  totalResolved: number;
+  overduePending: number;
+  urgentPending: number;
+}
+
+export function computeVerifierMetrics(
+  pending: ValidationTask[],
+  history: ValidationTask[],
+): VerifierMetricsSummary {
+  const approvedResolved = history.filter((task) => task.status === 'approved').length;
+  const rejectedResolved = history.filter((task) => task.status === 'rejected').length;
+  const totalResolved = approvedResolved + rejectedResolved;
+  const approvalRate = totalResolved === 0
+    ? 0
+    : Math.round((approvedResolved / totalResolved) * 100);
+
+  return {
+    approvalRate,
+    approvedResolved,
+    rejectedResolved,
+    totalResolved,
+    overduePending: pending.filter((task) => task.daysRemaining <= 0).length,
+    urgentPending: pending.filter((task) => task.daysRemaining <= 3).length,
+  };
+}


### PR DESCRIPTION
## Summary
- add `computeVerifierMetrics(pending, history)` for approval rate, resolved totals, urgent pending, and overdue pending counts
- add a token-styled `VerifierMetrics` card panel above the existing verifier dashboard summary cards
- document the metric definitions and token mapping, including that turnaround time needs future timestamp fields
- add unit and RTL coverage for metrics calculations and accessible card labels

## Validation
- `npx eslint src/utils/verifierMetrics.ts src/utils/__tests__/verifierMetrics.test.ts src/components/VerifierMetrics.tsx src/components/__tests__/VerifierMetrics.test.tsx src/pages/VerifierDashboard.tsx`
- targeted TypeScript check with a temporary tsconfig extending `tsconfig.json` and including only the changed files
- `git diff --cached --check`

## Blocked local checks
- `npx vitest run src/utils/__tests__/verifierMetrics.test.ts src/components/__tests__/VerifierMetrics.test.tsx` fails before tests run because Vite/esbuild cannot spawn locally: `Error: spawn EPERM`

Closes #180