### PR TITLE
fix: token-driven verifier colors

### DIFF
--- a/design-system/documentation/verifier-token-colors.md
+++ b/design-system/documentation/verifier-token-colors.md
@@ -1,0 +1,17 @@
+# Verifier token colors
+
+Verifier pages should use semantic CSS variables instead of Tailwind color utilities for surfaces, copy, borders, and action states.
+
+## Mapping
+
+- Page copy and labels: `--text` and `--muted`.
+- Cards, tables, and panels: `--surface`, `--surface-raised`, and `--border`.
+- Primary review actions: `--accent` with `--bg` foreground.
+- Approval and completion states: `--success`.
+- Rejection, missing, and urgent states: `--danger`.
+
+Urgency should not be color-only. Verifier dashboard rows and validation detail deadline pills include explicit `Urgent` copy when the task is inside the urgent threshold.
+
+## Regression Check
+
+Verifier tests scan rendered class names for hardcoded Tailwind color utilities such as `bg-white`, `text-gray-*`, `bg-blue-*`, `text-red-*`, and `border-l-blue-*`. Keep layout and spacing utilities in class names, but route color through token-backed styles or token-backed CSS classes.

--- a/src/pages/PendingValidations.tsx
+++ b/src/pages/PendingValidations.tsx
@@ -4,10 +4,19 @@ import { CountdownDeadline } from '../components/CountdownDeadline';
 import { Text } from '../components/Text';
 import { useVerifierStore } from '../Zustand/Store';
 
+const tokenStyles = {
+  mutedText: { color: 'var(--muted)' },
+  surfacePanel: { background: 'var(--surface)', borderColor: 'var(--border)' },
+  raisedPanel: { background: 'var(--surface-raised)', borderColor: 'var(--border)' },
+  textPanel: { color: 'var(--text)' },
+  primaryButton: { background: 'var(--accent)', color: 'var(--bg)' },
+  secondaryButton: { background: 'var(--surface)', borderColor: 'var(--border)', color: 'var(--text)' },
+};
+
 export default function PendingValidations() {
   const navigate = useNavigate();
   const { pendingValidations } = useVerifierStore();
-  
+
   // Optional: Simple state to handle sorting by days remaining
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
 
@@ -21,57 +30,59 @@ export default function PendingValidations() {
     <div className="flex flex-col gap-6 p-6">
       <header className="flex flex-col md:flex-row md:justify-between md:items-center gap-4 mb-2">
         <div>
-          <button 
+          <button
             onClick={() => navigate('/verifier')}
-            className="text-gray-500 hover:text-gray-800 mb-2 text-sm font-medium transition"
+            className="mb-2 text-sm font-medium transition"
+            style={tokenStyles.mutedText}
           >
             &larr; Back to Dashboard
           </button>
           <Text role="display" as="h1">Pending Validations</Text>
-          <Text role="body" as="p" className="text-gray-500 mt-1">
+          <Text role="body" as="p" className="mt-1" style={tokenStyles.mutedText}>
             Review and validate milestones submitted by vault owners.
           </Text>
         </div>
-        
-        <button 
+
+        <button
           onClick={() => setSortOrder(prev => prev === 'asc' ? 'desc' : 'asc')}
-          className="px-4 py-2 border border-gray-300 rounded text-sm font-medium hover:bg-gray-50 transition"
+          className="px-4 py-2 border rounded text-sm font-medium transition"
+          style={tokenStyles.secondaryButton}
         >
           Sort by Urgency: {sortOrder === 'asc' ? 'High to Low' : 'Low to High'}
         </button>
       </header>
 
-      <section className="bg-white border rounded-lg shadow-sm overflow-x-auto">
+      <section className="border rounded-lg shadow-sm overflow-x-auto" style={tokenStyles.surfacePanel}>
         {sortedValidations.length === 0 ? (
-          <div className="p-12 text-center text-gray-500">
+          <div className="p-12 text-center" style={tokenStyles.mutedText}>
             <Text role="body" as="h3">All caught up!</Text>
             <Text role="body" as="p" className="mt-2">There are no pending validations in your queue.</Text>
           </div>
         ) : (
           <table className="w-full text-left border-collapse">
             <thead>
-              <tr className="bg-gray-50 border-b border-gray-200">
-                <th className="p-4 font-medium text-sm text-gray-600">Vault & Milestone</th>
-                <th className="p-4 font-medium text-sm text-gray-600">Owner</th>
-                <th className="p-4 font-medium text-sm text-gray-600">Amount at Stake</th>
-                <th className="p-4 font-medium text-sm text-gray-600">Deadline</th>
-                <th className="p-4 font-medium text-sm text-gray-600 text-right">Actions</th>
+              <tr className="border-b" style={tokenStyles.raisedPanel}>
+                <th className="p-4 font-medium text-sm" style={tokenStyles.mutedText}>Vault & Milestone</th>
+                <th className="p-4 font-medium text-sm" style={tokenStyles.mutedText}>Owner</th>
+                <th className="p-4 font-medium text-sm" style={tokenStyles.mutedText}>Amount at Stake</th>
+                <th className="p-4 font-medium text-sm" style={tokenStyles.mutedText}>Deadline</th>
+                <th className="p-4 font-medium text-sm text-right" style={tokenStyles.mutedText}>Actions</th>
               </tr>
             </thead>
             <tbody>
               {sortedValidations.map((task) => (
-                <tr key={task.id} className="border-b border-gray-100 hover:bg-gray-50 transition">
+                <tr key={task.id} className="border-b transition" style={{ borderColor: 'var(--border)' }}>
                   <td className="p-4">
-                    <Text role="body" as="p" className="font-semibold text-gray-800">{task.vaultName}</Text>
-                    <Text role="body" as="p" className="text-sm text-gray-500 mt-1">{task.milestone}</Text>
+                    <Text role="body" as="p" className="font-semibold" style={tokenStyles.textPanel}>{task.vaultName}</Text>
+                    <Text role="body" as="p" className="text-sm mt-1" style={tokenStyles.mutedText}>{task.milestone}</Text>
                   </td>
                   <td className="p-4">
-                    <span className="bg-gray-100 text-gray-700 text-xs px-2 py-1 rounded font-mono">
+                    <span className="text-xs px-2 py-1 rounded font-mono" style={{ ...tokenStyles.raisedPanel, ...tokenStyles.textPanel }}>
                       {task.owner}
                     </span>
                   </td>
                   <td className="p-4">
-                    <Text role="body" as="p" className="font-medium text-gray-800">{task.amount}</Text>
+                    <Text role="body" as="p" className="font-medium" style={tokenStyles.textPanel}>{task.amount}</Text>
                   </td>
                   <td className="p-4">
                     <div className="flex flex-col">
@@ -80,9 +91,10 @@ export default function PendingValidations() {
                     </div>
                   </td>
                   <td className="p-4 text-right">
-                    <button 
+                    <button
                       onClick={() => navigate(`/verifier/queue/${task.id}`)}
-                      className="px-4 py-2 bg-blue-50 text-blue-700 rounded hover:bg-blue-100 transition text-sm font-medium"
+                      className="px-4 py-2 rounded transition text-sm font-medium"
+                      style={tokenStyles.primaryButton}
                     >
                       Review
                     </button>

--- a/src/pages/ValidationDetail.tsx
+++ b/src/pages/ValidationDetail.tsx
@@ -5,6 +5,17 @@ import { useVerifierStore } from '../Zustand/Store';
 import { ConfirmationModal } from '../components/ConfirmationModal';
 import { SafeLink } from '../components/SafeLink';
 
+const tokenStyles = {
+  mutedText: { color: 'var(--muted)' },
+  surfacePanel: { background: 'var(--surface)', borderColor: 'var(--border)' },
+  raisedPanel: { background: 'var(--surface-raised)', borderColor: 'var(--border)' },
+  textPanel: { color: 'var(--text)' },
+  primaryButton: { background: 'var(--accent)', color: 'var(--bg)' },
+  successButton: { background: 'var(--success)', color: 'var(--bg)' },
+  dangerButton: { background: 'var(--danger)', color: 'var(--bg)' },
+  secondaryButton: { background: 'var(--surface)', borderColor: 'var(--border)', color: 'var(--accent)' },
+};
+
 export default function ValidationDetail() {
   const { vaultId } = useParams<{ vaultId: string }>();
   const navigate = useNavigate();
@@ -24,12 +35,13 @@ export default function ValidationDetail() {
     return (
       <div className="p-12 text-center flex flex-col items-center gap-4">
         <Text role="display" as="h2">Validation Not Found</Text>
-        <Text role="body" as="p" className="text-gray-500">
+        <Text role="body" as="p" style={tokenStyles.mutedText}>
           This validation task may have already been processed or doesn't exist.
         </Text>
         <button 
           onClick={() => navigate('/verifier/queue')}
-          className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+          className="px-6 py-2 rounded transition"
+          style={tokenStyles.primaryButton}
         >
           Return to Queue
         </button>
@@ -58,19 +70,29 @@ export default function ValidationDetail() {
       <header>
         <button 
           onClick={() => navigate('/verifier/queue')}
-          className="text-gray-500 hover:text-gray-800 mb-4 text-sm font-medium transition"
+          className="mb-4 text-sm font-medium transition"
+          style={tokenStyles.mutedText}
         >
           &larr; Back to Queue
         </button>
         <div className="flex flex-col md:flex-row md:justify-between md:items-end gap-4">
           <div>
             <Text role="display" as="h1">Review Milestone</Text>
-            <Text role="body" as="p" className="text-gray-500 mt-1">
+            <Text role="body" as="p" className="mt-1" style={tokenStyles.mutedText}>
               Task ID: {task.id}
             </Text>
           </div>
-          <div className={`px-4 py-2 rounded font-bold text-sm ${task.daysRemaining <= 3 ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'}`}>
-            Deadline: {task.daysRemaining} days remaining
+          <div
+            className="px-4 py-2 rounded font-bold text-sm"
+            style={{
+              background: task.daysRemaining <= 3
+                ? 'color-mix(in srgb, var(--danger) 12%, transparent)'
+                : 'color-mix(in srgb, var(--success) 12%, transparent)',
+              color: task.daysRemaining <= 3 ? 'var(--danger)' : 'var(--success)',
+              border: `var(--border-width-1) solid ${task.daysRemaining <= 3 ? 'var(--danger)' : 'var(--success)'}`,
+            }}
+          >
+            Deadline: {task.daysRemaining <= 3 ? 'Urgent, ' : ''}{task.daysRemaining} days remaining
           </div>
         </div>
       </header>
@@ -78,33 +100,33 @@ export default function ValidationDetail() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Left Column: Details & Evidence */}
         <div className="lg:col-span-2 flex flex-col gap-6">
-          <section className="p-6 border rounded-lg bg-white shadow-sm">
+          <section className="p-6 border rounded-lg shadow-sm" style={tokenStyles.surfacePanel}>
             <Text role="display" as="h2" className="mb-4">Vault Summary</Text>
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <Text role="body" as="p" className="text-sm text-gray-500">Vault Name</Text>
+                <Text role="body" as="p" className="text-sm" style={tokenStyles.mutedText}>Vault Name</Text>
                 <Text role="body" as="p" className="font-medium">{task.vaultName}</Text>
               </div>
               <div>
-                <Text role="body" as="p" className="text-sm text-gray-500">Owner Wallet</Text>
-                <span className="bg-gray-100 text-gray-700 text-xs px-2 py-1 rounded font-mono block w-max mt-1">
+                <Text role="body" as="p" className="text-sm" style={tokenStyles.mutedText}>Owner Wallet</Text>
+                <span className="text-xs px-2 py-1 rounded font-mono block w-max mt-1" style={{ ...tokenStyles.raisedPanel, ...tokenStyles.textPanel }}>
                   {task.owner}
                 </span>
               </div>
               <div>
-                <Text role="body" as="p" className="text-sm text-gray-500">Amount at Stake</Text>
-                <Text role="body" as="p" className="font-bold text-green-700">{task.amount}</Text>
+                <Text role="body" as="p" className="text-sm" style={tokenStyles.mutedText}>Amount at Stake</Text>
+                <Text role="body" as="p" className="font-bold" style={{ color: 'var(--success)' }}>{task.amount}</Text>
               </div>
               <div>
-                <Text role="body" as="p" className="text-sm text-gray-500">Deadline Date</Text>
+                <Text role="body" as="p" className="text-sm" style={tokenStyles.mutedText}>Deadline Date</Text>
                 <Text role="body" as="p" className="font-medium">{task.deadline}</Text>
               </div>
             </div>
           </section>
 
-          <section className="p-6 border rounded-lg bg-white shadow-sm">
+          <section className="p-6 border rounded-lg shadow-sm" style={tokenStyles.surfacePanel}>
             <Text role="display" as="h2" className="mb-4">Milestone Evidence</Text>
-            <div className="p-4 bg-gray-50 border rounded mb-4">
+            <div className="p-4 border rounded mb-4" style={tokenStyles.raisedPanel}>
               <Text role="body" as="p" className="font-bold">Target Milestone:</Text>
               <Text role="body" as="p" className="mt-1">{task.milestone}</Text>
             </div>
@@ -113,19 +135,20 @@ export default function ValidationDetail() {
             {task.evidenceUrl ? (
               <SafeLink
                 href={task.evidenceUrl}
-                className="inline-block px-4 py-2 border border-blue-300 text-blue-700 bg-blue-50 rounded hover:bg-blue-100 transition font-medium text-sm"
+                className="inline-block px-4 py-2 border rounded transition font-medium text-sm"
+                style={tokenStyles.secondaryButton}
               >
                 &#128279; View Attached Evidence
               </SafeLink>
             ) : (
-              <Text role="body" as="p" className="text-gray-500 italic">No evidence link provided.</Text>
+              <Text role="body" as="p" className="italic" style={tokenStyles.mutedText}>No evidence link provided.</Text>
             )}
           </section>
         </div>
 
         {/* Right Column: Verification Actions */}
         <div className="flex flex-col gap-4">
-          <section className="p-6 border rounded-lg bg-white shadow-sm flex flex-col h-full">
+          <section className="p-6 border rounded-lg shadow-sm flex flex-col h-full" style={tokenStyles.surfacePanel}>
             <Text role="display" as="h2" className="mb-4">Verification Actions</Text>
             
             <label className="flex flex-col gap-2 mb-6 flex-grow">
@@ -134,20 +157,23 @@ export default function ValidationDetail() {
                 value={notes}
                 onChange={(e) => setNotes(e.target.value)}
                 placeholder="Start adding your review notes here..."
-                className="w-full border rounded p-3 text-sm h-32 focus:ring-2 focus:ring-blue-500 outline-none resize-none"
+                className="w-full border rounded p-3 text-sm h-32 focus:ring-2 outline-none resize-none"
+                style={{ ...tokenStyles.surfacePanel, color: 'var(--text)' }}
               />
             </label>
 
             <div className="flex flex-col gap-3 mt-auto">
               <button 
                 onClick={() => handleOpenModal('approve')}
-                className="w-full py-3 bg-green-600 text-white font-bold rounded hover:bg-green-700 transition"
+                className="w-full py-3 font-bold rounded transition"
+                style={tokenStyles.successButton}
               >
                 Approve Milestone
               </button>
               <button 
                 onClick={() => handleOpenModal('reject')}
-                className="w-full py-3 bg-red-600 text-white font-bold rounded hover:bg-red-700 transition"
+                className="w-full py-3 font-bold rounded transition"
+                style={tokenStyles.dangerButton}
               >
                 Reject Milestone
               </button>

--- a/src/pages/VerifierDashboard.tsx
+++ b/src/pages/VerifierDashboard.tsx
@@ -2,6 +2,15 @@ import { useNavigate } from 'react-router-dom';
 import { Text } from '../components/Text';
 import { useVerifierStore } from '../Zustand/Store';
 
+const tokenStyles = {
+  mutedText: { color: 'var(--muted)' },
+  surfacePanel: { background: 'var(--surface)', borderColor: 'var(--border)' },
+  raisedPanel: { background: 'var(--surface-raised)', borderColor: 'var(--border)' },
+  primaryButton: { background: 'var(--accent)', color: 'var(--bg)' },
+  secondaryButton: { background: 'var(--surface)', borderColor: 'var(--border)', color: 'var(--text)' },
+  accentText: { color: 'var(--accent)' },
+};
+
 export default function VerifierDashboard() {
   const navigate = useNavigate();
   
@@ -17,23 +26,37 @@ export default function VerifierDashboard() {
     <div className="flex flex-col gap-6 p-6">
       <header className="mb-4">
         <Text role="display" as="h1">Verifier Dashboard</Text>
-        <Text role="body" as="p" className="text-gray-500 mt-1">
+        <Text role="body" as="p" className="mt-1" style={tokenStyles.mutedText}>
           Overview of your assigned vaults and validation activity.
         </Text>
       </header>
 
       {/* Overview Stats Cards */}
       <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="p-6 border rounded-lg shadow-sm bg-white">
-          <Text role="body" as="p" className="text-gray-500 mb-2">Total Assigned</Text>
+        <div className="p-6 border rounded-lg shadow-sm" style={tokenStyles.surfacePanel}>
+          <Text role="body" as="p" className="mb-2" style={tokenStyles.mutedText}>Total Assigned</Text>
           <Text role="display" as="h1">{totalAssigned}</Text>
         </div>
-        <div className="p-6 border rounded-lg shadow-sm bg-white border-l-4 border-l-blue-500">
-          <Text role="body" as="p" className="text-gray-500 mb-2">Pending Validations</Text>
+        <div
+          className="p-6 border rounded-lg shadow-sm"
+          style={{
+            ...tokenStyles.surfacePanel,
+            borderLeftWidth: 'var(--border-width-4)',
+            borderLeftColor: 'var(--accent)',
+          }}
+        >
+          <Text role="body" as="p" className="mb-2" style={tokenStyles.mutedText}>Pending Validations</Text>
           <Text role="display" as="h1">{totalPending}</Text>
         </div>
-        <div className="p-6 border rounded-lg shadow-sm bg-white border-l-4 border-l-green-500">
-          <Text role="body" as="p" className="text-gray-500 mb-2">Completed</Text>
+        <div
+          className="p-6 border rounded-lg shadow-sm"
+          style={{
+            ...tokenStyles.surfacePanel,
+            borderLeftWidth: 'var(--border-width-4)',
+            borderLeftColor: 'var(--success)',
+          }}
+        >
+          <Text role="body" as="p" className="mb-2" style={tokenStyles.mutedText}>Completed</Text>
           <Text role="display" as="h1">{totalCompleted}</Text>
         </div>
       </section>
@@ -42,13 +65,15 @@ export default function VerifierDashboard() {
       <section className="flex gap-4 mt-4">
         <button 
           onClick={() => navigate('/verifier/queue')}
-          className="px-6 py-3 bg-blue-600 text-white font-medium rounded hover:bg-blue-700 transition"
+          className="px-6 py-3 font-medium rounded transition"
+          style={tokenStyles.primaryButton}
         >
           View Pending Queue
         </button>
         <button 
           onClick={() => navigate('/verifier/history')}
-          className="px-6 py-3 border border-gray-300 font-medium rounded hover:bg-gray-50 transition"
+          className="px-6 py-3 border font-medium rounded transition"
+          style={tokenStyles.secondaryButton}
         >
           View History
         </button>
@@ -59,18 +84,22 @@ export default function VerifierDashboard() {
         <Text role="display" as="h2" className="mb-4">Urgent Pending Validations</Text>
         <div className="flex flex-col gap-3">
           {pendingValidations.length === 0 ? (
-            <div className="p-8 border rounded shadow-sm text-center text-gray-500 bg-gray-50">
+            <div
+              className="p-8 border rounded shadow-sm text-center"
+              style={{ ...tokenStyles.raisedPanel, ...tokenStyles.mutedText }}
+            >
               <Text role="body" as="p">You have no pending validations at this time.</Text>
             </div>
           ) : (
             pendingValidations.slice(0, 3).map((task) => (
               <div 
                 key={task.id} 
-                className="p-4 border rounded shadow-sm flex flex-col md:flex-row justify-between md:items-center bg-white hover:shadow-md transition gap-4"
+                className="p-4 border rounded shadow-sm flex flex-col md:flex-row justify-between md:items-center hover:shadow-md transition gap-4"
+                style={tokenStyles.surfacePanel}
               >
                 <div>
                   <Text role="body" as="h3">{task.vaultName}</Text>
-                  <Text role="body" as="p" className="text-sm text-gray-500 mt-1">
+                  <Text role="body" as="p" className="text-sm mt-1" style={tokenStyles.mutedText}>
                     Milestone: {task.milestone}
                   </Text>
                 </div>
@@ -78,13 +107,15 @@ export default function VerifierDashboard() {
                   <Text 
                     role="body" 
                     as="p"
-                    className={`font-bold ${task.daysRemaining <= 3 ? 'text-red-600' : 'text-gray-700'}`}
+                    className="font-bold"
+                    style={{ color: task.daysRemaining <= 3 ? 'var(--danger)' : 'var(--text)' }}
                   >
-                    {task.daysRemaining} days left
+                    {task.daysRemaining <= 3 ? 'Urgent: ' : ''}{task.daysRemaining} days left
                   </Text>
                   <button 
                     onClick={() => navigate(`/verifier/queue/${task.id}`)}
-                    className="text-blue-600 hover:text-blue-800 font-medium text-sm mt-2"
+                    className="font-medium text-sm mt-2"
+                    style={tokenStyles.accentText}
                   >
                     Review Now &rarr;
                   </button>

--- a/src/pages/__tests__/PendingValidations.test.tsx
+++ b/src/pages/__tests__/PendingValidations.test.tsx
@@ -3,6 +3,7 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import PendingValidations from '../PendingValidations';
 import { useVerifierStore } from '../../Zustand/Store';
+import { expectNoVerifierHardcodedColorClasses } from './verifierColorClassAssertions';
 
 vi.mock('../../Zustand/Store', () => ({
   useVerifierStore: vi.fn(),
@@ -58,10 +59,19 @@ function renderPage() {
   );
 }
 
+function mockVerifierStore(pendingValidations = makeTasks()) {
+  vi.mocked(useVerifierStore).mockReturnValue({
+    pendingValidations,
+    validationHistory: [],
+    approveValidation: vi.fn(),
+    rejectValidation: vi.fn(),
+  } as ReturnType<typeof useVerifierStore>);
+}
+
 describe('PendingValidations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: makeTasks() });
+    mockVerifierStore();
   });
 
   it('renders the page heading', () => {
@@ -70,14 +80,14 @@ describe('PendingValidations', () => {
   });
 
   it('shows "All caught up!" when there are no pending validations', () => {
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+    mockVerifierStore([]);
     renderPage();
     expect(screen.getByText('All caught up!')).toBeInTheDocument();
     expect(screen.getByText(/no pending validations/i)).toBeInTheDocument();
   });
 
   it('does not render the table when queue is empty', () => {
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+    mockVerifierStore([]);
     renderPage();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
@@ -142,38 +152,36 @@ describe('PendingValidations', () => {
   });
 
   it('renders a single task without crashing', () => {
-    (useVerifierStore as any).mockReturnValue({
-      pendingValidations: [makeTasks()[0]],
-    });
+    mockVerifierStore([makeTasks()[0]]);
     renderPage();
     expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
     expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 row
   });
 
   it('handles ties in daysRemaining (stable relative order preserved)', () => {
-    (useVerifierStore as any).mockReturnValue({
-      pendingValidations: [
-        { ...makeTasks()[0], id: 'v-a', daysRemaining: 5 },
-        { ...makeTasks()[1], id: 'v-b', daysRemaining: 5 },
-      ],
-    });
+    mockVerifierStore([
+      { ...makeTasks()[0], id: 'v-a', daysRemaining: 5 },
+      { ...makeTasks()[1], id: 'v-b', daysRemaining: 5 },
+    ]);
     renderPage();
     const rows = screen.getAllByRole('row').slice(1);
     expect(rows).toHaveLength(2);
-    // both show 5 days left — just assert they render without error
-    expect(screen.getAllByText('5 days left')).toHaveLength(2);
+    expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
+    expect(screen.getByText('Beta Vault')).toBeInTheDocument();
   });
 
-  it('shows daysRemaining in red for tasks with 3 or fewer days', () => {
+  it('uses design tokens instead of hardcoded verifier color classes', () => {
     renderPage();
-    // v-2 has daysRemaining: 2 — should have red styling
-    const urgentSpan = screen.getByText('2 days left');
-    expect(urgentSpan.className).toContain('text-red-600');
-  });
 
-  it('shows daysRemaining in green for tasks with more than 3 days', () => {
-    renderPage();
-    const safeSpan = screen.getByText('10 days left');
-    expect(safeSpan.className).toContain('text-green-600');
+    expectNoVerifierHardcodedColorClasses();
+    expect(screen.getByRole('button', { name: /sort by urgency/i })).toHaveStyle({
+      background: 'var(--surface)',
+      borderColor: 'var(--border)',
+      color: 'var(--text)',
+    });
+    expect(screen.getAllByRole('button', { name: 'Review' })[0]).toHaveStyle({
+      background: 'var(--accent)',
+      color: 'var(--bg)',
+    });
   });
 });

--- a/src/pages/__tests__/ValidationDetail.test.tsx
+++ b/src/pages/__tests__/ValidationDetail.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import ValidationDetail from '../ValidationDetail';
 import { useVerifierStore } from '../../Zustand/Store';
+import { expectNoVerifierHardcodedColorClasses } from './verifierColorClassAssertions';
 
 // Mock focus-trap-react as it can be tricky in jsdom
 vi.mock('focus-trap-react', () => ({
@@ -42,13 +43,19 @@ describe('ValidationDetail Page', () => {
   const mockApproveValidation = vi.fn();
   const mockRejectValidation = vi.fn();
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    (useVerifierStore as any).mockReturnValue({
+  function mockVerifierStore(overrides: Partial<ReturnType<typeof useVerifierStore>> = {}) {
+    vi.mocked(useVerifierStore).mockReturnValue({
       pendingValidations: mockPendingValidations,
+      validationHistory: [],
       approveValidation: mockApproveValidation,
       rejectValidation: mockRejectValidation,
-    });
+      ...overrides,
+    } as ReturnType<typeof useVerifierStore>);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifierStore();
   });
 
   it('renders task details correctly', () => {
@@ -62,13 +69,34 @@ describe('ValidationDetail Page', () => {
     expect(screen.getByText('Task ID: v-101')).toBeInTheDocument();
     expect(screen.getByText('Test Vault')).toBeInTheDocument();
     expect(screen.getByText('Test Milestone')).toBeInTheDocument();
+    expectNoVerifierHardcodedColorClasses();
+  });
+
+  it('uses token styles and text cues for urgent deadline state', () => {
+    mockVerifierStore({
+      pendingValidations: [{ ...mockPendingValidations[0], daysRemaining: 2 }],
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/verifier/v-101']}>
+        <ValidationDetail />
+      </MemoryRouter>
+    );
+
+    expectNoVerifierHardcodedColorClasses();
+    expect(screen.getByText('Deadline: Urgent, 2 days remaining')).toHaveStyle({
+      color: 'var(--danger)',
+      border: 'var(--border-width-1) solid var(--danger)',
+    });
+    expect(screen.getByText('Vault Summary').closest('section')).toHaveStyle({
+      background: 'var(--surface)',
+      borderColor: 'var(--border)',
+    });
   });
 
   it('shows "Validation Not Found" if task does not exist', () => {
-    (useVerifierStore as any).mockReturnValue({
+    mockVerifierStore({
       pendingValidations: [],
-      approveValidation: mockApproveValidation,
-      rejectValidation: mockRejectValidation,
     });
 
     render(
@@ -166,10 +194,8 @@ describe('ValidationDetail Page', () => {
   });
 
   it('renders "No evidence link provided" when task has no evidenceUrl', () => {
-    (useVerifierStore as any).mockReturnValue({
+    mockVerifierStore({
       pendingValidations: [{ ...mockPendingValidations[0], evidenceUrl: undefined }],
-      approveValidation: mockApproveValidation,
-      rejectValidation: mockRejectValidation,
     });
 
     render(

--- a/src/pages/__tests__/VerifierDashboard.test.tsx
+++ b/src/pages/__tests__/VerifierDashboard.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import VerifierDashboard from '../VerifierDashboard';
+import { useVerifierStore } from '../../Zustand/Store';
+import { expectNoVerifierHardcodedColorClasses } from './verifierColorClassAssertions';
+
+vi.mock('../../Zustand/Store', () => ({
+  useVerifierStore: vi.fn(),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const pendingValidations = [
+  {
+    id: 'v-urgent',
+    vaultName: 'Urgent Vault',
+    owner: 'GOWNERURGENT',
+    amount: '1,000 USDC',
+    deadline: '2026-06-25',
+    daysRemaining: 2,
+    status: 'pending' as const,
+    milestone: 'Ship evidence',
+  },
+  {
+    id: 'v-normal',
+    vaultName: 'Steady Vault',
+    owner: 'GOWNERNORMAL',
+    amount: '2,000 USDC',
+    deadline: '2026-07-10',
+    daysRemaining: 8,
+    status: 'pending' as const,
+    milestone: 'Finalize milestone',
+  },
+];
+
+function renderDashboard() {
+  vi.mocked(useVerifierStore).mockReturnValue({
+    pendingValidations,
+    validationHistory: [
+      {
+        id: 'v-complete',
+        vaultName: 'Complete Vault',
+        owner: 'GOWNERDONE',
+        amount: '3,000 USDC',
+        deadline: '2026-06-20',
+        daysRemaining: 0,
+        status: 'approved',
+        milestone: 'Launch',
+      },
+    ],
+  } as ReturnType<typeof useVerifierStore>);
+
+  return render(
+    <MemoryRouter>
+      <VerifierDashboard />
+    </MemoryRouter>,
+  );
+}
+
+describe('VerifierDashboard token colors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses design tokens for verifier surfaces and urgent cues', () => {
+    renderDashboard();
+
+    expectNoVerifierHardcodedColorClasses();
+    expect(screen.getByText(/overview of your assigned vaults/i)).toHaveStyle({ color: 'var(--muted)' });
+    expect(screen.getByText('Total Assigned').closest('div')).toHaveStyle({
+      background: 'var(--surface)',
+      borderColor: 'var(--border)',
+    });
+    expect(screen.getByText('Pending Validations').closest('div')).toHaveStyle({
+      borderLeftColor: 'var(--accent)',
+    });
+    expect(screen.getByText('Completed').closest('div')).toHaveStyle({
+      borderLeftColor: 'var(--success)',
+    });
+    expect(screen.getByText('Urgent: 2 days left')).toHaveStyle({ color: 'var(--danger)' });
+    expect(screen.getByText('8 days left')).toHaveStyle({ color: 'var(--text)' });
+    expect(screen.getByRole('button', { name: /view pending queue/i })).toHaveStyle({
+      background: 'var(--accent)',
+      color: 'var(--bg)',
+    });
+  });
+});

--- a/src/pages/__tests__/verifierColorClassAssertions.ts
+++ b/src/pages/__tests__/verifierColorClassAssertions.ts
@@ -1,0 +1,12 @@
+import { expect } from 'vitest';
+
+const hardcodedColorClassPattern =
+  /\b(?:bg|text|border|border-l|hover:bg|hover:text|focus:ring)-(?:gray|blue|green|red)-\d{2,3}\b|\b(?:bg-white|text-white)\b/;
+
+export function expectNoVerifierHardcodedColorClasses(container: ParentNode = document.body) {
+  const classNames = Array.from(container.querySelectorAll('[class]'))
+    .map((element) => element.getAttribute('class') ?? '')
+    .join(' ');
+
+  expect(classNames).not.toMatch(hardcodedColorClassPattern);
+}


### PR DESCRIPTION
## Summary
- migrate VerifierDashboard, PendingValidations, and ValidationDetail color styling from hardcoded Tailwind color utilities to semantic design tokens
- add explicit urgent text cues for verifier deadline urgency so status is not color-only
- add token color documentation plus rendered class-name regression checks for hardcoded verifier color classes

## Validation
- `rg "\b(?:bg|text|border|border-l|hover:bg|hover:text|focus:ring)-(?:gray|blue|green|red)-[0-9]{2,3}\b|\b(?:bg-white|text-white)\b" src/pages/VerifierDashboard.tsx src/pages/PendingValidations.tsx src/pages/ValidationDetail.tsx` returned no matches
- `npx eslint src/pages/VerifierDashboard.tsx src/pages/PendingValidations.tsx src/pages/ValidationDetail.tsx src/pages/__tests__/VerifierDashboard.test.tsx src/pages/__tests__/PendingValidations.test.tsx src/pages/__tests__/ValidationDetail.test.tsx src/pages/__tests__/verifierColorClassAssertions.ts`
- targeted TypeScript check passed with a temporary tsconfig extending `tsconfig.json`, limited to the touched pages/tests; `noUnusedLocals` was disabled only to avoid an existing unused React import in `ConfirmationModal.tsx` pulled in by `ValidationDetail.tsx`
- `git diff --check`
- `git diff --cached --check`

## Blocked local checks
- `npx vitest run src/pages/__tests__/VerifierDashboard.test.tsx src/pages/__tests__/PendingValidations.test.tsx src/pages/__tests__/ValidationDetail.test.tsx` is blocked in this Windows sandbox because Vite cannot start esbuild: `Error: spawn EPERM` while loading `vitest.config.ts`.

Closes #208