### PR TITLE
feat: add global ErrorBoundary

### DIFF
--- a/design-system/documentation/error-boundary.md
+++ b/design-system/documentation/error-boundary.md
@@ -1,0 +1,37 @@
+# Error Boundary
+
+`ErrorBoundary` is a class-based render error boundary for route and feature
+subtrees. The app wraps the `Routes` tree with it so a page-level render error
+does not leave the shell blank.
+
+## Behavior
+
+- Implements `getDerivedStateFromError` to show the fallback after a render
+  exception.
+- Implements `componentDidCatch` and accepts an injectable `reporter(error,
+  errorInfo)` callback for tests or telemetry.
+- `Try again` clears the boundary state, allowing the current subtree to render
+  again after the underlying error is resolved.
+- `Go Home` links to `/` for route recovery.
+
+## Fallback Tokens
+
+- Background: `--surface`
+- Border: `--border`
+- Body text: `--text`
+- Supporting copy: `--muted`
+- Primary reset action: `--accent` on `--bg`
+
+The fallback uses `role="alert"` and `aria-live="assertive"` so screen readers
+announce the recovery state when an error is caught.
+
+## Usage
+
+```tsx
+<ErrorBoundary reporter={reportRenderError}>
+  <Routes>{/* route tree */}</Routes>
+</ErrorBoundary>
+```
+
+Wrap narrower subtrees the same way when a feature needs isolated recovery
+without resetting the entire route area.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { WalletProvider } from './context/WalletContext'
 import { ThemeProvider } from './context/ThemeContext'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import Layout from './components/Layout'
 import Skeleton from './components/Skeleton'
 
@@ -30,42 +31,44 @@ export default function App() {
       <WalletProvider>
         <BrowserRouter>
           <Layout>
-            <Routes>
-              {/* Critical paths */}
-              <Route path="/" element={<Home />} />
-              <Route path="/dashboard" element={<Dashboard />} />
-              <Route path="/vaults" element={<Vaults />} />
-              <Route path="/vaults/create" element={<CreateVault />} />
-              <Route path="/vaults/:id" element={<VaultDetail />} />
-              <Route path="/vaults/:id/transactions" element={<VaultTransactions />} />
-              <Route path="/transactions" element={<VaultTransactions />} />
+            <ErrorBoundary>
+              <Routes>
+                {/* Critical paths */}
+                <Route path="/" element={<Home />} />
+                <Route path="/dashboard" element={<Dashboard />} />
+                <Route path="/vaults" element={<Vaults />} />
+                <Route path="/vaults/create" element={<CreateVault />} />
+                <Route path="/vaults/:id" element={<VaultDetail />} />
+                <Route path="/vaults/:id/transactions" element={<VaultTransactions />} />
+                <Route path="/transactions" element={<VaultTransactions />} />
 
-              {/* Verifier routes */}
-              <Route path="/verifier" element={<VerifierDashboard />} />
-              <Route path="/verifier/queue" element={<PendingValidations />} />
-              <Route path="/verifier/queue/:vaultId" element={<ValidationDetail />} />
-              <Route path="/verifier/history" element={<ValidationHistory />} />
+                {/* Verifier routes */}
+                <Route path="/verifier" element={<VerifierDashboard />} />
+                <Route path="/verifier/queue" element={<PendingValidations />} />
+                <Route path="/verifier/queue/:vaultId" element={<ValidationDetail />} />
+                <Route path="/verifier/history" element={<ValidationHistory />} />
 
-              {/* Lazy-loaded heavy routes */}
-              <Route
-                path="/analytics"
-                element={
-                  <Suspense fallback={PageFallback}>
-                    <Analytics />
-                  </Suspense>
-                }
-              />
-              <Route
-                path="/notifications"
-                element={
-                  <Suspense fallback={PageFallback}>
-                    <Notification />
-                  </Suspense>
-                }
-              />
+                {/* Lazy-loaded heavy routes */}
+                <Route
+                  path="/analytics"
+                  element={
+                    <Suspense fallback={PageFallback}>
+                      <Analytics />
+                    </Suspense>
+                  }
+                />
+                <Route
+                  path="/notifications"
+                  element={
+                    <Suspense fallback={PageFallback}>
+                      <Notification />
+                    </Suspense>
+                  }
+                />
 
-              <Route path="*" element={<NotFound />} />
-            </Routes>
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </ErrorBoundary>
           </Layout>
         </BrowserRouter>
       </WalletProvider>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,91 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { Text } from './Text';
+
+export type ErrorBoundaryReporter = (error: Error, errorInfo: ErrorInfo) => void;
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  reporter?: ErrorBoundaryReporter;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+const defaultReporter: ErrorBoundaryReporter = (error, errorInfo) => {
+  console.error('Uncaught render error', error, errorInfo);
+};
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {
+    error: null,
+  };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    const reporter = this.props.reporter ?? defaultReporter;
+    reporter(error, errorInfo);
+  }
+
+  private reset = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+
+    return (
+      <section
+        role="alert"
+        aria-live="assertive"
+        className="m-6 p-6 border rounded-lg shadow-sm"
+        style={{
+          background: 'var(--surface)',
+          borderColor: 'var(--border)',
+          color: 'var(--text)',
+        }}
+      >
+        <Text role="display" as="h1" style={{ marginBottom: '0.75rem' }}>
+          Something went wrong
+        </Text>
+        <Text role="body" as="p" style={{ color: 'var(--muted)', maxWidth: 560 }}>
+          The page hit an unexpected rendering error. You can retry the current
+          view or return home.
+        </Text>
+        <div className="flex flex-wrap gap-3 mt-6">
+          <button
+            type="button"
+            onClick={this.reset}
+            className="px-4 py-2 rounded font-medium"
+            style={{
+              background: 'var(--accent)',
+              color: 'var(--bg)',
+              border: '1px solid var(--accent)',
+            }}
+          >
+            Try again
+          </button>
+          <Link
+            to="/"
+            className="px-4 py-2 rounded font-medium"
+            style={{
+              background: 'var(--surface)',
+              color: 'var(--text)',
+              border: '1px solid var(--border)',
+              textDecoration: 'none',
+            }}
+          >
+            Go Home
+          </Link>
+        </div>
+      </section>
+    );
+  }
+}

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+function ProblemChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('route exploded');
+  }
+
+  return <div>Recovered route</div>;
+}
+
+function NestedShell({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders an accessible fallback and reports render errors', () => {
+    const reporter = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <ErrorBoundary reporter={reporter}>
+          <ProblemChild shouldThrow />
+        </ErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong');
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go Home' })).toHaveAttribute('href', '/');
+    expect(reporter).toHaveBeenCalledTimes(1);
+    expect(reporter.mock.calls[0][0]).toHaveProperty('message', 'route exploded');
+    expect(reporter.mock.calls[0][1].componentStack).toContain('ProblemChild');
+  });
+
+  it('resets boundary state so recovered children can render', () => {
+    const reporter = vi.fn();
+    const { rerender } = render(
+      <MemoryRouter>
+        <ErrorBoundary reporter={reporter}>
+          <ProblemChild shouldThrow />
+        </ErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    rerender(
+      <MemoryRouter>
+        <ErrorBoundary reporter={reporter}>
+          <ProblemChild shouldThrow={false} />
+        </ErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+
+    expect(screen.getByText('Recovered route')).toBeInTheDocument();
+  });
+
+  it('catches nested render errors', () => {
+    render(
+      <MemoryRouter>
+        <ErrorBoundary reporter={vi.fn()}>
+          <NestedShell>
+            <ProblemChild shouldThrow />
+          </NestedShell>
+        </ErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('unexpected rendering error');
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable class-based `ErrorBoundary` with `getDerivedStateFromError`, `componentDidCatch`, and injectable reporting
- render a token-styled accessible fallback with Try again reset and a Home link
- wrap the App routes tree without changing the existing lazy route Suspense boundaries
- document usage and add RTL coverage for reporting, reset recovery, Home link, and nested render errors

## Validation
- `npx eslint src/App.tsx src/components/ErrorBoundary.tsx src/components/__tests__/ErrorBoundary.test.tsx`
- targeted TypeScript check with a temporary tsconfig extending `tsconfig.json`, including only the changed files, with `noUnusedLocals` disabled to avoid unrelated existing imported-file unused warnings from the App tree
- `git diff --check`

## Blocked local checks
- `npx vitest run src/components/__tests__/ErrorBoundary.test.tsx` fails before tests run because Vite/esbuild cannot spawn locally: `Error: spawn EPERM`

Closes #183