### PR TITLE
feat: add typed vault data service

### DIFF
--- a/docs/VAULT_DATA_LAYER.md
+++ b/docs/VAULT_DATA_LAYER.md
@@ -1,0 +1,31 @@
+# Vault Data Layer
+
+`src/services/vaultService.ts` is the single vault data seam for the current frontend mocks. Pages should import shared types from `src/types/vault.ts` and read vault data through `vaultService` instead of declaring page-local vault, milestone, or transaction arrays.
+
+## Public API
+
+- `listVaults(): Promise<Vault[]>` returns the list used by vault list/detail routes.
+- `getVault(id): Promise<Vault | undefined>` returns one typed vault or `undefined` for unknown ids.
+- `getTransactions(id): Promise<VaultTransaction[]>` returns transactions scoped to one vault id.
+- `listTransactions(): Promise<VaultTransaction[]>` returns the transaction-ledger projection used by `/transactions`.
+
+Dashboard-specific methods (`getDashboardSummary`, `listDashboardVaults`, `listDashboardActivity`, and `listDashboardDeadlines`) keep the existing dashboard fixture values intact while moving the data out of the page.
+
+Snapshot methods exist for the mock implementation so pages can preserve the current first render without a loading flicker. New integration code should prefer the Promise methods.
+
+## Integration Seam
+
+When real contract data is available, replace the backing fixtures inside `vaultService` with adapters for:
+
+- Soroban contract reads for vault state, contract addresses, milestones, and release destinations.
+- Horizon or indexer reads for transaction hashes, ledger numbers, fees, status, and timestamps.
+- Any app backend cache that joins contract state with user-facing names or verifier metadata.
+
+Keep the exported service method signatures stable. That lets page components remain unchanged while the implementation moves from local mock data to network-backed reads.
+
+## Data Rules
+
+- Preserve the shared `Vault`, `Milestone`, and `VaultTransaction` contracts in `src/types/vault.ts`.
+- Return cloned values from the mock service so callers cannot mutate the backing fixtures.
+- Convert external timestamps to ISO strings at the service boundary; pages can format them for display.
+- Represent missing vault ids with `undefined` and missing transaction lists with an empty array.

--- a/src/components/VaultCard.tsx
+++ b/src/components/VaultCard.tsx
@@ -3,8 +3,7 @@ import { Text } from './Text';
 import { VaultProgressBar } from './VaultProgressBar';
 import React from 'react';
 import { CountdownDeadline } from './CountdownDeadline';
-
-export type VaultStatus = 'active' | 'pending_validation' | 'completed' | 'failed';
+import type { VaultStatus } from '../types/vault';
 
 export interface VaultCardProps {
   id: string;
@@ -23,6 +22,7 @@ function StatusBadge({ status }: { status: VaultStatus }) {
     pending_validation: { label: 'Pending', bg: 'var(--warning-transparent)', fg: 'var(--warning)' },
     completed: { label: 'Completed', bg: 'var(--success-transparent)', fg: 'var(--success)' },
     failed: { label: 'Failed', bg: 'var(--danger-transparent)', fg: 'var(--danger)' },
+    cancelled: { label: 'Cancelled', bg: 'rgba(156,163,175,0.1)', fg: 'var(--muted)' },
   }[status];
 
   return (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,145 +1,16 @@
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom'
 import { Text } from '../components/Text';
 import VaultCard from '../components/VaultCard';
-
-// ── Types ─────────────────────────────────────────────────────────────────────
-type VaultStatus = "active" | "pending_validation" | "completed" | "failed";
-
-interface VaultPreview {
-  id: string;
-  name: string;
-  amount: number;
-  currency: string;
-  status: VaultStatus;
-  progressPct: number; // 0-100 time elapsed
-  deadline: string;
-}
-
-interface Activity {
-  id: string;
-  type: "created" | "validated" | "released" | "redirected";
-  vault: string;
-  timestamp: string;
-  amount?: number;
-}
-
-interface Deadline {
-  id: string;
-  name: string;
-  deadline: string;
-  amount: number;
-}
-
-// ── Mock Data ─────────────────────────────────────────────────────────────────
-const SUMMARY = {
-  totalLocked: 25500,
-  activeVaults: 3,
-  pendingMilestones: 2,
-  completionRate: 67,
-};
-
-const VAULTS: VaultPreview[] = [
-  {
-    id: "1",
-    name: "Alpha Vault",
-    amount: 12500,
-    currency: "USDC",
-    status: "active",
-    progressPct: 42,
-    deadline: "2024-07-15T10:00:00Z",
-  },
-  {
-    id: "2",
-    name: "Beta Reserve",
-    amount: 8800,
-    currency: "USDC",
-    status: "pending_validation",
-    progressPct: 78,
-    deadline: "2024-05-20T10:00:00Z",
-  },
-  {
-    id: "3",
-    name: "Gamma Fund",
-    amount: 4200,
-    currency: "USDC",
-    status: "active",
-    progressPct: 25,
-    deadline: "2024-09-01T10:00:00Z",
-  },
-];
-
-const ACTIVITY: Activity[] = [
-  {
-    id: "a1",
-    type: "validated",
-    vault: "Alpha Vault",
-    timestamp: "2024-04-28T14:30:00Z",
-  },
-  {
-    id: "a2",
-    type: "created",
-    vault: "Gamma Fund",
-    timestamp: "2024-04-27T09:00:00Z",
-    amount: 4200,
-  },
-  {
-    id: "a3",
-    type: "released",
-    vault: "Delta Safe",
-    timestamp: "2024-04-25T16:45:00Z",
-    amount: 15000,
-  },
-  {
-    id: "a4",
-    type: "redirected",
-    vault: "Epsilon Pool",
-    timestamp: "2024-04-24T11:20:00Z",
-    amount: 3300,
-  },
-];
-
-const DEADLINES: Deadline[] = [
-  {
-    id: "2",
-    name: "Beta Reserve",
-    deadline: "2024-05-20T10:00:00Z",
-    amount: 8800,
-  },
-  {
-    id: "1",
-    name: "Alpha Vault",
-    deadline: "2024-07-15T10:00:00Z",
-    amount: 12500,
-  },
-];
+import { vaultService } from '../services/vaultService';
+import type {
+  DashboardActivity as Activity,
+  DashboardDeadline as Deadline,
+  DashboardSummary,
+  VaultPreview,
+} from '../types/vault';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-const STATUS_CFG: Record<
-  VaultStatus,
-  { label: string; color: string; bg: string }
-> = {
-  active: {
-    label: "Active",
-    color: "var(--accent)",
-    bg: "var(--accent-transparent)",
-  },
-  pending_validation: {
-    label: "Pending Validation",
-    color: "var(--warning)",
-    bg: "rgba(245,158,11,0.1)",
-  },
-  completed: {
-    label: "Completed",
-    color: "var(--success)",
-    bg: "rgba(16,185,129,0.1)",
-  },
-  failed: {
-    label: "Failed",
-    color: "var(--danger)",
-    bg: "rgba(239,68,68,0.1)",
-  },
-};
-
 const ACTIVITY_CFG: Record<
   Activity["type"],
   { label: string; icon: string; color: string }
@@ -233,26 +104,6 @@ function SummaryCard({
   );
 }
 
-function StatusBadge({ status }: { status: VaultStatus }) {
-  const cfg = STATUS_CFG[status];
-  return (
-    <span
-      style={{
-        background: cfg.bg,
-        color: cfg.color,
-        border: `var(--border-width-1) solid ${cfg.color}`,
-        borderRadius: "var(--radius-full)",
-        padding: "2px 10px",
-        fontSize: 11,
-        fontWeight: 600,
-        whiteSpace: "nowrap",
-      }}
-    >
-      {cfg.label}
-    </span>
-  );
-}
-
 function SectionHeader({
   title,
   action,
@@ -285,7 +136,41 @@ function SectionHeader({
 
 // ── Dashboard ─────────────────────────────────────────────────────────────────
 export default function Dashboard() {
-  const hasVaults = VAULTS.length > 0;
+  const [summary, setSummary] = useState<DashboardSummary>(() =>
+    vaultService.getDashboardSummarySnapshot(),
+  );
+  const [vaults, setVaults] = useState<VaultPreview[]>(() =>
+    vaultService.listDashboardVaultsSnapshot(),
+  );
+  const [activity, setActivity] = useState<Activity[]>(() =>
+    vaultService.listDashboardActivitySnapshot(),
+  );
+  const [deadlines, setDeadlines] = useState<Deadline[]>(() =>
+    vaultService.listDashboardDeadlinesSnapshot(),
+  );
+
+  useEffect(() => {
+    let active = true;
+
+    Promise.all([
+      vaultService.getDashboardSummary(),
+      vaultService.listDashboardVaults(),
+      vaultService.listDashboardActivity(),
+      vaultService.listDashboardDeadlines(),
+    ]).then(([nextSummary, nextVaults, nextActivity, nextDeadlines]) => {
+      if (!active) return;
+      setSummary(nextSummary);
+      setVaults(nextVaults);
+      setActivity(nextActivity);
+      setDeadlines(nextDeadlines);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const hasVaults = vaults.length > 0;
 
   return (
     <div
@@ -316,21 +201,21 @@ export default function Dashboard() {
       >
         <SummaryCard
           label="Total Locked"
-          value={`$${SUMMARY.totalLocked.toLocaleString()}`}
+          value={`$${summary.totalLocked.toLocaleString()}`}
           sub="USDC"
           accent
         />
         <SummaryCard
           label="Active Vaults"
-          value={String(SUMMARY.activeVaults)}
+          value={String(summary.activeVaults)}
         />
         <SummaryCard
           label="Pending Milestones"
-          value={String(SUMMARY.pendingMilestones)}
+          value={String(summary.pendingMilestones)}
         />
         <SummaryCard
           label="Completion Rate"
-          value={`${SUMMARY.completionRate}%`}
+          value={`${summary.completionRate}%`}
           sub="all time"
         />
       </div>
@@ -418,7 +303,7 @@ export default function Dashboard() {
             />
             {hasVaults ? (
               <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-                {VAULTS.map(v => (
+                {vaults.map(v => (
                   <VaultCard
                     key={v.id}
                     id={v.id}
@@ -487,7 +372,7 @@ export default function Dashboard() {
                 gap: "0.5rem",
               }}
             >
-              {ACTIVITY.map((a) => {
+              {activity.map((a) => {
                 const cfg = ACTIVITY_CFG[a.type];
                 return (
                   <div
@@ -565,7 +450,7 @@ export default function Dashboard() {
             }}
           >
             <SectionHeader title="Upcoming Deadlines" />
-            {DEADLINES.length === 0 ? (
+            {deadlines.length === 0 ? (
               <Text role="caption" as="div" style={{ color: "var(--muted)" }}>
                 No upcoming deadlines.
               </Text>
@@ -577,7 +462,7 @@ export default function Dashboard() {
                   gap: "0.75rem",
                 }}
               >
-                {DEADLINES.map((d) => {
+                {deadlines.map((d) => {
                   const days = daysRemaining(d.deadline);
                   const color = urgencyColor(days);
                   return (

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { MilestoneTracker } from "../components/MilestoneTracker";
 import { VaultProgressBar } from "../components/VaultProgressBar";
@@ -8,186 +8,8 @@ import {
   type FundReleaseStatusProps,
 } from "../components/FundReleaseStatus";
 import { Text } from "../components/Text";
-
-// ── Types ─────────────────────────────────────────────────────────────────────
-type VaultStatus =
-  | "active"
-  | "completed"
-  | "failed"
-  | "cancelled"
-  | "pending_validation";
-
-type MilestoneStatus = "pending" | "validated" | "failed";
-
-interface Milestone {
-  id: string;
-  title: string;
-  description: string;
-  criteria: string;
-  status: MilestoneStatus;
-  validatedAt?: string;
-  evidenceUrl?: string;
-}
-
-interface VaultTransaction {
-  id: string;
-  type: "create" | "validate" | "release" | "redirect";
-  hash: string;
-  timestamp: string;
-  amount?: number;
-}
-
-interface Vault {
-  id: string;
-  name: string;
-  status: VaultStatus;
-  amount: number;
-  currency: string;
-  createdAt: string;
-  deadline: string;
-  creatorAddress: string;
-  verifierAddress?: string;
-  successAddress: string;
-  failureAddress: string;
-  contractAddress: string;
-  milestones: Milestone[];
-  transactions: VaultTransaction[];
-}
-
-// ── Mock Data ─────────────────────────────────────────────────────────────────
-const MOCK_VAULTS: Record<string, Vault> = {
-  "1": {
-    id: "1",
-    name: "Alpha Vault",
-    status: "active",
-    amount: 12500,
-    currency: "USDC",
-    createdAt: "2024-01-15T10:00:00Z",
-    deadline: "2024-07-15T10:00:00Z",
-    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
-    verifierAddress: "GVERIF3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    contractAddress: "GCONT3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    milestones: [
-      {
-        id: "m1",
-        title: "Phase 1 Complete",
-        description: "Complete initial development phase",
-        criteria: "All unit tests passing, code reviewed",
-        status: "validated",
-        validatedAt: "2024-02-20T14:30:00Z",
-        evidenceUrl: "https://github.com/org/repo/pull/42",
-      },
-      {
-        id: "m2",
-        title: "Beta Launch",
-        description: "Launch beta version to 100 users",
-        criteria: "Beta deployed, 100 active users onboarded",
-        status: "pending",
-      },
-    ],
-    transactions: [
-      {
-        id: "tx1",
-        type: "create",
-        hash: "a3f9d1c8e2b74056af3d9c1b2e8f0a4d",
-        timestamp: "2024-01-15T10:00:00Z",
-        amount: 12500,
-      },
-      {
-        id: "tx2",
-        type: "validate",
-        hash: "b4e0c2d9f3a85167bg4e0d2c3f9a5e8b",
-        timestamp: "2024-02-20T14:30:00Z",
-      },
-    ],
-  },
-  "2": {
-    id: "2",
-    name: "Beta Reserve",
-    status: "completed",
-    amount: 4200.5,
-    currency: "USDC",
-    createdAt: "2023-10-01T09:00:00Z",
-    deadline: "2024-01-01T09:00:00Z",
-    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
-    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    contractAddress: "GCONT4KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    milestones: [
-      {
-        id: "m1",
-        title: "Project Delivery",
-        description: "Deliver final project",
-        criteria: "All deliverables submitted and approved",
-        status: "validated",
-        validatedAt: "2023-12-28T11:00:00Z",
-        evidenceUrl: "https://docs.example.com/delivery",
-      },
-    ],
-    transactions: [
-      {
-        id: "tx1",
-        type: "create",
-        hash: "e7b3f5a2c6d18490ej7b3a5f6c2d8b1e",
-        timestamp: "2023-10-01T09:00:00Z",
-        amount: 4200.5,
-      },
-      {
-        id: "tx2",
-        type: "validate",
-        hash: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
-        timestamp: "2023-12-28T11:00:00Z",
-      },
-      {
-        id: "tx3",
-        type: "release",
-        hash: "c5f1d3e0a4b96278ch5f1e3d4a0b6f9c",
-        timestamp: "2024-01-01T09:00:00Z",
-        amount: 4200.5,
-      },
-    ],
-  },
-  "3": {
-    id: "3",
-    name: "Gamma Fund",
-    status: "failed",
-    amount: 8800,
-    currency: "USDC",
-    createdAt: "2023-08-01T08:00:00Z",
-    deadline: "2023-12-01T08:00:00Z",
-    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
-    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    contractAddress: "GCONT5KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    milestones: [
-      {
-        id: "m1",
-        title: "Milestone 1",
-        description: "First milestone",
-        criteria: "Criteria not met",
-        status: "failed",
-      },
-    ],
-    transactions: [
-      {
-        id: "tx1",
-        type: "create",
-        hash: "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8",
-        timestamp: "2023-08-01T08:00:00Z",
-        amount: 8800,
-      },
-      {
-        id: "tx2",
-        type: "redirect",
-        hash: "d6a2e4f1b5c07389di6a2f4e5b1c7a0d",
-        timestamp: "2023-12-01T08:00:00Z",
-        amount: 8800,
-      },
-    ],
-  },
-};
+import { vaultService } from "../services/vaultService";
+import type { Vault, VaultStatus } from "../types/vault";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 const STATUS_CONFIG: Record<
@@ -375,7 +197,28 @@ function Card({
 // ── Main Component ────────────────────────────────────────────────────────────
 export default function VaultDetail() {
   const { id } = useParams<{ id: string }>();
-  const vault = id ? MOCK_VAULTS[id] : undefined;
+  const [vault, setVault] = useState<Vault | undefined>(() =>
+    id ? vaultService.getVaultSnapshot(id) : undefined,
+  );
+
+  useEffect(() => {
+    let active = true;
+
+    if (!id) {
+      setVault(undefined);
+      return () => {
+        active = false;
+      };
+    }
+
+    vaultService.getVault(id).then((nextVault) => {
+      if (active) setVault(nextVault);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [id]);
 
   if (!vault) {
     return (

--- a/src/pages/VaultTransactions.tsx
+++ b/src/pages/VaultTransactions.tsx
@@ -1,18 +1,20 @@
-import { useState, useMemo, useCallback } from "react";
-
-// ── Types ─────────────────────────────────────────────────────────────────────
-type TxType = "create" | "validate" | "release" | "redirect";
-type TxStatus = "confirmed" | "pending" | "failed";
+import { useEffect, useState, useMemo, useCallback } from "react";
+import { vaultService } from "../services/vaultService";
+import type {
+  VaultTransaction as ServiceVaultTransaction,
+  VaultTransactionStatus,
+  VaultTransactionType,
+} from "../types/vault";
 
 interface Transaction {
   id: string;
-  type: TxType;
+  type: VaultTransactionType;
   vault: string;
   amount: number;
   fee: number;
   block: number;
   hash: string;
-  status: TxStatus;
+  status: VaultTransactionStatus;
   from: string;
   to: string;
   timestamp: Date;
@@ -39,151 +41,28 @@ interface IconProps {
   size?: number;
 }
 
-// ── Mock Data ─────────────────────────────────────────────────────────────────
-const MOCK_TRANSACTIONS: Transaction[] = [
-  {
-    id: "tx1",
-    type: "create",
-    vault: "Alpha Vault",
-    amount: 12500.0,
-    fee: 0.00012,
-    block: 48201933,
-    hash: "a3f9d1c8e2b74056af3d9c1b2e8f0a4d7c5e9b3f1a2d4c6e8b0f2a4c6d8e0f2a",
-    status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2),
-    memo: "Initial deposit",
-  },
-  {
-    id: "tx2",
-    type: "validate",
-    vault: "Alpha Vault",
-    amount: 0,
-    fee: 0.00008,
-    block: 48202011,
-    hash: "b4e0c2d9f3a85167bg4e0d2c3f9a5e8b4c6d0e2f4a6c8e0b2d4f6a8c0e2d4f6a",
-    status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 1.5),
-    memo: "",
-  },
-  {
-    id: "tx3",
-    type: "release",
-    vault: "Beta Reserve",
-    amount: 4200.5,
-    fee: 0.00015,
-    block: 48202450,
-    hash: "c5f1d3e0a4b96278ch5f1e3d4a0b6f9c5d7e1f3b5d7f9b1d3f5b7d9f1b3d5f7b",
-    status: "confirmed",
-    from: "GCVAULT...M3P",
-    to: "GBVZ3...QK7L",
-    timestamp: new Date(Date.now() - 1000 * 60 * 45),
-    memo: "Milestone payout",
-  },
-  {
-    id: "tx4",
-    type: "redirect",
-    vault: "Gamma Fund",
-    amount: 8800.0,
-    fee: 0.00011,
-    block: 48202891,
-    hash: "d6a2e4f1b5c07389di6a2f4e5b1c7a0d6e8f2a4c6e8a0c2e4f6a8c0e2f4a6c8e",
-    status: "pending",
-    from: "GCVAULT...M3P",
-    to: "GDELTA...X9K",
-    timestamp: new Date(Date.now() - 1000 * 60 * 20),
-    memo: "Redirect to escrow",
-  },
-  {
-    id: "tx5",
-    type: "create",
-    vault: "Beta Reserve",
-    amount: 31000.0,
-    fee: 0.00013,
-    block: 48201100,
-    hash: "e7b3f5a2c6d18490ej7b3a5f6c2d8b1e7f9a3b5d7f9b1d3f5b7d9f1b3d5f7b9d",
-    status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 5),
-    memo: "New vault",
-  },
-  {
-    id: "tx6",
-    type: "release",
-    vault: "Alpha Vault",
-    amount: 500.0,
-    fee: 0.00009,
-    block: 48203100,
-    hash: "f8c4a6b3d7e29501fk8c4b6a7d3e9c2f8a0c4b6d8f0b2d4f6a8b0d2f4a6b8d0f",
-    status: "failed",
-    from: "GCVAULT...M3P",
-    to: "GBVZ3...QK7L",
-    timestamp: new Date(Date.now() - 1000 * 60 * 10),
-    memo: "Partial release",
-  },
-  {
-    id: "tx7",
-    type: "validate",
-    vault: "Gamma Fund",
-    amount: 0,
-    fee: 0.00007,
-    block: 48201788,
-    hash: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
-    status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 3.5),
-    memo: "",
-  },
-  {
-    id: "tx8",
-    type: "redirect",
-    vault: "Alpha Vault",
-    amount: 1200.75,
-    fee: 0.0001,
-    block: 48203222,
-    hash: "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3",
-    status: "pending",
-    from: "GCVAULT...M3P",
-    to: "GBVZ3...QK7L",
-    timestamp: new Date(Date.now() - 1000 * 60 * 5),
-    memo: "Reallocation",
-  },
-  {
-    id: "tx9",
-    type: "create",
-    vault: "Delta Safe",
-    amount: 99000.0,
-    fee: 0.0002,
-    block: 48200500,
-    hash: "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4",
-    status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 8),
-    memo: "Large vault",
-  },
-  {
-    id: "tx10",
-    type: "release",
-    vault: "Delta Safe",
-    amount: 15000.0,
-    fee: 0.00016,
-    block: 48203400,
-    hash: "d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5",
-    status: "confirmed",
-    from: "GCVAULT...M3P",
-    to: "GBVZ3...QK7L",
-    timestamp: new Date(Date.now() - 1000 * 60 * 2),
-    memo: "Q3 release",
-  },
-];
+function toTransaction(tx: ServiceVaultTransaction): Transaction {
+  return {
+    id: tx.id,
+    type: tx.type,
+    vault: tx.vaultName ?? "Unknown Vault",
+    amount: tx.amount ?? 0,
+    fee: tx.fee ?? 0,
+    block: tx.block ?? 0,
+    hash: tx.hash,
+    status: tx.status ?? "confirmed",
+    from: tx.from ?? "",
+    to: tx.to ?? "",
+    timestamp: new Date(tx.timestamp),
+    memo: tx.memo ?? "",
+  };
+}
 
-const TYPE_META: Record<TxType, TypeMeta> = {
+function listTransactionSnapshots(): Transaction[] {
+  return vaultService.listTransactionsSnapshot().map(toTransaction);
+}
+
+const TYPE_META: Record<VaultTransactionType, TypeMeta> = {
   create: {
     label: "Create",
     color: "#6ee7b7",
@@ -214,7 +93,7 @@ const TYPE_META: Record<TxType, TypeMeta> = {
   },
 };
 
-const STATUS_META: Record<TxStatus, StatusMeta> = {
+const STATUS_META: Record<VaultTransactionStatus, StatusMeta> = {
   confirmed: {
     label: "Confirmed",
     color: "#6ee7b7",
@@ -235,10 +114,6 @@ const STATUS_META: Record<TxStatus, StatusMeta> = {
   },
 };
 
-const VAULTS = [
-  "All Vaults",
-  ...Array.from(new Set(MOCK_TRANSACTIONS.map((t) => t.vault))),
-];
 const TYPES: string[] = [
   "All Types",
   "create",
@@ -323,6 +198,9 @@ function exportCSV(txs: Transaction[]): void {
 
 // ── Main Component ────────────────────────────────────────────────────────────
 export default function VaultTransactions() {
+  const [transactions, setTransactions] = useState<Transaction[]>(() =>
+    listTransactionSnapshots(),
+  );
   const [filterType, setFilterType] = useState<string>("All Types");
   const [filterVault, setFilterVault] = useState<string>("All Vaults");
   const [filterStatus, setFilterStatus] = useState<string>("all");
@@ -333,6 +211,18 @@ export default function VaultTransactions() {
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
 
+  useEffect(() => {
+    let active = true;
+
+    vaultService.listTransactions().then((nextTransactions) => {
+      if (active) setTransactions(nextTransactions.map(toTransaction));
+    });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
   const copy = useCallback((text: string, id: string) => {
     navigator.clipboard.writeText(text).catch(() => {});
     setCopiedId(id);
@@ -340,7 +230,7 @@ export default function VaultTransactions() {
   }, []);
 
   const filtered = useMemo<Transaction[]>(() => {
-    let list = [...MOCK_TRANSACTIONS];
+    let list = [...transactions];
     if (filterType !== "All Types")
       list = list.filter((t) => t.type === filterType);
     if (filterVault !== "All Vaults")
@@ -369,6 +259,7 @@ export default function VaultTransactions() {
     amountMin,
     amountMax,
     sortDir,
+    transactions,
   ]);
 
   const pending = filtered.filter((t) => t.status === "pending");
@@ -377,11 +268,16 @@ export default function VaultTransactions() {
 
   const stats = useMemo(
     () => ({
-      total: MOCK_TRANSACTIONS.length,
-      fees: MOCK_TRANSACTIONS.reduce((s, t) => s + t.fee, 0),
-      capital: MOCK_TRANSACTIONS.reduce((s, t) => s + t.amount, 0),
+      total: transactions.length,
+      fees: transactions.reduce((s, t) => s + t.fee, 0),
+      capital: transactions.reduce((s, t) => s + t.amount, 0),
     }),
-    [],
+    [transactions],
+  );
+
+  const vaultOptions = useMemo(
+    () => ["All Vaults", ...Array.from(new Set(transactions.map((t) => t.vault)))],
+    [transactions],
   );
 
   const clearFilters = () => {
@@ -475,7 +371,7 @@ export default function VaultTransactions() {
               <Select
                 value={filterVault}
                 onChange={setFilterVault}
-                options={VAULTS}
+                options={vaultOptions}
               />
               <Select
                 value={filterStatus}

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -1,13 +1,8 @@
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Text } from '../components/Text'
-
-type VaultStatus = 'active' | 'completed' | 'failed' | 'cancelled' | 'pending_validation'
-
-const MOCK_VAULTS = [
-  { id: '1', name: 'Alpha Vault',   amount: 12500,  currency: 'USDC', status: 'active' as VaultStatus,    deadline: '2024-07-15T10:00:00Z' },
-  { id: '2', name: 'Beta Reserve',  amount: 4200.5, currency: 'USDC', status: 'completed' as VaultStatus, deadline: '2024-01-01T09:00:00Z' },
-  { id: '3', name: 'Gamma Fund',    amount: 8800,   currency: 'USDC', status: 'failed' as VaultStatus,    deadline: '2023-12-01T08:00:00Z' },
-]
+import { vaultService } from '../services/vaultService'
+import type { VaultStatus } from '../types/vault'
 
 const STATUS_CONFIG: Record<VaultStatus, { label: string; color: string; bg: string }> = {
   active:             { label: 'Active',             color: 'var(--accent)',  bg: 'var(--accent-transparent)' },
@@ -18,6 +13,20 @@ const STATUS_CONFIG: Record<VaultStatus, { label: string; color: string; bg: str
 }
 
 export default function Vaults() {
+  const [vaults, setVaults] = useState(() => vaultService.listVaultsSnapshot())
+
+  useEffect(() => {
+    let active = true
+
+    vaultService.listVaults().then((nextVaults) => {
+      if (active) setVaults(nextVaults)
+    })
+
+    return () => {
+      active = false
+    }
+  }, [])
+
   return (
     <div>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2rem', flexWrap: 'wrap', gap: '1rem' }}>
@@ -41,7 +50,7 @@ export default function Vaults() {
       </div>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-        {MOCK_VAULTS.map((vault) => {
+        {vaults.map((vault) => {
           const cfg = STATUS_CONFIG[vault.status]
           return (
             <Link

--- a/src/services/__tests__/vaultService.test.ts
+++ b/src/services/__tests__/vaultService.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { vaultService } from "../vaultService";
+
+describe("vaultService", () => {
+  it("lists the current vault mocks through the async data layer", async () => {
+    const vaults = await vaultService.listVaults();
+
+    expect(vaults.map((vault) => vault.name)).toEqual([
+      "Alpha Vault",
+      "Beta Reserve",
+      "Gamma Fund",
+    ]);
+    expect(vaults[1]).toMatchObject({
+      id: "2",
+      amount: 4200.5,
+      status: "completed",
+    });
+  });
+
+  it("returns one typed vault by id and undefined for unknown ids", async () => {
+    await expect(vaultService.getVault("1")).resolves.toMatchObject({
+      id: "1",
+      name: "Alpha Vault",
+      milestones: expect.arrayContaining([
+        expect.objectContaining({ id: "m1", status: "validated" }),
+      ]),
+    });
+
+    await expect(vaultService.getVault("missing")).resolves.toBeUndefined();
+  });
+
+  it("returns vault-scoped transactions from the required getTransactions seam", async () => {
+    const alphaTransactions = await vaultService.getTransactions("1");
+
+    expect(alphaTransactions).toHaveLength(2);
+    expect(alphaTransactions.map((transaction) => transaction.type)).toEqual([
+      "create",
+      "validate",
+    ]);
+    await expect(vaultService.getTransactions("missing")).resolves.toEqual([]);
+  });
+
+  it("lists the transaction-ledger mock for the transactions page", async () => {
+    const transactions = await vaultService.listTransactions();
+
+    expect(transactions).toHaveLength(10);
+    expect(transactions.some((tx) => tx.status === "pending")).toBe(true);
+    expect(transactions.some((tx) => tx.status === "failed")).toBe(true);
+  });
+
+  it("returns cloned data so callers cannot mutate the backing mock", async () => {
+    const firstRead = await vaultService.listVaults();
+    firstRead[0].name = "Mutated Vault";
+
+    const secondRead = await vaultService.listVaults();
+
+    expect(secondRead[0].name).toBe("Alpha Vault");
+  });
+});

--- a/src/services/vaultService.ts
+++ b/src/services/vaultService.ts
@@ -1,0 +1,442 @@
+import type {
+  DashboardActivity,
+  DashboardDeadline,
+  DashboardSummary,
+  Vault,
+  VaultPreview,
+  VaultTransaction,
+} from "../types/vault";
+
+const DASHBOARD_SUMMARY: DashboardSummary = {
+  totalLocked: 25500,
+  activeVaults: 3,
+  pendingMilestones: 2,
+  completionRate: 67,
+};
+
+const DASHBOARD_VAULTS: VaultPreview[] = [
+  {
+    id: "1",
+    name: "Alpha Vault",
+    amount: 12500,
+    currency: "USDC",
+    status: "active",
+    progressPct: 42,
+    deadline: "2024-07-15T10:00:00Z",
+  },
+  {
+    id: "2",
+    name: "Beta Reserve",
+    amount: 8800,
+    currency: "USDC",
+    status: "pending_validation",
+    progressPct: 78,
+    deadline: "2024-05-20T10:00:00Z",
+  },
+  {
+    id: "3",
+    name: "Gamma Fund",
+    amount: 4200,
+    currency: "USDC",
+    status: "active",
+    progressPct: 25,
+    deadline: "2024-09-01T10:00:00Z",
+  },
+];
+
+const DASHBOARD_ACTIVITY: DashboardActivity[] = [
+  {
+    id: "a1",
+    type: "validated",
+    vault: "Alpha Vault",
+    timestamp: "2024-04-28T14:30:00Z",
+  },
+  {
+    id: "a2",
+    type: "created",
+    vault: "Gamma Fund",
+    timestamp: "2024-04-27T09:00:00Z",
+    amount: 4200,
+  },
+  {
+    id: "a3",
+    type: "released",
+    vault: "Delta Safe",
+    timestamp: "2024-04-25T16:45:00Z",
+    amount: 15000,
+  },
+  {
+    id: "a4",
+    type: "redirected",
+    vault: "Epsilon Pool",
+    timestamp: "2024-04-24T11:20:00Z",
+    amount: 3300,
+  },
+];
+
+const DASHBOARD_DEADLINES: DashboardDeadline[] = [
+  {
+    id: "2",
+    name: "Beta Reserve",
+    deadline: "2024-05-20T10:00:00Z",
+    amount: 8800,
+  },
+  {
+    id: "1",
+    name: "Alpha Vault",
+    deadline: "2024-07-15T10:00:00Z",
+    amount: 12500,
+  },
+];
+
+const VAULTS_BY_ID: Record<string, Vault> = {
+  "1": {
+    id: "1",
+    name: "Alpha Vault",
+    status: "active",
+    amount: 12500,
+    currency: "USDC",
+    createdAt: "2024-01-15T10:00:00Z",
+    deadline: "2024-07-15T10:00:00Z",
+    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
+    verifierAddress: "GVERIF3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    contractAddress: "GCONT3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    milestones: [
+      {
+        id: "m1",
+        title: "Phase 1 Complete",
+        description: "Complete initial development phase",
+        criteria: "All unit tests passing, code reviewed",
+        status: "validated",
+        validatedAt: "2024-02-20T14:30:00Z",
+        evidenceUrl: "https://github.com/org/repo/pull/42",
+      },
+      {
+        id: "m2",
+        title: "Beta Launch",
+        description: "Launch beta version to 100 users",
+        criteria: "Beta deployed, 100 active users onboarded",
+        status: "pending",
+      },
+    ],
+    transactions: [
+      {
+        id: "tx1",
+        type: "create",
+        hash: "a3f9d1c8e2b74056af3d9c1b2e8f0a4d",
+        timestamp: "2024-01-15T10:00:00Z",
+        amount: 12500,
+      },
+      {
+        id: "tx2",
+        type: "validate",
+        hash: "b4e0c2d9f3a85167bg4e0d2c3f9a5e8b",
+        timestamp: "2024-02-20T14:30:00Z",
+      },
+    ],
+  },
+  "2": {
+    id: "2",
+    name: "Beta Reserve",
+    status: "completed",
+    amount: 4200.5,
+    currency: "USDC",
+    createdAt: "2023-10-01T09:00:00Z",
+    deadline: "2024-01-01T09:00:00Z",
+    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
+    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    contractAddress: "GCONT4KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    milestones: [
+      {
+        id: "m1",
+        title: "Project Delivery",
+        description: "Deliver final project",
+        criteria: "All deliverables submitted and approved",
+        status: "validated",
+        validatedAt: "2023-12-28T11:00:00Z",
+        evidenceUrl: "https://docs.example.com/delivery",
+      },
+    ],
+    transactions: [
+      {
+        id: "tx1",
+        type: "create",
+        hash: "e7b3f5a2c6d18490ej7b3a5f6c2d8b1e",
+        timestamp: "2023-10-01T09:00:00Z",
+        amount: 4200.5,
+      },
+      {
+        id: "tx2",
+        type: "validate",
+        hash: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+        timestamp: "2023-12-28T11:00:00Z",
+      },
+      {
+        id: "tx3",
+        type: "release",
+        hash: "c5f1d3e0a4b96278ch5f1e3d4a0b6f9c",
+        timestamp: "2024-01-01T09:00:00Z",
+        amount: 4200.5,
+      },
+    ],
+  },
+  "3": {
+    id: "3",
+    name: "Gamma Fund",
+    status: "failed",
+    amount: 8800,
+    currency: "USDC",
+    createdAt: "2023-08-01T08:00:00Z",
+    deadline: "2023-12-01T08:00:00Z",
+    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
+    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    contractAddress: "GCONT5KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    milestones: [
+      {
+        id: "m1",
+        title: "Milestone 1",
+        description: "First milestone",
+        criteria: "Criteria not met",
+        status: "failed",
+      },
+    ],
+    transactions: [
+      {
+        id: "tx1",
+        type: "create",
+        hash: "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8",
+        timestamp: "2023-08-01T08:00:00Z",
+        amount: 8800,
+      },
+      {
+        id: "tx2",
+        type: "redirect",
+        hash: "d6a2e4f1b5c07389di6a2f4e5b1c7a0d",
+        timestamp: "2023-12-01T08:00:00Z",
+        amount: 8800,
+      },
+    ],
+  },
+};
+
+function recentTimestamp(msAgo: number): string {
+  return new Date(Date.now() - msAgo).toISOString();
+}
+
+const LEDGER_TRANSACTIONS: VaultTransaction[] = [
+  {
+    id: "tx1",
+    type: "create",
+    vaultId: "1",
+    vaultName: "Alpha Vault",
+    amount: 12500.0,
+    fee: 0.00012,
+    block: 48201933,
+    hash: "a3f9d1c8e2b74056af3d9c1b2e8f0a4d7c5e9b3f1a2d4c6e8b0f2a4c6d8e0f2a",
+    status: "confirmed",
+    from: "GBVZ3...QK7L",
+    to: "GCVAULT...M3P",
+    timestamp: recentTimestamp(1000 * 60 * 60 * 2),
+    memo: "Initial deposit",
+  },
+  {
+    id: "tx2",
+    type: "validate",
+    vaultId: "1",
+    vaultName: "Alpha Vault",
+    amount: 0,
+    fee: 0.00008,
+    block: 48202011,
+    hash: "b4e0c2d9f3a85167bg4e0d2c3f9a5e8b4c6d0e2f4a6c8e0b2d4f6a8c0e2d4f6a",
+    status: "confirmed",
+    from: "GBVZ3...QK7L",
+    to: "GCVAULT...M3P",
+    timestamp: recentTimestamp(1000 * 60 * 60 * 1.5),
+    memo: "",
+  },
+  {
+    id: "tx3",
+    type: "release",
+    vaultId: "2",
+    vaultName: "Beta Reserve",
+    amount: 4200.5,
+    fee: 0.00015,
+    block: 48202450,
+    hash: "c5f1d3e0a4b96278ch5f1e3d4a0b6f9c5d7e1f3b5d7f9b1d3f5b7d9f1b3d5f7b",
+    status: "confirmed",
+    from: "GCVAULT...M3P",
+    to: "GBVZ3...QK7L",
+    timestamp: recentTimestamp(1000 * 60 * 45),
+    memo: "Milestone payout",
+  },
+  {
+    id: "tx4",
+    type: "redirect",
+    vaultId: "3",
+    vaultName: "Gamma Fund",
+    amount: 8800.0,
+    fee: 0.00011,
+    block: 48202891,
+    hash: "d6a2e4f1b5c07389di6a2f4e5b1c7a0d6e8f2a4c6e8a0c2e4f6a8c0e2f4a6c8e",
+    status: "pending",
+    from: "GCVAULT...M3P",
+    to: "GDELTA...X9K",
+    timestamp: recentTimestamp(1000 * 60 * 20),
+    memo: "Redirect to escrow",
+  },
+  {
+    id: "tx5",
+    type: "create",
+    vaultId: "2",
+    vaultName: "Beta Reserve",
+    amount: 31000.0,
+    fee: 0.00013,
+    block: 48201100,
+    hash: "e7b3f5a2c6d18490ej7b3a5f6c2d8b1e7f9a3b5d7f9b1d3f5b7d9f1b3d5f7b9d",
+    status: "confirmed",
+    from: "GBVZ3...QK7L",
+    to: "GCVAULT...M3P",
+    timestamp: recentTimestamp(1000 * 60 * 60 * 5),
+    memo: "New vault",
+  },
+  {
+    id: "tx6",
+    type: "release",
+    vaultId: "1",
+    vaultName: "Alpha Vault",
+    amount: 500.0,
+    fee: 0.00009,
+    block: 48203100,
+    hash: "f8c4a6b3d7e29501fk8c4b6a7d3e9c2f8a0c4b6d8f0b2d4f6a8b0d2f4a6b8d0f",
+    status: "failed",
+    from: "GCVAULT...M3P",
+    to: "GBVZ3...QK7L",
+    timestamp: recentTimestamp(1000 * 60 * 10),
+    memo: "Partial release",
+  },
+  {
+    id: "tx7",
+    type: "validate",
+    vaultId: "3",
+    vaultName: "Gamma Fund",
+    amount: 0,
+    fee: 0.00007,
+    block: 48201788,
+    hash: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+    status: "confirmed",
+    from: "GBVZ3...QK7L",
+    to: "GCVAULT...M3P",
+    timestamp: recentTimestamp(1000 * 60 * 60 * 3.5),
+    memo: "",
+  },
+  {
+    id: "tx8",
+    type: "redirect",
+    vaultId: "1",
+    vaultName: "Alpha Vault",
+    amount: 1200.75,
+    fee: 0.0001,
+    block: 48203222,
+    hash: "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3",
+    status: "pending",
+    from: "GCVAULT...M3P",
+    to: "GBVZ3...QK7L",
+    timestamp: recentTimestamp(1000 * 60 * 5),
+    memo: "Reallocation",
+  },
+  {
+    id: "tx9",
+    type: "create",
+    vaultId: "4",
+    vaultName: "Delta Safe",
+    amount: 99000.0,
+    fee: 0.0002,
+    block: 48200500,
+    hash: "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4",
+    status: "confirmed",
+    from: "GBVZ3...QK7L",
+    to: "GCVAULT...M3P",
+    timestamp: recentTimestamp(1000 * 60 * 60 * 8),
+    memo: "Large vault",
+  },
+  {
+    id: "tx10",
+    type: "release",
+    vaultId: "4",
+    vaultName: "Delta Safe",
+    amount: 15000.0,
+    fee: 0.00016,
+    block: 48203400,
+    hash: "d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5",
+    status: "confirmed",
+    from: "GCVAULT...M3P",
+    to: "GBVZ3...QK7L",
+    timestamp: recentTimestamp(1000 * 60 * 2),
+    memo: "Q3 release",
+  },
+];
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function listVaultsSnapshot(): Vault[] {
+  return clone(Object.values(VAULTS_BY_ID));
+}
+
+function getVaultSnapshot(id: string): Vault | undefined {
+  const vault = VAULTS_BY_ID[id];
+  return vault ? clone(vault) : undefined;
+}
+
+function getTransactionsSnapshot(id: string): VaultTransaction[] {
+  return clone(VAULTS_BY_ID[id]?.transactions ?? []);
+}
+
+function listTransactionsSnapshot(): VaultTransaction[] {
+  return clone(LEDGER_TRANSACTIONS);
+}
+
+function getDashboardSummarySnapshot(): DashboardSummary {
+  return clone(DASHBOARD_SUMMARY);
+}
+
+function listDashboardVaultsSnapshot(): VaultPreview[] {
+  return clone(DASHBOARD_VAULTS);
+}
+
+function listDashboardActivitySnapshot(): DashboardActivity[] {
+  return clone(DASHBOARD_ACTIVITY);
+}
+
+function listDashboardDeadlinesSnapshot(): DashboardDeadline[] {
+  return clone(DASHBOARD_DEADLINES);
+}
+
+export const vaultService = {
+  listVaults: async (): Promise<Vault[]> => listVaultsSnapshot(),
+  getVault: async (id: string): Promise<Vault | undefined> => getVaultSnapshot(id),
+  getTransactions: async (id: string): Promise<VaultTransaction[]> =>
+    getTransactionsSnapshot(id),
+  listTransactions: async (): Promise<VaultTransaction[]> => listTransactionsSnapshot(),
+  getDashboardSummary: async (): Promise<DashboardSummary> =>
+    getDashboardSummarySnapshot(),
+  listDashboardVaults: async (): Promise<VaultPreview[]> =>
+    listDashboardVaultsSnapshot(),
+  listDashboardActivity: async (): Promise<DashboardActivity[]> =>
+    listDashboardActivitySnapshot(),
+  listDashboardDeadlines: async (): Promise<DashboardDeadline[]> =>
+    listDashboardDeadlinesSnapshot(),
+  listVaultsSnapshot,
+  getVaultSnapshot,
+  getTransactionsSnapshot,
+  listTransactionsSnapshot,
+  getDashboardSummarySnapshot,
+  listDashboardVaultsSnapshot,
+  listDashboardActivitySnapshot,
+  listDashboardDeadlinesSnapshot,
+};

--- a/src/types/vault.ts
+++ b/src/types/vault.ts
@@ -1,0 +1,85 @@
+export type VaultStatus =
+  | "active"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "pending_validation";
+
+export type MilestoneStatus = "pending" | "validated" | "failed";
+export type VaultTransactionType = "create" | "validate" | "release" | "redirect";
+export type VaultTransactionStatus = "confirmed" | "pending" | "failed";
+
+export interface Milestone {
+  id: string;
+  title: string;
+  description: string;
+  criteria: string;
+  status: MilestoneStatus;
+  validatedAt?: string;
+  evidenceUrl?: string;
+}
+
+export interface VaultTransaction {
+  id: string;
+  type: VaultTransactionType;
+  hash: string;
+  timestamp: string;
+  vaultId?: string;
+  vaultName?: string;
+  amount?: number;
+  fee?: number;
+  block?: number;
+  status?: VaultTransactionStatus;
+  from?: string;
+  to?: string;
+  memo?: string;
+}
+
+export interface Vault {
+  id: string;
+  name: string;
+  status: VaultStatus;
+  amount: number;
+  currency: string;
+  createdAt: string;
+  deadline: string;
+  creatorAddress: string;
+  verifierAddress?: string;
+  successAddress: string;
+  failureAddress: string;
+  contractAddress: string;
+  milestones: Milestone[];
+  transactions: VaultTransaction[];
+}
+
+export interface VaultPreview {
+  id: string;
+  name: string;
+  amount: number;
+  currency: string;
+  status: VaultStatus;
+  progressPct: number;
+  deadline: string;
+}
+
+export interface DashboardSummary {
+  totalLocked: number;
+  activeVaults: number;
+  pendingMilestones: number;
+  completionRate: number;
+}
+
+export interface DashboardActivity {
+  id: string;
+  type: "created" | "validated" | "released" | "redirected";
+  vault: string;
+  timestamp: string;
+  amount?: number;
+}
+
+export interface DashboardDeadline {
+  id: string;
+  name: string;
+  deadline: string;
+  amount: number;
+}


### PR DESCRIPTION
Closes #216.

## Summary
- Adds shared vault, milestone, and transaction contracts in `src/types/vault.ts`.
- Introduces an async mock-backed `vaultService` with required `listVaults`, `getVault(id)`, and `getTransactions(id)` seams plus dashboard/ledger projections.
- Refactors Dashboard, Vaults, VaultDetail, and VaultTransactions to consume the service while preserving current mock values on first render via snapshot methods.
- Adds service tests and documents the future Soroban/Horizon/indexer integration seam.

## Testing
- `npx eslint src/types/vault.ts src/services/vaultService.ts src/services/__tests__/vaultService.test.ts src/components/VaultCard.tsx src/pages/Dashboard.tsx src/pages/Vaults.tsx src/pages/VaultDetail.tsx src/pages/VaultTransactions.tsx`
- `npx tsc --noEmit --target ES2020 --lib ES2020,DOM,DOM.Iterable --module ESNext --moduleResolution bundler --allowImportingTsExtensions --isolatedModules --moduleDetection force --jsx react-jsx --strict --skipLibCheck --types vitest,@testing-library/jest-dom src/types/vault.ts src/services/vaultService.ts src/services/__tests__/vaultService.test.ts src/components/VaultCard.tsx src/pages/Dashboard.tsx src/pages/Vaults.tsx src/pages/VaultDetail.tsx src/pages/VaultTransactions.tsx`
- `git diff --check`
- `npx vitest run src/services/__tests__/vaultService.test.ts` fails locally before tests run because Vite/esbuild cannot start: `Error: spawn EPERM`