### PR TITLE
feat: add shared StatusChip

### DIFF
--- a/design-system/documentation/status-chip.md
+++ b/design-system/documentation/status-chip.md
@@ -1,0 +1,32 @@
+# Status Chip
+
+`StatusChip` renders a presentational, non-focusable status label for vault and
+validation states. It centralizes the status-to-token mapping used by vault
+cards, vault lists, pending validations, and validation history.
+
+## Status Mapping
+
+| Status | Default label | Token |
+| --- | --- | --- |
+| `active` | Active | `--accent` |
+| `pending_validation` | Pending Validation | `--warning` |
+| `completed` | Completed | `--success` |
+| `failed` | Failed | `--danger` |
+| `cancelled` | Cancelled | `--muted` |
+| `approved` | Approved | `--success` |
+| `rejected` | Rejected | `--danger` |
+
+Backgrounds use `color-mix()` with the same semantic token so light and dark
+themes inherit the existing palette. Unknown runtime statuses fall back to the
+muted token and the `Unknown` label.
+
+## Sizing And Labels
+
+- `size="md"` is the default list/table chip size.
+- `size="sm"` is used in compact card or row metadata.
+- A `label` override can preserve legacy visible labels while retaining the
+shared semantic token mapping. For example, compact vault cards keep the
+existing `Pending` label for `pending_validation`.
+
+Each chip exposes `aria-label="Status: <label>"`, so the status is announced as
+text and never depends on color alone.

--- a/src/components/StatusChip.tsx
+++ b/src/components/StatusChip.tsx
@@ -1,0 +1,111 @@
+import type { CSSProperties } from 'react';
+
+export type StatusChipStatus =
+  | 'active'
+  | 'pending_validation'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'approved'
+  | 'rejected';
+
+export type StatusChipSize = 'sm' | 'md';
+
+interface StatusChipConfig {
+  label: string;
+  color: string;
+  background: string;
+}
+
+const STATUS_CHIP_CONFIG: Record<StatusChipStatus, StatusChipConfig> = {
+  active: {
+    label: 'Active',
+    color: 'var(--accent)',
+    background: 'color-mix(in srgb, var(--accent) 14%, transparent)',
+  },
+  pending_validation: {
+    label: 'Pending Validation',
+    color: 'var(--warning)',
+    background: 'color-mix(in srgb, var(--warning) 16%, transparent)',
+  },
+  completed: {
+    label: 'Completed',
+    color: 'var(--success)',
+    background: 'color-mix(in srgb, var(--success) 14%, transparent)',
+  },
+  failed: {
+    label: 'Failed',
+    color: 'var(--danger)',
+    background: 'color-mix(in srgb, var(--danger) 14%, transparent)',
+  },
+  cancelled: {
+    label: 'Cancelled',
+    color: 'var(--muted)',
+    background: 'color-mix(in srgb, var(--muted) 14%, transparent)',
+  },
+  approved: {
+    label: 'Approved',
+    color: 'var(--success)',
+    background: 'color-mix(in srgb, var(--success) 14%, transparent)',
+  },
+  rejected: {
+    label: 'Rejected',
+    color: 'var(--danger)',
+    background: 'color-mix(in srgb, var(--danger) 14%, transparent)',
+  },
+};
+
+const UNKNOWN_STATUS_CONFIG: StatusChipConfig = {
+  label: 'Unknown',
+  color: 'var(--muted)',
+  background: 'color-mix(in srgb, var(--muted) 14%, transparent)',
+};
+
+const STATUS_CHIP_SIZE_STYLES: Record<StatusChipSize, CSSProperties> = {
+  sm: {
+    padding: '2px 8px',
+    fontSize: 11,
+  },
+  md: {
+    padding: '2px 10px',
+    fontSize: 12,
+  },
+};
+
+interface StatusChipProps {
+  status: StatusChipStatus;
+  size?: StatusChipSize;
+  label?: string;
+  className?: string;
+}
+
+export function StatusChip({
+  status,
+  size = 'md',
+  label,
+  className,
+}: StatusChipProps) {
+  const config = STATUS_CHIP_CONFIG[status] ?? UNKNOWN_STATUS_CONFIG;
+  const visibleLabel = label ?? config.label;
+
+  return (
+    <span
+      className={className}
+      aria-label={`Status: ${visibleLabel}`}
+      style={{
+        background: config.background,
+        color: config.color,
+        border: `var(--border-width-1) solid ${config.color}`,
+        borderRadius: 'var(--radius-full)',
+        fontWeight: 600,
+        whiteSpace: 'nowrap',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+        ...STATUS_CHIP_SIZE_STYLES[size],
+      }}
+    >
+      {visibleLabel}
+    </span>
+  );
+}

--- a/src/components/VaultCard.tsx
+++ b/src/components/VaultCard.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router-dom';
+import { CountdownDeadline } from './CountdownDeadline';
+import { StatusChip } from './StatusChip';
 import { Text } from './Text';
 import { VaultProgressBar } from './VaultProgressBar';
-import React from 'react';
-import { CountdownDeadline } from './CountdownDeadline';
 
 export type VaultStatus = 'active' | 'pending_validation' | 'completed' | 'failed';
 
@@ -15,35 +15,6 @@ export interface VaultCardProps {
   deadline: string;
   progressPct: number;
   linkTo?: string;
-}
-
-function StatusBadge({ status }: { status: VaultStatus }) {
-  const config = {
-    active: { label: 'Active', bg: 'var(--accent-transparent)', fg: 'var(--accent)' },
-    pending_validation: { label: 'Pending', bg: 'var(--warning-transparent)', fg: 'var(--warning)' },
-    completed: { label: 'Completed', bg: 'var(--success-transparent)', fg: 'var(--success)' },
-    failed: { label: 'Failed', bg: 'var(--danger-transparent)', fg: 'var(--danger)' },
-  }[status];
-
-  return (
-    <span
-      style={{
-        background: config.bg,
-        color: config.fg,
-        border: `1px solid ${config.fg}`,
-        borderRadius: 'var(--radius-full)',
-        padding: '2px 8px',
-        fontSize: 11,
-        fontWeight: 600,
-        whiteSpace: 'nowrap',
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 4,
-      }}
-    >
-      {config.label}
-    </span>
-  );
 }
 
 export default function VaultCard({
@@ -86,7 +57,11 @@ export default function VaultCard({
           </Text>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <StatusBadge status={status} />
+          <StatusChip
+            status={status}
+            size="sm"
+            label={status === 'pending_validation' ? 'Pending' : undefined}
+          />
         </div>
         <div style={{ gridColumn: '1 / -1' }}>
           <VaultProgressBar value={progressPct} label={`${name} progress`} />

--- a/src/components/__tests__/StatusChip.test.tsx
+++ b/src/components/__tests__/StatusChip.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { StatusChip } from '../StatusChip';
+import type { StatusChipStatus } from '../StatusChip';
+
+const statusCases: Array<[StatusChipStatus, string, string]> = [
+  ['active', 'Active', 'var(--accent)'],
+  ['pending_validation', 'Pending Validation', 'var(--warning)'],
+  ['completed', 'Completed', 'var(--success)'],
+  ['failed', 'Failed', 'var(--danger)'],
+  ['cancelled', 'Cancelled', 'var(--muted)'],
+  ['approved', 'Approved', 'var(--success)'],
+  ['rejected', 'Rejected', 'var(--danger)'],
+];
+
+describe('StatusChip', () => {
+  it.each(statusCases)('renders %s with its label and semantic token', (status, label, color) => {
+    render(<StatusChip status={status} />);
+
+    const chip = screen.getByLabelText(`Status: ${label}`);
+    expect(chip).toHaveTextContent(label);
+    expect(chip).toHaveStyle({ color });
+  });
+
+  it('supports the compact size variant', () => {
+    render(<StatusChip status="active" size="sm" />);
+
+    expect(screen.getByLabelText('Status: Active')).toHaveStyle({
+      padding: '2px 8px',
+      fontSize: '11px',
+    });
+  });
+
+  it('allows legacy labels while keeping status token styling', () => {
+    render(<StatusChip status="pending_validation" label="Pending" />);
+
+    const chip = screen.getByLabelText('Status: Pending');
+    expect(chip).toHaveTextContent('Pending');
+    expect(chip).toHaveStyle({ color: 'var(--warning)' });
+  });
+
+  it('falls back for unexpected runtime statuses', () => {
+    render(<StatusChip status={'archived' as StatusChipStatus} />);
+
+    const chip = screen.getByLabelText('Status: Unknown');
+    expect(chip).toHaveTextContent('Unknown');
+    expect(chip).toHaveStyle({ color: 'var(--muted)' });
+  });
+});

--- a/src/pages/PendingValidations.tsx
+++ b/src/pages/PendingValidations.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CountdownDeadline } from '../components/CountdownDeadline';
+import { StatusChip } from '../components/StatusChip';
 import { Text } from '../components/Text';
 import { useVerifierStore } from '../Zustand/Store';
 
@@ -64,6 +65,9 @@ export default function PendingValidations() {
                   <td className="p-4">
                     <Text role="body" as="p" className="font-semibold text-gray-800">{task.vaultName}</Text>
                     <Text role="body" as="p" className="text-sm text-gray-500 mt-1">{task.milestone}</Text>
+                    <div className="mt-2">
+                      <StatusChip status="pending_validation" size="sm" label="Pending" />
+                    </div>
                   </td>
                   <td className="p-4">
                     <span className="bg-gray-100 text-gray-700 text-xs px-2 py-1 rounded font-mono">

--- a/src/pages/ValidationHistory.tsx
+++ b/src/pages/ValidationHistory.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { StatusChip } from '../components/StatusChip';
 import { Text } from '../components/Text';
 import { useVerifierStore } from '../Zustand/Store';
 import {
@@ -173,18 +174,12 @@ export default function ValidationHistory() {
               >
                 <div className="flex flex-col gap-2 md:w-1/3">
                   <div className="flex items-center gap-3">
-                    <span
-                      className="px-2 py-1 rounded text-xs font-bold uppercase"
-                      style={{
-                        color: task.status === 'approved' ? 'var(--success)' : 'var(--danger)',
-                        border: `1px solid ${task.status === 'approved' ? 'var(--success)' : 'var(--danger)'}`,
-                        background: task.status === 'approved'
-                          ? 'var(--success-transparent)'
-                          : 'var(--danger-transparent)',
-                      }}
-                    >
-                      {task.status}
-                    </span>
+                    <StatusChip
+                      status={task.status === 'pending' ? 'pending_validation' : task.status}
+                      size="sm"
+                      label={task.status}
+                      className="uppercase"
+                    />
                     <Text role="body" as="span" className="text-sm" style={{ color: 'var(--muted)' }}>
                       ID: {task.id}
                     </Text>

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { StatusChip } from '../components/StatusChip'
 import { Text } from '../components/Text'
 
 type VaultStatus = 'active' | 'completed' | 'failed' | 'cancelled' | 'pending_validation'
@@ -8,14 +9,6 @@ const MOCK_VAULTS = [
   { id: '2', name: 'Beta Reserve',  amount: 4200.5, currency: 'USDC', status: 'completed' as VaultStatus, deadline: '2024-01-01T09:00:00Z' },
   { id: '3', name: 'Gamma Fund',    amount: 8800,   currency: 'USDC', status: 'failed' as VaultStatus,    deadline: '2023-12-01T08:00:00Z' },
 ]
-
-const STATUS_CONFIG: Record<VaultStatus, { label: string; color: string; bg: string }> = {
-  active:             { label: 'Active',             color: 'var(--accent)',  bg: 'var(--accent-transparent)' },
-  completed:          { label: 'Completed',          color: 'var(--success)', bg: 'rgba(16,185,129,0.1)' },
-  failed:             { label: 'Failed',             color: 'var(--danger)',  bg: 'rgba(239,68,68,0.1)' },
-  cancelled:          { label: 'Cancelled',          color: 'var(--muted)',   bg: 'rgba(156,163,175,0.1)' },
-  pending_validation: { label: 'Pending Validation', color: 'var(--warning)', bg: 'rgba(245,158,11,0.1)' },
-}
 
 export default function Vaults() {
   return (
@@ -42,7 +35,6 @@ export default function Vaults() {
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
         {MOCK_VAULTS.map((vault) => {
-          const cfg = STATUS_CONFIG[vault.status]
           return (
             <Link
               key={vault.id}
@@ -70,13 +62,7 @@ export default function Vaults() {
                   <Text role="body" as="span" style={{ fontWeight: 700, color: 'var(--accent)' }}>
                     {vault.amount.toLocaleString()} {vault.currency}
                   </Text>
-                  <span style={{
-                    background: cfg.bg, color: cfg.color,
-                    border: `var(--border-width-1) solid ${cfg.color}`,
-                    borderRadius: 'var(--radius-full)', padding: '2px 10px', fontSize: 12, fontWeight: 600,
-                  }}>
-                    {cfg.label}
-                  </span>
+                  <StatusChip status={vault.status} />
                 </div>
               </div>
             </Link>


### PR DESCRIPTION
## Summary
- add a shared `StatusChip` component with semantic-token mapping for vault and validation statuses
- refactor VaultCard, Vaults, PendingValidations, and ValidationHistory to use the shared chip
- preserve existing visible labels through explicit label overrides where current screens differed
- document the status/token mapping and add coverage for statuses, size variants, legacy labels, and unknown runtime fallback

## Validation
- `npx eslint src/components/StatusChip.tsx src/components/__tests__/StatusChip.test.tsx src/components/VaultCard.tsx src/pages/Vaults.tsx src/pages/PendingValidations.tsx src/pages/ValidationHistory.tsx`
- targeted TypeScript check with a temporary tsconfig extending `tsconfig.json`, including `src/vite-env.d.ts` and only the changed TS/TSX files
- `git diff --check`

## Blocked local checks
- `npx vitest run src/components/__tests__/StatusChip.test.tsx` fails before tests run because Vite/esbuild cannot spawn locally: `Error: spawn EPERM`

Closes #181