### PR TITLE
perf: window long VaultTransactions lists

### DIFF
--- a/design-system/documentation/vaulttransactions-windowing.md
+++ b/design-system/documentation/vaulttransactions-windowing.md
@@ -1,0 +1,17 @@
+# VaultTransactions windowing
+
+`VaultTransactions` keeps the current small-list output unchanged. Windowing only turns on when the rendered confirmed transaction count exceeds `VAULT_TRANSACTION_WINDOW_THRESHOLD` (`30`).
+
+## Pure Range Helper
+
+`getWindowRange` in `src/utils/windowRange.ts` owns the virtualization math:
+
+- Lists at or below the threshold return `isWindowed: false` and render all rows.
+- Larger lists calculate `start`, `end`, `beforeHeight`, and `afterHeight` from `scrollTop`, row height, viewport height, and overscan.
+- `sliceWindow` returns the original array for non-windowed ranges so small lists keep referential behavior.
+
+## Page Behavior
+
+The confirmed transaction section uses the helper to render only the visible rows plus overscan for large histories. Pending and failed sections remain unwindowed because they are short, high-priority status groups.
+
+The section header shows the active rendered range, for example `Rendering 10-13 of 80`, so the behavior is inspectable during performance testing.

--- a/src/pages/VaultTransactions.tsx
+++ b/src/pages/VaultTransactions.tsx
@@ -1,10 +1,11 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, type UIEvent } from "react";
+import { getWindowRange, sliceWindow, type WindowRange } from "../utils/windowRange";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
-type TxType = "create" | "validate" | "release" | "redirect";
-type TxStatus = "confirmed" | "pending" | "failed";
+export type TxType = "create" | "validate" | "release" | "redirect";
+export type TxStatus = "confirmed" | "pending" | "failed";
 
-interface Transaction {
+export interface Transaction {
   id: string;
   type: TxType;
   vault: string;
@@ -38,6 +39,11 @@ interface IconProps {
   color?: string;
   size?: number;
 }
+
+const VAULT_TRANSACTION_WINDOW_THRESHOLD = 30;
+const VAULT_TRANSACTION_ROW_HEIGHT = 76;
+const VAULT_TRANSACTION_VIEWPORT_HEIGHT = 640;
+const VAULT_TRANSACTION_OVERSCAN = 4;
 
 // ── Mock Data ─────────────────────────────────────────────────────────────────
 const MOCK_TRANSACTIONS: Transaction[] = [
@@ -235,10 +241,6 @@ const STATUS_META: Record<TxStatus, StatusMeta> = {
   },
 };
 
-const VAULTS = [
-  "All Vaults",
-  ...Array.from(new Set(MOCK_TRANSACTIONS.map((t) => t.vault))),
-];
 const TYPES: string[] = [
   "All Types",
   "create",
@@ -322,7 +324,21 @@ function exportCSV(txs: Transaction[]): void {
 }
 
 // ── Main Component ────────────────────────────────────────────────────────────
-export default function VaultTransactions() {
+interface VaultTransactionsProps {
+  transactions?: Transaction[];
+  windowThreshold?: number;
+  rowHeight?: number;
+  viewportHeight?: number;
+  overscan?: number;
+}
+
+export default function VaultTransactions({
+  transactions = MOCK_TRANSACTIONS,
+  windowThreshold = VAULT_TRANSACTION_WINDOW_THRESHOLD,
+  rowHeight = VAULT_TRANSACTION_ROW_HEIGHT,
+  viewportHeight = VAULT_TRANSACTION_VIEWPORT_HEIGHT,
+  overscan = VAULT_TRANSACTION_OVERSCAN,
+}: VaultTransactionsProps = {}) {
   const [filterType, setFilterType] = useState<string>("All Types");
   const [filterVault, setFilterVault] = useState<string>("All Vaults");
   const [filterStatus, setFilterStatus] = useState<string>("all");
@@ -332,6 +348,23 @@ export default function VaultTransactions() {
   const [selectedTx, setSelectedTx] = useState<Transaction | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+  const [confirmedScrollTop, setConfirmedScrollTop] = useState(0);
+
+  const metadataMaps = useMemo(
+    () => ({
+      typeMeta: TYPE_META,
+      statusMeta: STATUS_META,
+    }),
+    [],
+  );
+
+  const vaultOptions = useMemo(
+    () => [
+      "All Vaults",
+      ...Array.from(new Set(transactions.map((transaction) => transaction.vault))),
+    ],
+    [transactions],
+  );
 
   const copy = useCallback((text: string, id: string) => {
     navigator.clipboard.writeText(text).catch(() => {});
@@ -340,7 +373,7 @@ export default function VaultTransactions() {
   }, []);
 
   const filtered = useMemo<Transaction[]>(() => {
-    let list = [...MOCK_TRANSACTIONS];
+    let list = [...transactions];
     if (filterType !== "All Types")
       list = list.filter((t) => t.type === filterType);
     if (filterVault !== "All Vaults")
@@ -369,6 +402,7 @@ export default function VaultTransactions() {
     amountMin,
     amountMax,
     sortDir,
+    transactions,
   ]);
 
   const pending = filtered.filter((t) => t.status === "pending");
@@ -377,12 +411,34 @@ export default function VaultTransactions() {
 
   const stats = useMemo(
     () => ({
-      total: MOCK_TRANSACTIONS.length,
-      fees: MOCK_TRANSACTIONS.reduce((s, t) => s + t.fee, 0),
-      capital: MOCK_TRANSACTIONS.reduce((s, t) => s + t.amount, 0),
+      total: transactions.length,
+      fees: transactions.reduce((s, t) => s + t.fee, 0),
+      capital: transactions.reduce((s, t) => s + t.amount, 0),
     }),
-    [],
+    [transactions],
   );
+
+  const confirmedWindow = useMemo(
+    () =>
+      getWindowRange({
+        total: rest.length,
+        scrollTop: confirmedScrollTop,
+        rowHeight,
+        viewportHeight,
+        threshold: windowThreshold,
+        overscan,
+      }),
+    [confirmedScrollTop, overscan, rest.length, rowHeight, viewportHeight, windowThreshold],
+  );
+
+  const visibleConfirmed = useMemo(
+    () => sliceWindow(rest, confirmedWindow),
+    [confirmedWindow, rest],
+  );
+
+  const handleConfirmedScroll = useCallback((event: UIEvent<HTMLDivElement>) => {
+    setConfirmedScrollTop(event.currentTarget.scrollTop);
+  }, []);
 
   const clearFilters = () => {
     setFilterType("All Types");
@@ -475,7 +531,7 @@ export default function VaultTransactions() {
               <Select
                 value={filterVault}
                 onChange={setFilterVault}
-                options={VAULTS}
+                options={vaultOptions}
               />
               <Select
                 value={filterStatus}
@@ -528,6 +584,8 @@ export default function VaultTransactions() {
                 <TxRow
                   key={tx.id}
                   tx={tx}
+                  typeMeta={metadataMaps.typeMeta}
+                  statusMeta={metadataMaps.statusMeta}
                   onSelect={setSelectedTx}
                   onCopy={copy}
                   copiedId={copiedId}
@@ -543,6 +601,8 @@ export default function VaultTransactions() {
                 <TxRow
                   key={tx.id}
                   tx={tx}
+                  typeMeta={metadataMaps.typeMeta}
+                  statusMeta={metadataMaps.statusMeta}
                   onSelect={setSelectedTx}
                   onCopy={copy}
                   copiedId={copiedId}
@@ -554,14 +614,24 @@ export default function VaultTransactions() {
           )}
 
           {/* Confirmed */}
-          <Section title="Confirmed" accent="#6ee7b7" count={rest.length}>
+          <Section
+            title="Confirmed"
+            accent="#6ee7b7"
+            count={rest.length}
+            windowRange={confirmedWindow}
+            viewportHeight={viewportHeight}
+            onScroll={handleConfirmedScroll}
+            testId="confirmed-transaction-list"
+          >
             {rest.length === 0 ? (
               <EmptyState hasFilters={hasFilters} onClear={clearFilters} />
             ) : (
-              rest.map((tx) => (
+              visibleConfirmed.map((tx) => (
                 <TxRow
                   key={tx.id}
                   tx={tx}
+                  typeMeta={metadataMaps.typeMeta}
+                  statusMeta={metadataMaps.statusMeta}
                   onSelect={setSelectedTx}
                   onCopy={copy}
                   copiedId={copiedId}
@@ -590,36 +660,70 @@ interface SectionProps {
   accent: string;
   count: number;
   children: React.ReactNode;
+  windowRange?: WindowRange;
+  viewportHeight?: number;
+  onScroll?: (event: UIEvent<HTMLDivElement>) => void;
+  testId?: string;
 }
 
-function Section({ title, accent, count, children }: SectionProps) {
+function Section({
+  title,
+  accent,
+  count,
+  children,
+  windowRange,
+  viewportHeight,
+  onScroll,
+  testId,
+}: SectionProps) {
+  const isWindowed = windowRange?.isWindowed ?? false;
+
   return (
     <section className="vt-section">
       <div className="vt-section-header">
         <span className="vt-section-dot" style={{ background: accent }} />
         <span className="vt-section-title">{title}</span>
         <span className="vt-section-count">{count}</span>
+        {isWindowed && windowRange && (
+          <span className="vt-section-window">
+            Rendering {windowRange.start + 1}-{windowRange.end} of {count}
+          </span>
+        )}
       </div>
-      <div className="vt-tx-list">{children}</div>
+      <div
+        className="vt-tx-list"
+        data-testid={testId}
+        onScroll={onScroll}
+        style={isWindowed && windowRange ? {
+          maxHeight: viewportHeight,
+          overflowY: "auto",
+          paddingTop: windowRange.beforeHeight,
+          paddingBottom: windowRange.afterHeight,
+        } : undefined}
+      >
+        {children}
+      </div>
     </section>
   );
 }
 
 interface TxRowProps {
   tx: Transaction;
+  typeMeta: Readonly<Record<TxType, TypeMeta>>;
+  statusMeta: Readonly<Record<TxStatus, StatusMeta>>;
   onSelect: (tx: Transaction) => void;
   onCopy: (text: string, id: string) => void;
   copiedId: string | null;
   children?: React.ReactNode;
 }
 
-function TxRow({ tx, onSelect, onCopy, copiedId, children }: TxRowProps) {
-  const meta = TYPE_META[tx.type];
-  const status = STATUS_META[tx.status];
+function TxRow({ tx, typeMeta, statusMeta, onSelect, onCopy, copiedId, children }: TxRowProps) {
+  const meta = typeMeta[tx.type];
+  const status = statusMeta[tx.status];
   const Icon = meta.icon;
 
   return (
-    <div className="vt-tx-row" onClick={() => onSelect(tx)}>
+    <div className="vt-tx-row" data-testid="vault-transaction-row" onClick={() => onSelect(tx)}>
       <div
         className="vt-tx-icon"
         style={{ background: meta.bg, border: `1px solid ${meta.border}` }}
@@ -1188,6 +1292,9 @@ const CSS = `
   .vt-section-count {
     font-size: 11px; background: rgba(255,255,255,0.06); border-radius: var(--radius-full);
     padding: 2px 8px; color: #64748b; font-family: 'JetBrains Mono', monospace;
+  }
+  .vt-section-window {
+    margin-left: auto; font-size: 11px; color: #475569; font-family: 'JetBrains Mono', monospace;
   }
   .vt-tx-list { display: flex; flex-direction: column; gap: 4px; }
   .vt-tx-row {

--- a/src/pages/__tests__/VaultTransactions.test.tsx
+++ b/src/pages/__tests__/VaultTransactions.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import VaultTransactions, { type Transaction } from '../VaultTransactions';
+
+function makeTransaction(index: number, overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: `tx-${index}`,
+    type: 'create',
+    vault: `Vault ${index}`,
+    amount: 100 + index,
+    fee: 0.0001,
+    block: 48000000 + index,
+    hash: `hash-${index.toString().padStart(3, '0')}-abcdef1234567890`,
+    status: 'confirmed',
+    from: 'GSOURCE...TEST',
+    to: 'GDEST...TEST',
+    timestamp: new Date(Date.UTC(2026, 0, 1, 12, 0, 0) - index * 60000),
+    memo: '',
+    ...overrides,
+  };
+}
+
+describe('VaultTransactions windowing', () => {
+  it('renders every row for small transaction lists', () => {
+    const transactions = Array.from({ length: 5 }, (_, index) => makeTransaction(index));
+    const { container } = render(
+      <VaultTransactions transactions={transactions} windowThreshold={10} rowHeight={64} viewportHeight={128} />,
+    );
+
+    expect(screen.queryByText(/Rendering \d+-\d+ of/i)).not.toBeInTheDocument();
+    expect(container.querySelectorAll('[data-testid="vault-transaction-row"]')).toHaveLength(5);
+    expect(screen.getByText('Vault 0')).toBeInTheDocument();
+    expect(screen.getByText('Vault 4')).toBeInTheDocument();
+  });
+
+  it('renders only the visible window for large confirmed transaction lists', () => {
+    const transactions = Array.from({ length: 80 }, (_, index) => makeTransaction(index));
+    const { container } = render(
+      <VaultTransactions
+        transactions={transactions}
+        windowThreshold={10}
+        rowHeight={64}
+        viewportHeight={128}
+        overscan={1}
+      />,
+    );
+
+    expect(screen.getByText('Rendering 1-3 of 80')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-testid="vault-transaction-row"]')).toHaveLength(3);
+    expect(screen.getByText('Vault 0')).toBeInTheDocument();
+    expect(screen.queryByText('Vault 79')).not.toBeInTheDocument();
+  });
+
+  it('updates the rendered transaction window on scroll', () => {
+    const transactions = Array.from({ length: 80 }, (_, index) => makeTransaction(index));
+    render(
+      <VaultTransactions
+        transactions={transactions}
+        windowThreshold={10}
+        rowHeight={64}
+        viewportHeight={128}
+        overscan={1}
+      />,
+    );
+
+    fireEvent.scroll(screen.getByTestId('confirmed-transaction-list'), {
+      target: { scrollTop: 640 },
+    });
+
+    expect(screen.getByText('Rendering 10-13 of 80')).toBeInTheDocument();
+    expect(screen.getByText('Vault 9')).toBeInTheDocument();
+    expect(screen.getByText('Vault 12')).toBeInTheDocument();
+    expect(screen.queryByText('Vault 0')).not.toBeInTheDocument();
+  });
+});

--- a/src/utils/__tests__/windowRange.test.ts
+++ b/src/utils/__tests__/windowRange.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { getWindowRange, sliceWindow } from '../windowRange';
+
+const baseOptions = {
+  scrollTop: 0,
+  rowHeight: 50,
+  viewportHeight: 200,
+  threshold: 10,
+  overscan: 2,
+};
+
+describe('getWindowRange', () => {
+  it('returns an empty non-windowed range for zero rows', () => {
+    expect(getWindowRange({ ...baseOptions, total: 0 })).toEqual({
+      start: 0,
+      end: 0,
+      beforeHeight: 0,
+      afterHeight: 0,
+      totalHeight: 0,
+      visibleCount: 0,
+      isWindowed: false,
+    });
+  });
+
+  it('does not window lists below or at the threshold', () => {
+    expect(getWindowRange({ ...baseOptions, total: 9 })).toMatchObject({
+      start: 0,
+      end: 9,
+      visibleCount: 9,
+      isWindowed: false,
+    });
+
+    expect(getWindowRange({ ...baseOptions, total: 10 })).toMatchObject({
+      start: 0,
+      end: 10,
+      visibleCount: 10,
+      isWindowed: false,
+    });
+  });
+
+  it('windows a large list at the top with overscan after the viewport', () => {
+    expect(getWindowRange({ ...baseOptions, total: 100 })).toMatchObject({
+      start: 0,
+      end: 6,
+      beforeHeight: 0,
+      afterHeight: 4700,
+      visibleCount: 6,
+      isWindowed: true,
+    });
+  });
+
+  it('windows a large list around the current scroll position', () => {
+    expect(getWindowRange({ ...baseOptions, total: 100, scrollTop: 1000 })).toMatchObject({
+      start: 18,
+      end: 26,
+      beforeHeight: 900,
+      afterHeight: 3700,
+      visibleCount: 8,
+      isWindowed: true,
+    });
+  });
+
+  it('clamps the range at the end of the list', () => {
+    expect(getWindowRange({ ...baseOptions, total: 20, scrollTop: 2000 })).toMatchObject({
+      start: 14,
+      end: 20,
+      beforeHeight: 700,
+      afterHeight: 0,
+      visibleCount: 6,
+      isWindowed: true,
+    });
+  });
+});
+
+describe('sliceWindow', () => {
+  it('returns the original items when the range is not windowed', () => {
+    const items = ['a', 'b', 'c'];
+    const range = getWindowRange({ ...baseOptions, total: items.length });
+
+    expect(sliceWindow(items, range)).toBe(items);
+  });
+
+  it('returns only the visible window when windowed', () => {
+    const items = Array.from({ length: 20 }, (_, index) => index);
+    const range = getWindowRange({ ...baseOptions, total: items.length, scrollTop: 500 });
+
+    expect(sliceWindow(items, range)).toEqual([8, 9, 10, 11, 12, 13, 14, 15]);
+  });
+});

--- a/src/utils/windowRange.ts
+++ b/src/utils/windowRange.ts
@@ -1,0 +1,75 @@
+export interface WindowRangeOptions {
+  total: number;
+  scrollTop: number;
+  rowHeight: number;
+  viewportHeight: number;
+  threshold: number;
+  overscan?: number;
+}
+
+export interface WindowRange {
+  start: number;
+  end: number;
+  beforeHeight: number;
+  afterHeight: number;
+  totalHeight: number;
+  visibleCount: number;
+  isWindowed: boolean;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function safePositiveInteger(value: number, fallback: number) {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+export function getWindowRange({
+  total,
+  scrollTop,
+  rowHeight,
+  viewportHeight,
+  threshold,
+  overscan = 4,
+}: WindowRangeOptions): WindowRange {
+  const safeTotal = safePositiveInteger(total, 0);
+  const safeRowHeight = safePositiveInteger(rowHeight, 1);
+  const safeViewportHeight = safePositiveInteger(viewportHeight, safeRowHeight);
+  const safeThreshold = safePositiveInteger(threshold, 0);
+  const safeOverscan = safePositiveInteger(overscan, 0);
+  const totalHeight = safeTotal * safeRowHeight;
+
+  if (safeTotal <= safeThreshold) {
+    return {
+      start: 0,
+      end: safeTotal,
+      beforeHeight: 0,
+      afterHeight: 0,
+      totalHeight,
+      visibleCount: safeTotal,
+      isWindowed: false,
+    };
+  }
+
+  const maxScrollTop = Math.max(0, totalHeight - safeViewportHeight);
+  const normalizedScrollTop = clamp(scrollTop, 0, maxScrollTop);
+  const firstVisible = Math.floor(normalizedScrollTop / safeRowHeight);
+  const visibleRows = Math.ceil(safeViewportHeight / safeRowHeight);
+  const start = clamp(firstVisible - safeOverscan, 0, safeTotal);
+  const end = clamp(firstVisible + visibleRows + safeOverscan, start, safeTotal);
+
+  return {
+    start,
+    end,
+    beforeHeight: start * safeRowHeight,
+    afterHeight: Math.max(0, (safeTotal - end) * safeRowHeight),
+    totalHeight,
+    visibleCount: end - start,
+    isWindowed: true,
+  };
+}
+
+export function sliceWindow<T>(items: T[], range: WindowRange): T[] {
+  return range.isWindowed ? items.slice(range.start, range.end) : items;
+}


### PR DESCRIPTION
## Summary
- add a pure `windowRange` helper with unit coverage for zero, threshold, top, middle, and end ranges
- add thresholded windowed rendering to the confirmed VaultTransactions section while keeping small lists fully rendered
- pass stable memoized type/status metadata maps into transaction rows and document the windowing threshold/approach

## Validation
- `npx eslint src/pages/VaultTransactions.tsx src/pages/__tests__/VaultTransactions.test.tsx src/utils/windowRange.ts src/utils/__tests__/windowRange.test.ts`
- `npx tsc --noEmit --target ES2020 --lib ES2020,DOM,DOM.Iterable --module ESNext --moduleResolution bundler --allowImportingTsExtensions --isolatedModules --moduleDetection force --jsx react-jsx --strict --skipLibCheck --types vitest,@testing-library/jest-dom --baseUrl . src/pages/VaultTransactions.tsx src/pages/__tests__/VaultTransactions.test.tsx src/utils/windowRange.ts src/utils/__tests__/windowRange.test.ts`
- `git diff --check`
- `git diff --cached --check`

## Blocked local checks
- `npx vitest run src/utils/__tests__/windowRange.test.ts src/pages/__tests__/VaultTransactions.test.tsx` is blocked in this Windows sandbox because Vite cannot start esbuild: `Error: spawn EPERM` while loading `vitest.config.ts`.

Closes #210