### PR TITLE
test: audit Layout navigation accessibility

### DIFF
--- a/design-system/documentation/layout-navigation-accessibility.md
+++ b/design-system/documentation/layout-navigation-accessibility.md
@@ -1,0 +1,13 @@
+# Layout navigation accessibility
+
+The header exposes two navigation surfaces:
+
+- Desktop header links live in `nav[aria-label="Primary navigation"]`.
+- The mobile drawer keeps its modal dialog semantics separate from `nav[aria-label="Mobile navigation"]`.
+
+Only the link for the current route should carry `aria-current="page"` across the visible header navigation set. The Disciplr brand link stays a home shortcut and does not receive `aria-current`, so the active page has a single programmatic current link.
+
+Header controls must keep accessible names:
+
+- Wallet connection controls expose their visible wallet action text.
+- The mobile drawer trigger uses `aria-label="Open navigation menu"` and keeps `aria-expanded` synchronized with drawer state.

--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -171,6 +171,12 @@
   border: 0;
 }
 
+.mobile-drawer-nav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
 .mobile-drawer-close {
   align-self: flex-end;
   background: none;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -14,7 +14,10 @@ export default function Layout({ children }: LayoutProps) {
   const [isDrawerOpen, setDrawerOpen] = useState(false);
   const toggleDrawer = () => setDrawerOpen(prev => !prev);
   const location = useLocation();
+  const isHomeActive = location.pathname === "/";
   const isTransactionsActive = location.pathname === "/transactions";
+  const isAnalyticsActive = location.pathname === "/analytics";
+  const isCreateVaultActive = location.pathname === "/vaults/create";
   const backgroundA11yProps = isDrawerOpen
     ? ({ "aria-hidden": true, inert: "" } as HTMLAttributes<HTMLElement> & { inert: "" })
     : {};
@@ -50,14 +53,15 @@ export default function Layout({ children }: LayoutProps) {
           </Link>
         </div>
 
-        <nav className="desktop-nav" {...backgroundA11yProps}>
+        <nav className="desktop-nav" aria-label="Primary navigation" {...backgroundA11yProps}>
           <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
             <Link
               to="/"
               className="header-link"
+              aria-current={isHomeActive ? "page" : undefined}
               style={{
                 color:
-                  location.pathname === "/" ? "var(--accent)" : "var(--muted)",
+                  isHomeActive ? "var(--accent)" : "var(--muted)",
               }}
             >
               <Text role="caption" as="span">
@@ -67,11 +71,10 @@ export default function Layout({ children }: LayoutProps) {
 
             <Link
               to="/analytics"
+              aria-current={isAnalyticsActive ? "page" : undefined}
               style={{
                 color:
-                  location.pathname === "/analytics"
-                    ? "var(--accent)"
-                    : "var(--muted)",
+                  isAnalyticsActive ? "var(--accent)" : "var(--muted)",
                 textDecoration: "none",
               }}
             >
@@ -80,6 +83,7 @@ export default function Layout({ children }: LayoutProps) {
 
             <Link
               to="/vaults/create"
+              aria-current={isCreateVaultActive ? "page" : undefined}
               style={{
                 color: "var(--surface)",
                 background: "var(--accent)",

--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { X } from 'lucide-react';
 import FocusTrap from 'focus-trap-react';
 import { WalletConnectButton } from './Wallet/WalletConnectButton';
@@ -12,6 +12,8 @@ interface MobileDrawerProps {
 export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
   const drawerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLElement | null>(null);
+  const location = useLocation();
+  const isActive = (path: string) => location.pathname === path;
 
   useEffect(() => {
     if (!isOpen) return;
@@ -61,7 +63,7 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
       }}
     >
       <div className="mobile-drawer-backdrop" onClick={onClose}>
-        <nav
+        <div
           className="mobile-drawer"
           role="dialog"
           aria-modal="true"
@@ -77,20 +79,42 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
           <button className="mobile-drawer-close" onClick={onClose} aria-label="Close navigation drawer">
             <X size={24} />
           </button>
-          <Link to="/" className="mobile-drawer-link" onClick={onClose}>
-            Home
-          </Link>
-          <Link to="/transactions" className="mobile-drawer-link" onClick={onClose}>
-            Transactions
-          </Link>
-          <Link to="/analytics" className="mobile-drawer-link" onClick={onClose}>
-            Analytics
-          </Link>
-          <Link to="/vaults/create" className="mobile-drawer-link" onClick={onClose}>
-            Create Vault
-          </Link>
+          <nav className="mobile-drawer-nav" aria-label="Mobile navigation">
+            <Link
+              to="/"
+              className="mobile-drawer-link"
+              aria-current={isActive('/') ? 'page' : undefined}
+              onClick={onClose}
+            >
+              Home
+            </Link>
+            <Link
+              to="/transactions"
+              className="mobile-drawer-link"
+              aria-current={isActive('/transactions') ? 'page' : undefined}
+              onClick={onClose}
+            >
+              Transactions
+            </Link>
+            <Link
+              to="/analytics"
+              className="mobile-drawer-link"
+              aria-current={isActive('/analytics') ? 'page' : undefined}
+              onClick={onClose}
+            >
+              Analytics
+            </Link>
+            <Link
+              to="/vaults/create"
+              className="mobile-drawer-link"
+              aria-current={isActive('/vaults/create') ? 'page' : undefined}
+              onClick={onClose}
+            >
+              Create Vault
+            </Link>
+          </nav>
           <WalletConnectButton />
-        </nav>
+        </div>
       </div>
     </FocusTrap>
   );

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -1,33 +1,65 @@
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import Layout from '../Layout';
 
 vi.mock('../Wallet/WalletConnectButton', () => ({
   WalletConnectButton: () => <button type="button">Connect wallet</button>,
 }));
 
+function renderLayout(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Layout>
+        <div>Content</div>
+      </Layout>
+    </MemoryRouter>,
+  );
+}
+
+const activeRouteCases = [
+  { path: '/', name: 'Home' },
+  { path: '/transactions', name: 'Transactions' },
+  { path: '/analytics', name: 'Analytics' },
+  { path: '/vaults/create', name: 'Create Vault' },
+];
+
 describe('Layout component navigation', () => {
+  test('exposes a named primary navigation landmark and named header controls', () => {
+    renderLayout('/');
+
+    const nav = screen.getByRole('navigation', { name: /primary navigation/i });
+
+    expect(within(nav).getByRole('link', { name: /home/i })).toBeInTheDocument();
+    expect(within(nav).getByRole('link', { name: /analytics/i })).toBeInTheDocument();
+    expect(within(nav).getByRole('link', { name: /create vault/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /transactions/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /connect wallet/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /open navigation menu/i })).toBeInTheDocument();
+  });
+
+  test.each(activeRouteCases)('marks only the active header link for $path with aria-current', ({ path, name }) => {
+    renderLayout(path);
+
+    const activeLinks = screen
+      .getAllByRole('link')
+      .filter((link) => link.getAttribute('aria-current') === 'page');
+
+    expect(activeLinks).toHaveLength(1);
+    expect(activeLinks[0]).toHaveAccessibleName(name);
+  });
+
   test('transactions link receives active class and aria-current when on /transactions', () => {
-    render(
-      <MemoryRouter initialEntries={['/transactions']}>
-        <Layout>
-          <div>Content</div>
-        </Layout>
-      </MemoryRouter>
-    );
+    renderLayout('/transactions');
+
     const link = screen.getByRole('link', { name: /transactions/i });
     expect(link).toHaveAttribute('aria-current', 'page');
     expect(link).toHaveClass('active');
   });
 
   test('transactions link is not active on other routes', () => {
-    render(
-      <MemoryRouter initialEntries={['/']}>
-        <Layout>
-          <div>Content</div>
-        </Layout>
-      </MemoryRouter>
-    );
+    renderLayout('/');
+
     const link = screen.getByRole('link', { name: /transactions/i });
     expect(link).not.toHaveAttribute('aria-current');
     expect(link).not.toHaveClass('active');

--- a/src/components/__tests__/MobileDrawer.test.tsx
+++ b/src/components/__tests__/MobileDrawer.test.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { ReactNode } from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import Layout from '../Layout';
 import MobileDrawer from '../MobileDrawer';
@@ -20,9 +21,9 @@ vi.mock('../Wallet/WalletConnectButton', () => ({
   WalletConnectButton: () => <button type="button">Connect wallet</button>,
 }));
 
-function renderOpenDrawer(onClose = vi.fn()) {
+function renderOpenDrawer(onClose = vi.fn(), initialEntry = '/') {
   render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <MobileDrawer isOpen onClose={onClose} />
     </MemoryRouter>,
   );
@@ -71,6 +72,22 @@ describe('MobileDrawer accessibility', () => {
       screen.getByRole('button', { name: /close navigation drawer/i }),
     );
     expect((focusTrapState.options[0].fallbackFocus as () => HTMLElement)()).toBe(dialog);
+  });
+
+  test('exposes a labelled mobile navigation landmark with the active route', () => {
+    renderOpenDrawer(vi.fn(), '/analytics');
+
+    const nav = screen.getByRole('navigation', { name: /mobile navigation/i });
+    const activeLinks = within(nav)
+      .getAllByRole('link')
+      .filter((link) => link.getAttribute('aria-current') === 'page');
+
+    expect(within(nav).getByRole('link', { name: /home/i })).toBeInTheDocument();
+    expect(within(nav).getByRole('link', { name: /transactions/i })).toBeInTheDocument();
+    expect(within(nav).getByRole('link', { name: /analytics/i })).toBeInTheDocument();
+    expect(within(nav).getByRole('link', { name: /create vault/i })).toBeInTheDocument();
+    expect(activeLinks).toHaveLength(1);
+    expect(activeLinks[0]).toHaveAccessibleName('Analytics');
   });
 
   test('closes on Escape and restores focus to the trigger', async () => {
@@ -122,7 +139,7 @@ describe('MobileDrawer accessibility', () => {
     if (activeElementDescriptor) {
       Object.defineProperty(document, 'activeElement', activeElementDescriptor);
     } else {
-      delete (document as Document & { activeElement?: Element | null }).activeElement;
+      Reflect.deleteProperty(document, 'activeElement');
     }
   });
 


### PR DESCRIPTION
## Summary
- add named desktop and mobile navigation landmarks for the Layout header surfaces
- ensure exactly one current header link exposes `aria-current="page"` for Home, Transactions, Analytics, and Create Vault routes
- separate the mobile drawer dialog role from its navigation landmark and document the nav accessibility expectations
- extend Layout and MobileDrawer tests with role/name and active-route assertions

## Validation
- `npx eslint src/components/Layout.tsx src/components/MobileDrawer.tsx src/components/__tests__/Layout.test.tsx src/components/__tests__/MobileDrawer.test.tsx`
- `npx tsc --noEmit --target ES2020 --lib ES2020,DOM,DOM.Iterable --module ESNext --moduleResolution bundler --allowImportingTsExtensions --isolatedModules --moduleDetection force --jsx react-jsx --strict --skipLibCheck --types vitest,@testing-library/jest-dom --baseUrl . src/components/Layout.tsx src/components/MobileDrawer.tsx src/components/__tests__/Layout.test.tsx src/components/__tests__/MobileDrawer.test.tsx`
- `git diff --check`
- `git diff --cached --check`

## Blocked local checks
- `npx vitest run src/components/__tests__/Layout.test.tsx src/components/__tests__/MobileDrawer.test.tsx` is blocked in this Windows sandbox because Vite cannot start esbuild: `Error: spawn EPERM` while loading `vitest.config.ts`.

Closes #206