### PR TITLE
test: accessible table semantics for validation and transaction tables

### DIFF
--- a/design-system/documentation/table-accessibility.md
+++ b/design-system/documentation/table-accessibility.md
@@ -1,0 +1,24 @@
+# Table Accessibility
+
+Use native table markup when the UI is visually tabular. If a view must keep a card or list layout, expose the same structure with ARIA table roles.
+
+## Required Semantics
+
+- Give every data table a programmatic name with a `<caption>` or `aria-label`.
+- Mark native table headers with `scope="col"` or `scope="row"`.
+- For ARIA tables, use `role="table"`, `role="rowgroup"`, `role="row"`, `role="columnheader"`, and `role="cell"` together.
+- Expose active sorting on the sorted column with `aria-sort="ascending"` or `aria-sort="descending"`.
+- Keep hidden table headers available to assistive tech with visually hidden CSS, not `display: none`.
+
+## Non-Color Cues
+
+Status, urgency, and risk must not be communicated by color alone. Pair color with visible text such as `Urgent`, `Pending`, `Failed`, or an equivalent `aria-label`.
+
+## Test Expectations
+
+Tests for tables should assert:
+
+- The table can be found by role and accessible name.
+- Column headers are present and scoped.
+- Sorted columns expose `aria-sort`.
+- Status and urgency meanings are available as text or labels.

--- a/src/pages/PendingValidations.tsx
+++ b/src/pages/PendingValidations.tsx
@@ -12,10 +12,11 @@ export default function PendingValidations() {
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
 
   const sortedValidations = [...pendingValidations].sort((a, b) => {
-    return sortOrder === 'asc' 
-      ? a.daysRemaining - b.daysRemaining 
+    return sortOrder === 'asc'
+      ? a.daysRemaining - b.daysRemaining
       : b.daysRemaining - a.daysRemaining;
   });
+  const deadlineSort = sortOrder === 'asc' ? 'ascending' : 'descending';
 
   return (
     <div className="flex flex-col gap-6 p-6">
@@ -33,8 +34,10 @@ export default function PendingValidations() {
           </Text>
         </div>
         
-        <button 
+        <button
           onClick={() => setSortOrder(prev => prev === 'asc' ? 'desc' : 'asc')}
+          aria-controls="pending-validations-table"
+          aria-label={`Sort by Urgency: ${sortOrder === 'asc' ? 'High to Low' : 'Low to High'}`}
           className="px-4 py-2 border border-gray-300 rounded text-sm font-medium hover:bg-gray-50 transition"
         >
           Sort by Urgency: {sortOrder === 'asc' ? 'High to Low' : 'Low to High'}
@@ -48,14 +51,17 @@ export default function PendingValidations() {
             <Text role="body" as="p" className="mt-2">There are no pending validations in your queue.</Text>
           </div>
         ) : (
-          <table className="w-full text-left border-collapse">
+          <table id="pending-validations-table" className="w-full text-left border-collapse">
+            <caption className="sr-only">
+              Pending validations queue sorted by deadline urgency.
+            </caption>
             <thead>
               <tr className="bg-gray-50 border-b border-gray-200">
-                <th className="p-4 font-medium text-sm text-gray-600">Vault & Milestone</th>
-                <th className="p-4 font-medium text-sm text-gray-600">Owner</th>
-                <th className="p-4 font-medium text-sm text-gray-600">Amount at Stake</th>
-                <th className="p-4 font-medium text-sm text-gray-600">Deadline</th>
-                <th className="p-4 font-medium text-sm text-gray-600 text-right">Actions</th>
+                <th scope="col" className="p-4 font-medium text-sm text-gray-600">Vault & Milestone</th>
+                <th scope="col" className="p-4 font-medium text-sm text-gray-600">Owner</th>
+                <th scope="col" className="p-4 font-medium text-sm text-gray-600">Amount at Stake</th>
+                <th scope="col" aria-sort={deadlineSort} className="p-4 font-medium text-sm text-gray-600">Deadline</th>
+                <th scope="col" className="p-4 font-medium text-sm text-gray-600 text-right">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -77,6 +83,11 @@ export default function PendingValidations() {
                     <div className="flex flex-col">
                       <Text role="body" as="p" className="text-sm">{task.deadline}</Text>
                       <CountdownDeadline deadline={task.deadline} />
+                      {task.daysRemaining <= 3 && (
+                        <span className="mt-1 inline-flex w-fit rounded-full bg-red-50 px-2 py-0.5 text-xs font-semibold text-red-700">
+                          Urgent
+                        </span>
+                      )}
                     </div>
                   </td>
                   <td className="p-4 text-right">

--- a/src/pages/VaultTransactions.tsx
+++ b/src/pages/VaultTransactions.tsx
@@ -246,6 +246,12 @@ const TYPES: string[] = [
   "release",
   "redirect",
 ];
+const TRANSACTION_TABLE_COLUMNS = [
+  "Transaction",
+  "Amount and fee",
+  "Status and time",
+  "Actions",
+];
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 function truncHash(hash: string, head = 8, tail = 6): string {
@@ -523,7 +529,12 @@ export default function VaultTransactions() {
 
           {/* Pending */}
           {pending.length > 0 && (
-            <Section title="Pending" accent="#fcd34d" count={pending.length}>
+            <Section
+              title="Pending"
+              accent="#fcd34d"
+              count={pending.length}
+              tableLabel="Pending transactions table"
+            >
               {pending.map((tx) => (
                 <TxRow
                   key={tx.id}
@@ -538,7 +549,12 @@ export default function VaultTransactions() {
 
           {/* Failed */}
           {failed.length > 0 && (
-            <Section title="Failed" accent="#fca5a5" count={failed.length}>
+            <Section
+              title="Failed"
+              accent="#fca5a5"
+              count={failed.length}
+              tableLabel="Failed transactions table"
+            >
               {failed.map((tx) => (
                 <TxRow
                   key={tx.id}
@@ -554,9 +570,22 @@ export default function VaultTransactions() {
           )}
 
           {/* Confirmed */}
-          <Section title="Confirmed" accent="#6ee7b7" count={rest.length}>
+          <Section
+            title="Confirmed"
+            accent="#6ee7b7"
+            count={rest.length}
+            tableLabel="Confirmed transactions table"
+          >
             {rest.length === 0 ? (
-              <EmptyState hasFilters={hasFilters} onClear={clearFilters} />
+              <div className="vt-empty-row" role="row">
+                <div
+                  className="vt-empty-cell"
+                  role="cell"
+                  aria-colspan={TRANSACTION_TABLE_COLUMNS.length}
+                >
+                  <EmptyState hasFilters={hasFilters} onClear={clearFilters} />
+                </div>
+              </div>
             ) : (
               rest.map((tx) => (
                 <TxRow
@@ -589,10 +618,11 @@ interface SectionProps {
   title: string;
   accent: string;
   count: number;
+  tableLabel: string;
   children: React.ReactNode;
 }
 
-function Section({ title, accent, count, children }: SectionProps) {
+function Section({ title, accent, count, tableLabel, children }: SectionProps) {
   return (
     <section className="vt-section">
       <div className="vt-section-header">
@@ -600,7 +630,30 @@ function Section({ title, accent, count, children }: SectionProps) {
         <span className="vt-section-title">{title}</span>
         <span className="vt-section-count">{count}</span>
       </div>
-      <div className="vt-tx-list">{children}</div>
+      <div
+        className="vt-tx-list"
+        role="table"
+        aria-label={tableLabel}
+        aria-colcount={TRANSACTION_TABLE_COLUMNS.length}
+        aria-rowcount={Math.max(count, 1) + 1}
+      >
+        <div className="vt-sr-only" role="rowgroup">
+          <div role="row">
+            {TRANSACTION_TABLE_COLUMNS.map((column, index) => (
+              <span
+                key={column}
+                role="columnheader"
+                aria-colindex={index + 1}
+              >
+                {column}
+              </span>
+            ))}
+          </div>
+        </div>
+        <div className="vt-tx-rowgroup" role="rowgroup">
+          {children}
+        </div>
+      </div>
     </section>
   );
 }
@@ -619,15 +672,21 @@ function TxRow({ tx, onSelect, onCopy, copiedId, children }: TxRowProps) {
   const Icon = meta.icon;
 
   return (
-    <div className="vt-tx-row" onClick={() => onSelect(tx)}>
+    <div
+      className="vt-tx-row"
+      role="row"
+      aria-label={`${status.label} ${meta.label} transaction for ${tx.vault}`}
+      onClick={() => onSelect(tx)}
+    >
       <div
         className="vt-tx-icon"
+        aria-hidden="true"
         style={{ background: meta.bg, border: `1px solid ${meta.border}` }}
       >
         <Icon color={meta.color} />
       </div>
 
-      <div className="vt-tx-main">
+      <div className="vt-tx-main" role="cell">
         <div className="vt-tx-top">
           <span className="vt-tx-type" style={{ color: meta.color }}>
             {meta.label}
@@ -659,7 +718,7 @@ function TxRow({ tx, onSelect, onCopy, copiedId, children }: TxRowProps) {
         </div>
       </div>
 
-      <div className="vt-tx-amount">
+      <div className="vt-tx-amount" role="cell">
         {tx.amount > 0 && (
           <span className="vt-tx-amount-val">
             {fmtAmount(tx.amount)}
@@ -669,18 +728,25 @@ function TxRow({ tx, onSelect, onCopy, copiedId, children }: TxRowProps) {
         <span className="vt-tx-fee">Fee: {tx.fee.toFixed(5)}</span>
       </div>
 
-      <div className="vt-tx-right">
+      <div className="vt-tx-right" role="cell">
         <span
           className="vt-tx-status"
+          aria-label={`Status: ${status.label}`}
           style={{ color: status.color, background: status.bg }}
         >
-          <span className="vt-status-dot" style={{ background: status.dot }} />
+          <span
+            className="vt-status-dot"
+            aria-hidden="true"
+            style={{ background: status.dot }}
+          />
           {status.label}
         </span>
         <span className="vt-tx-time">{fmtTime(tx.timestamp)}</span>
       </div>
 
-      {children}
+      <div className="vt-tx-actions" role="cell">
+        {children}
+      </div>
     </div>
   );
 }
@@ -1189,7 +1255,12 @@ const CSS = `
     font-size: 11px; background: rgba(255,255,255,0.06); border-radius: var(--radius-full);
     padding: 2px 8px; color: #64748b; font-family: 'JetBrains Mono', monospace;
   }
+  .vt-sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+  }
   .vt-tx-list { display: flex; flex-direction: column; gap: 4px; }
+  .vt-tx-rowgroup { display: flex; flex-direction: column; gap: 4px; }
   .vt-tx-row {
     display: flex; align-items: center; gap: 14px;
     background: rgba(255,255,255,0.02); border: 1px solid rgba(255,255,255,0.05);
@@ -1227,12 +1298,14 @@ const CSS = `
   }
   .vt-status-dot { width: 5px; height: 5px; border-radius: 50%; flex-shrink: 0; }
   .vt-tx-time { font-size: 11px; color: #334155; }
+  .vt-tx-actions { display: flex; align-items: center; justify-content: flex-end; flex-shrink: 0; min-width: 0; }
   .vt-retry-btn {
     background: rgba(252,165,165,0.08); border: 1px solid rgba(252,165,165,0.2);
     color: #fca5a5; font-family: 'Syne', sans-serif; font-size: 11px; font-weight: 700;
     padding: 5px 10px; border-radius: 6px; cursor: pointer; flex-shrink: 0; transition: all var(--duration-normal) var(--ease-in-out);
   }
   .vt-retry-btn:hover { background: rgba(252,165,165,0.15); }
+  .vt-empty-row, .vt-empty-cell { width: 100%; }
   .vt-empty { text-align: center; padding: 56px 24px; }
   .vt-empty-icon { font-size: 36px; margin-bottom: 14px; opacity: 0.2; }
   .vt-empty-title { font-size: 16px; font-weight: 700; color: #e2e8f0; margin-bottom: 6px; }

--- a/src/pages/__tests__/PendingValidations.test.tsx
+++ b/src/pages/__tests__/PendingValidations.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import PendingValidations from '../PendingValidations';
@@ -58,10 +58,16 @@ function renderPage() {
   );
 }
 
+function mockVerifierStore(pendingValidations = makeTasks()) {
+  vi.mocked(useVerifierStore).mockReturnValue({
+    pendingValidations,
+  } as unknown as ReturnType<typeof useVerifierStore>);
+}
+
 describe('PendingValidations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: makeTasks() });
+    mockVerifierStore();
   });
 
   it('renders the page heading', () => {
@@ -70,16 +76,39 @@ describe('PendingValidations', () => {
   });
 
   it('shows "All caught up!" when there are no pending validations', () => {
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+    mockVerifierStore([]);
     renderPage();
     expect(screen.getByText('All caught up!')).toBeInTheDocument();
     expect(screen.getByText(/no pending validations/i)).toBeInTheDocument();
   });
 
   it('does not render the table when queue is empty', () => {
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+    mockVerifierStore([]);
     renderPage();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('exposes table name, column scopes, and deadline sort state', () => {
+    renderPage();
+
+    const table = screen.getByRole('table', {
+      name: /pending validations queue/i,
+    });
+    const headers = within(table).getAllByRole('columnheader');
+
+    expect(headers).toHaveLength(5);
+    headers.forEach((header) => {
+      expect(header).toHaveAttribute('scope', 'col');
+    });
+    expect(
+      within(table).getByRole('columnheader', { name: 'Deadline' }),
+    ).toHaveAttribute('aria-sort', 'ascending');
+
+    fireEvent.click(screen.getByRole('button', { name: /High to Low/i }));
+
+    expect(
+      within(table).getByRole('columnheader', { name: 'Deadline' }),
+    ).toHaveAttribute('aria-sort', 'descending');
   });
 
   it('renders a row for each pending task', () => {
@@ -142,38 +171,31 @@ describe('PendingValidations', () => {
   });
 
   it('renders a single task without crashing', () => {
-    (useVerifierStore as any).mockReturnValue({
-      pendingValidations: [makeTasks()[0]],
-    });
+    mockVerifierStore([makeTasks()[0]]);
     renderPage();
     expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
     expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 row
   });
 
   it('handles ties in daysRemaining (stable relative order preserved)', () => {
-    (useVerifierStore as any).mockReturnValue({
-      pendingValidations: [
-        { ...makeTasks()[0], id: 'v-a', daysRemaining: 5 },
-        { ...makeTasks()[1], id: 'v-b', daysRemaining: 5 },
-      ],
-    });
+    mockVerifierStore([
+      { ...makeTasks()[0], id: 'v-a', daysRemaining: 5 },
+      { ...makeTasks()[1], id: 'v-b', daysRemaining: 5 },
+    ]);
     renderPage();
     const rows = screen.getAllByRole('row').slice(1);
     expect(rows).toHaveLength(2);
-    // both show 5 days left — just assert they render without error
-    expect(screen.getAllByText('5 days left')).toHaveLength(2);
+    expect(within(rows[0]).getByText('Alpha Vault')).toBeInTheDocument();
+    expect(within(rows[1]).getByText('Beta Vault')).toBeInTheDocument();
   });
 
-  it('shows daysRemaining in red for tasks with 3 or fewer days', () => {
+  it('adds a visible urgency cue for tasks with 3 or fewer days remaining', () => {
     renderPage();
-    // v-2 has daysRemaining: 2 — should have red styling
-    const urgentSpan = screen.getByText('2 days left');
-    expect(urgentSpan.className).toContain('text-red-600');
-  });
 
-  it('shows daysRemaining in green for tasks with more than 3 days', () => {
-    renderPage();
-    const safeSpan = screen.getByText('10 days left');
-    expect(safeSpan.className).toContain('text-green-600');
+    const rows = screen.getAllByRole('row').slice(1);
+
+    expect(within(rows[0]).getByText('Beta Vault')).toBeInTheDocument();
+    expect(within(rows[0]).getByText('Urgent')).toBeInTheDocument();
+    expect(within(rows[1]).queryByText('Urgent')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/__tests__/VaultTransactions.test.tsx
+++ b/src/pages/__tests__/VaultTransactions.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import VaultTransactions from '../VaultTransactions';
+
+const columnNames = [
+  'Transaction',
+  'Amount and fee',
+  'Status and time',
+  'Actions',
+];
+
+describe('VaultTransactions', () => {
+  it('exposes each transaction group as a named accessible table', () => {
+    render(<VaultTransactions />);
+
+    expect(
+      screen.getByRole('table', { name: /pending transactions table/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('table', { name: /failed transactions table/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('table', { name: /confirmed transactions table/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('provides column headers for transaction tables', () => {
+    render(<VaultTransactions />);
+
+    const pendingTable = screen.getByRole('table', {
+      name: /pending transactions table/i,
+    });
+    const headers = within(pendingTable).getAllByRole('columnheader');
+
+    expect(headers).toHaveLength(columnNames.length);
+    columnNames.forEach((name, index) => {
+      expect(
+        within(pendingTable).getByRole('columnheader', { name }),
+      ).toHaveAttribute('aria-colindex', String(index + 1));
+    });
+  });
+
+  it('maps transaction rows to cells and labels status in text', () => {
+    render(<VaultTransactions />);
+
+    const pendingTable = screen.getByRole('table', {
+      name: /pending transactions table/i,
+    });
+    const rows = within(pendingTable).getAllByRole('row').slice(1);
+
+    expect(rows).toHaveLength(2);
+    expect(within(rows[0]).getAllByRole('cell')).toHaveLength(
+      columnNames.length,
+    );
+    expect(within(rows[0]).getByLabelText('Status: Pending')).toHaveTextContent(
+      'Pending',
+    );
+  });
+});


### PR DESCRIPTION
Closes #207.

## Summary
- Adds caption/scope/aria-sort semantics to the PendingValidations table and a visible Urgent cue for deadline urgency.
- Exposes VaultTransactions groups as named ARIA tables with column headers, rows, cells, and explicit status labels.
- Adds regression coverage plus table accessibility conventions in the design-system docs.

## Testing
- `npx eslint src/pages/PendingValidations.tsx src/pages/VaultTransactions.tsx src/pages/__tests__/PendingValidations.test.tsx src/pages/__tests__/VaultTransactions.test.tsx`
- `npx tsc -p tsconfig.codex-table-a11y.json --noEmit --pretty false` using a temporary targeted config, then removed it
- `npx vitest run src/pages/__tests__/PendingValidations.test.tsx src/pages/__tests__/VaultTransactions.test.tsx` fails locally before tests run because Vite/esbuild cannot start: `Error: spawn EPERM`