### PR TITLE
feat: add Vaults list filtering

### DIFF
--- a/design-system/documentation/vaults-filtering.md
+++ b/design-system/documentation/vaults-filtering.md
@@ -1,0 +1,23 @@
+# Vaults filtering
+
+The Vaults list exposes a compact toolbar for status filtering, name search, and deterministic sorting.
+
+## Helper API
+
+Use `filterVaults(vaults, { status, query })` for pure list filtering:
+
+- `status` accepts `all`, `active`, `pending_validation`, `completed`, `failed`, or `cancelled`.
+- `query` is trimmed and matched case-insensitively against the vault name.
+- The helper returns a new filtered list and does not mutate the source array.
+
+Use `sortVaults(vaults, { by, dir })` for pure list sorting:
+
+- `by` accepts `deadline` or `amount`.
+- `dir` accepts `asc` or `desc`.
+- Ties keep the original order so repeated renders remain stable.
+
+## UI rules
+
+- Status filters are native buttons with `aria-pressed`, so mouse, touch, and keyboard activation share the same behavior.
+- Empty results use semantic design tokens for the surface, border, and muted copy.
+- Vault row links keep the `/vaults/:id` target so existing navigation behavior remains unchanged.

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -1,23 +1,48 @@
+import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Text } from '../components/Text'
+import { filterVaults, sortVaults } from '../utils/vaultFilter'
+import type { VaultListItem, VaultSortOptions, VaultStatusFilter } from '../utils/vaultFilter'
 
-type VaultStatus = 'active' | 'completed' | 'failed' | 'cancelled' | 'pending_validation'
-
-const MOCK_VAULTS = [
-  { id: '1', name: 'Alpha Vault',   amount: 12500,  currency: 'USDC', status: 'active' as VaultStatus,    deadline: '2024-07-15T10:00:00Z' },
-  { id: '2', name: 'Beta Reserve',  amount: 4200.5, currency: 'USDC', status: 'completed' as VaultStatus, deadline: '2024-01-01T09:00:00Z' },
-  { id: '3', name: 'Gamma Fund',    amount: 8800,   currency: 'USDC', status: 'failed' as VaultStatus,    deadline: '2023-12-01T08:00:00Z' },
+const MOCK_VAULTS: VaultListItem[] = [
+  { id: '1', name: 'Alpha Vault',   amount: 12500,  currency: 'USDC', status: 'active',    deadline: '2024-07-15T10:00:00Z' },
+  { id: '2', name: 'Beta Reserve',  amount: 4200.5, currency: 'USDC', status: 'completed', deadline: '2024-01-01T09:00:00Z' },
+  { id: '3', name: 'Gamma Fund',    amount: 8800,   currency: 'USDC', status: 'failed',    deadline: '2023-12-01T08:00:00Z' },
 ]
 
+type VaultStatus = VaultListItem['status']
+type VaultSortValue = 'deadline-asc' | 'amount-desc'
+
 const STATUS_CONFIG: Record<VaultStatus, { label: string; color: string; bg: string }> = {
-  active:             { label: 'Active',             color: 'var(--accent)',  bg: 'var(--accent-transparent)' },
-  completed:          { label: 'Completed',          color: 'var(--success)', bg: 'rgba(16,185,129,0.1)' },
-  failed:             { label: 'Failed',             color: 'var(--danger)',  bg: 'rgba(239,68,68,0.1)' },
-  cancelled:          { label: 'Cancelled',          color: 'var(--muted)',   bg: 'rgba(156,163,175,0.1)' },
-  pending_validation: { label: 'Pending Validation', color: 'var(--warning)', bg: 'rgba(245,158,11,0.1)' },
+  active:             { label: 'Active',             color: 'var(--accent)',  bg: 'color-mix(in srgb, var(--accent) 14%, transparent)' },
+  completed:          { label: 'Completed',          color: 'var(--success)', bg: 'color-mix(in srgb, var(--success) 14%, transparent)' },
+  failed:             { label: 'Failed',             color: 'var(--danger)',  bg: 'color-mix(in srgb, var(--danger) 14%, transparent)' },
+  cancelled:          { label: 'Cancelled',          color: 'var(--muted)',   bg: 'color-mix(in srgb, var(--muted) 14%, transparent)' },
+  pending_validation: { label: 'Pending Validation', color: 'var(--warning)', bg: 'color-mix(in srgb, var(--warning) 16%, transparent)' },
+}
+
+const STATUS_FILTERS: Array<{ value: VaultStatusFilter; label: string; color: string; bg: string }> = [
+  { value: 'all', label: 'All', color: 'var(--accent)', bg: 'color-mix(in srgb, var(--accent) 14%, transparent)' },
+  { value: 'active', ...STATUS_CONFIG.active },
+  { value: 'pending_validation', ...STATUS_CONFIG.pending_validation },
+  { value: 'completed', ...STATUS_CONFIG.completed },
+  { value: 'failed', ...STATUS_CONFIG.failed },
+]
+
+const SORT_OPTIONS: Record<VaultSortValue, VaultSortOptions> = {
+  'deadline-asc': { by: 'deadline', dir: 'asc' },
+  'amount-desc': { by: 'amount', dir: 'desc' },
 }
 
 export default function Vaults() {
+  const [statusFilter, setStatusFilter] = useState<VaultStatusFilter>('all')
+  const [query, setQuery] = useState('')
+  const [sortValue, setSortValue] = useState<VaultSortValue>('deadline-asc')
+  const visibleVaults = useMemo(() => {
+    const filtered = filterVaults(MOCK_VAULTS, { status: statusFilter, query })
+    return sortVaults(filtered, SORT_OPTIONS[sortValue])
+  }, [query, sortValue, statusFilter])
+
   return (
     <div>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2rem', flexWrap: 'wrap', gap: '1rem' }}>
@@ -40,14 +65,106 @@ export default function Vaults() {
         </Link>
       </div>
 
+      <section
+        aria-label="Vault filters"
+        style={{
+          background: 'var(--surface)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius)',
+          padding: '1rem',
+          marginBottom: '1rem',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '0.75rem',
+          alignItems: 'end',
+        }}
+      >
+        <div role="group" aria-label="Filter vaults by status" style={{ display: 'flex', gap: '0.4rem', flexWrap: 'wrap' }}>
+          {STATUS_FILTERS.map((filter) => {
+            const selected = statusFilter === filter.value
+            return (
+              <button
+                key={filter.value}
+                type="button"
+                aria-pressed={selected}
+                onClick={() => setStatusFilter(filter.value)}
+                style={{
+                  background: selected ? filter.bg : 'var(--surface)',
+                  color: selected ? filter.color : 'var(--text)',
+                  border: `1px solid ${selected ? filter.color : 'var(--border)'}`,
+                  borderRadius: 'var(--radius-full)',
+                  padding: '0.35rem 0.75rem',
+                  fontSize: 13,
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                }}
+              >
+                {filter.label}
+              </button>
+            )
+          })}
+        </div>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem', minWidth: 220, flex: '1 1 220px' }}>
+          <Text role="caption" as="span" style={{ color: 'var(--muted)' }}>Search by name</Text>
+          <input
+            aria-label="Search vaults by name"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search vaults"
+            style={{
+              background: 'var(--bg)',
+              color: 'var(--text)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: '0.55rem 0.75rem',
+            }}
+          />
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+          <Text role="caption" as="span" style={{ color: 'var(--muted)' }}>Sort</Text>
+          <select
+            aria-label="Sort vaults"
+            value={sortValue}
+            onChange={(event) => setSortValue(event.target.value as VaultSortValue)}
+            style={{
+              background: 'var(--bg)',
+              color: 'var(--text)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: '0.55rem 0.75rem',
+            }}
+          >
+            <option value="deadline-asc">Deadline soonest</option>
+            <option value="amount-desc">Amount highest</option>
+          </select>
+        </label>
+      </section>
+
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-        {MOCK_VAULTS.map((vault) => {
+        {visibleVaults.length === 0 ? (
+          <div
+            role="status"
+            style={{
+              background: 'var(--surface)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              color: 'var(--muted)',
+              padding: '2rem',
+              textAlign: 'center',
+            }}
+          >
+            No vaults match your filters.
+          </div>
+        ) : visibleVaults.map((vault) => {
           const cfg = STATUS_CONFIG[vault.status]
           return (
             <Link
               key={vault.id}
               to={`/vaults/${vault.id}`}
               style={{ textDecoration: 'none', color: 'inherit' }}
+              data-testid="vault-row"
             >
               <div style={{
                 background: 'var(--surface)', border: '1px solid var(--border)',

--- a/src/pages/__tests__/Vaults.test.tsx
+++ b/src/pages/__tests__/Vaults.test.tsx
@@ -1,46 +1,69 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { vi } from 'vitest';
-import Vaults from '../../pages/Vaults';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import Vaults from '../Vaults';
 
-// Helper to mock fetch function
-const mockSuccess = <T,>(data: T) => vi.fn().mockResolvedValue(data);
-const mockFailure = (message = 'Network error') => vi.fn().mockRejectedValue(new Error(message));
+function renderVaults() {
+  return render(
+    <MemoryRouter>
+      <Vaults />
+    </MemoryRouter>,
+  );
+}
 
-describe('Vaults page states', () => {
-  test('shows loading skeletons initially', async () => {
-    render(<Vaults fetchVaults={mockSuccess([])} />);
-    // Skeletons should be present immediately
-    const skeletons = screen.getAllByTestId('skeleton');
-    expect(skeletons.length).toBeGreaterThanOrEqual(3);
-    // Wait for loading to finish (no data)
-    await waitFor(() => expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument());
+function vaultRowNames() {
+  return screen.getAllByTestId('vault-row').map((row) => {
+    const heading = within(row).getByText(/Alpha Vault|Beta Reserve|Gamma Fund/);
+    return heading.textContent;
+  });
+}
+
+describe('Vaults', () => {
+  it('renders vault rows sorted by soonest deadline by default and preserves row links', () => {
+    renderVaults();
+
+    expect(vaultRowNames()).toEqual(['Gamma Fund', 'Beta Reserve', 'Alpha Vault']);
+    expect(screen.getByRole('link', { name: /Alpha Vault/i })).toHaveAttribute('href', '/vaults/1');
   });
 
-  test('shows empty state when no vaults', async () => {
-    render(<Vaults fetchVaults={mockSuccess([])} />);
-    await waitFor(() => screen.getByText(/You don’t have any vaults yet./i));
-    expect(screen.getByRole('link', { name: /Create your first vault/i })).toBeInTheDocument();
+  it('filters vaults with keyboard-operable status chips', () => {
+    renderVaults();
+
+    const completed = screen.getByRole('button', { name: 'Completed' });
+    fireEvent.click(completed);
+
+    expect(completed).toHaveAttribute('aria-pressed', 'true');
+    expect(vaultRowNames()).toEqual(['Beta Reserve']);
+    expect(screen.queryByText('Alpha Vault')).not.toBeInTheDocument();
   });
 
-  test('shows data state when vaults exist', async () => {
-    const mockData = [
-      { id: '1', name: 'Test Vault', amount: 1000, currency: 'USDC', status: 'active' as any, deadline: '2025-01-01T00:00:00Z' },
-    ];
-    render(<Vaults fetchVaults={mockSuccess(mockData)} />);
-    await waitFor(() => screen.getByText('Test Vault'));
-    expect(screen.getByText(/Test Vault/i)).toBeInTheDocument();
+  it('searches vault names case-insensitively', () => {
+    renderVaults();
+
+    fireEvent.change(screen.getByLabelText('Search vaults by name'), {
+      target: { value: 'gamma' },
+    });
+
+    expect(vaultRowNames()).toEqual(['Gamma Fund']);
+    expect(screen.queryByText('Alpha Vault')).not.toBeInTheDocument();
   });
 
-  test('shows error state and can retry', async () => {
-    const fetchMock = mockFailure();
-    render(<Vaults fetchVaults={fetchMock} />);
-    await waitFor(() => screen.getByText(/Failed to load vaults./i));
-    const retryBtn = screen.getByRole('button', { name: /Retry/i });
-    expect(retryBtn).toBeInTheDocument();
-    // Mock success on retry
-    fetchMock.mockImplementationOnce(() => Promise.resolve([]));
-    userEvent.click(retryBtn);
-    await waitFor(() => screen.getByText(/You don’t have any vaults yet./i));
+  it('sorts vaults by highest amount', () => {
+    renderVaults();
+
+    fireEvent.change(screen.getByLabelText('Sort vaults'), {
+      target: { value: 'amount-desc' },
+    });
+
+    expect(vaultRowNames()).toEqual(['Alpha Vault', 'Gamma Fund', 'Beta Reserve']);
+  });
+
+  it('shows a token-styled empty state when filters match no vaults', () => {
+    renderVaults();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pending Validation' }));
+
+    expect(screen.getByRole('status')).toHaveTextContent('No vaults match your filters.');
+    expect(screen.queryByTestId('vault-row')).not.toBeInTheDocument();
   });
 });

--- a/src/utils/__tests__/vaultFilter.test.ts
+++ b/src/utils/__tests__/vaultFilter.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { filterVaults, sortVaults } from '../vaultFilter';
+import type { VaultListItem } from '../vaultFilter';
+
+const vaults: VaultListItem[] = [
+  {
+    id: 'alpha',
+    name: 'Alpha Vault',
+    amount: 100,
+    currency: 'USDC',
+    status: 'active',
+    deadline: '2026-01-03T00:00:00Z',
+  },
+  {
+    id: 'beta',
+    name: 'Beta Reserve',
+    amount: 300,
+    currency: 'USDC',
+    status: 'completed',
+    deadline: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'gamma',
+    name: 'Gamma Vault',
+    amount: 200,
+    currency: 'USDC',
+    status: 'active',
+    deadline: '2026-01-02T00:00:00Z',
+  },
+];
+
+describe('filterVaults', () => {
+  it('filters by status', () => {
+    expect(filterVaults(vaults, { status: 'active', query: '' }).map((vault) => vault.id)).toEqual([
+      'alpha',
+      'gamma',
+    ]);
+  });
+
+  it('searches names case-insensitively and trims whitespace', () => {
+    expect(filterVaults(vaults, { status: 'all', query: '  reserve ' }).map((vault) => vault.id)).toEqual([
+      'beta',
+    ]);
+  });
+
+  it('combines status and search filters', () => {
+    expect(filterVaults(vaults, { status: 'completed', query: 'vault' })).toEqual([]);
+  });
+});
+
+describe('sortVaults', () => {
+  it('sorts by deadline ascending', () => {
+    expect(sortVaults(vaults, { by: 'deadline', dir: 'asc' }).map((vault) => vault.id)).toEqual([
+      'beta',
+      'gamma',
+      'alpha',
+    ]);
+  });
+
+  it('sorts by amount descending', () => {
+    expect(sortVaults(vaults, { by: 'amount', dir: 'desc' }).map((vault) => vault.id)).toEqual([
+      'beta',
+      'gamma',
+      'alpha',
+    ]);
+  });
+
+  it('preserves original order when sort values tie', () => {
+    const tied = [
+      { ...vaults[0], id: 'first', amount: 100 },
+      { ...vaults[1], id: 'second', amount: 100 },
+    ];
+
+    expect(sortVaults(tied, { by: 'amount', dir: 'desc' }).map((vault) => vault.id)).toEqual([
+      'first',
+      'second',
+    ]);
+  });
+});

--- a/src/utils/vaultFilter.ts
+++ b/src/utils/vaultFilter.ts
@@ -1,0 +1,60 @@
+export type VaultListStatus = 'active' | 'completed' | 'failed' | 'cancelled' | 'pending_validation';
+export type VaultStatusFilter = 'all' | VaultListStatus;
+export type VaultSortBy = 'deadline' | 'amount';
+export type VaultSortDir = 'asc' | 'desc';
+
+export interface VaultListItem {
+  id: string;
+  name: string;
+  amount: number;
+  currency: string;
+  status: VaultListStatus;
+  deadline: string;
+}
+
+export interface VaultFilterOptions {
+  status: VaultStatusFilter;
+  query: string;
+}
+
+export interface VaultSortOptions {
+  by: VaultSortBy;
+  dir: VaultSortDir;
+}
+
+export function filterVaults(
+  vaults: VaultListItem[],
+  { status, query }: VaultFilterOptions,
+): VaultListItem[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return vaults.filter((vault) => {
+    const matchesStatus = status === 'all' || vault.status === status;
+    const matchesQuery = normalizedQuery.length === 0 ||
+      vault.name.toLowerCase().includes(normalizedQuery);
+
+    return matchesStatus && matchesQuery;
+  });
+}
+
+export function sortVaults(
+  vaults: VaultListItem[],
+  { by, dir }: VaultSortOptions,
+): VaultListItem[] {
+  const direction = dir === 'asc' ? 1 : -1;
+
+  return vaults
+    .map((vault, index) => ({ vault, index }))
+    .sort((a, b) => {
+      const primary = by === 'deadline'
+        ? Date.parse(a.vault.deadline) - Date.parse(b.vault.deadline)
+        : a.vault.amount - b.vault.amount;
+
+      if (primary !== 0) {
+        return primary * direction;
+      }
+
+      return a.index - b.index;
+    })
+    .map(({ vault }) => vault);
+}


### PR DESCRIPTION
## Summary
- add pure `filterVaults` and `sortVaults` helpers for Vaults status, name query, and deterministic sorting
- add the Vaults toolbar with status chips, name search, deadline/amount sort, and an empty-results state using design tokens
- replace stale Vaults page tests with current filtering/search/sort behavior coverage and document the helper API

## Validation
- `npx eslint src/pages/Vaults.tsx src/pages/__tests__/Vaults.test.tsx src/utils/vaultFilter.ts src/utils/__tests__/vaultFilter.test.ts`
- `npx tsc --noEmit --target ES2020 --lib ES2020,DOM,DOM.Iterable --module ESNext --moduleResolution bundler --allowImportingTsExtensions --isolatedModules --moduleDetection force --jsx react-jsx --strict --skipLibCheck --types vitest,@testing-library/jest-dom --baseUrl . src/pages/Vaults.tsx src/pages/__tests__/Vaults.test.tsx src/utils/vaultFilter.ts src/utils/__tests__/vaultFilter.test.ts`
- `git diff --check`
- `git diff --cached --check`

## Blocked local checks
- `npx vitest run src/utils/__tests__/vaultFilter.test.ts src/pages/__tests__/Vaults.test.tsx` is blocked in this Windows sandbox because Vite cannot start esbuild: `Error: spawn EPERM` while loading `vitest.config.ts`.

Closes #177