### PR TITLE
feat: batch approve and reject pending validations

### DIFF
--- a/src/Zustand/Store.ts
+++ b/src/Zustand/Store.ts
@@ -1,4 +1,4 @@
-import { getNotifications } from "@/components/Notification/exampleNotification/example";
+import { getNotifications } from "../components/Notification/exampleNotification/example";
 import { create } from "zustand";
 
 // --- Existing Notification Store ---
@@ -35,6 +35,8 @@ type VerifierStoreType = {
   validationHistory: ValidationTask[];
   approveValidation: (id: string, notes?: string) => void;
   rejectValidation: (id: string, notes?: string) => void;
+  batchApprove: (ids: string[], notes?: string) => void;
+  batchReject: (ids: string[], notes?: string) => void;
 };
 
 // Mock initial data based on the issue requirements
@@ -77,7 +79,7 @@ const initialHistory: ValidationTask[] = [
   }
 ];
 
-export const useVerifierStore = create<VerifierStoreType>((set) => ({
+export const useVerifierStore = create<VerifierStoreType>((set, get) => ({
   pendingValidations: initialPending,
   validationHistory: initialHistory,
   
@@ -107,5 +109,13 @@ export const useVerifierStore = create<VerifierStoreType>((set) => ({
       pendingValidations: newPending,
       validationHistory: [task, ...state.validationHistory]
     };
-  })
+  }),
+
+  batchApprove: (ids, notes) => {
+    ids.forEach((id) => get().approveValidation(id, notes));
+  },
+
+  batchReject: (ids, notes) => {
+    ids.forEach((id) => get().rejectValidation(id, notes));
+  }
 }));

--- a/src/Zustand/__tests__/Store.test.ts
+++ b/src/Zustand/__tests__/Store.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useVerifierStore, type ValidationTask } from '../Store';
+
+const makeTask = (id: string, vaultName: string): ValidationTask => ({
+  id,
+  vaultName,
+  owner: `0x${id}`,
+  amount: '1,000 USDC',
+  deadline: '2026-07-01',
+  daysRemaining: 7,
+  status: 'pending',
+  milestone: `${vaultName} milestone`,
+});
+
+describe('useVerifierStore batch validation mutators', () => {
+  beforeEach(() => {
+    useVerifierStore.setState({
+      pendingValidations: [
+        makeTask('v-1', 'Alpha Vault'),
+        makeTask('v-2', 'Beta Vault'),
+        makeTask('v-3', 'Gamma Vault'),
+      ],
+      validationHistory: [],
+    });
+  });
+
+  it('batchApprove moves selected pending tasks into history with notes', () => {
+    useVerifierStore.getState().batchApprove(['v-1', 'missing-id', 'v-2'], 'Ready to release.');
+
+    const state = useVerifierStore.getState();
+    expect(state.pendingValidations.map((task) => task.id)).toEqual(['v-3']);
+    expect(state.validationHistory.map((task) => task.id)).toEqual(['v-2', 'v-1']);
+    expect(state.validationHistory.every((task) => task.status === 'approved')).toBe(true);
+    expect(state.validationHistory.every((task) => task.notes === 'Ready to release.')).toBe(true);
+  });
+
+  it('batchReject moves only unresolved pending tasks into history', () => {
+    useVerifierStore.getState().approveValidation('v-1', 'Single approval first.');
+    useVerifierStore.getState().batchReject(['v-1', 'v-3'], 'Evidence is incomplete.');
+
+    const state = useVerifierStore.getState();
+    expect(state.pendingValidations.map((task) => task.id)).toEqual(['v-2']);
+    expect(state.validationHistory.map((task) => task.id)).toEqual(['v-3', 'v-1']);
+    expect(state.validationHistory[0]).toMatchObject({
+      id: 'v-3',
+      status: 'rejected',
+      notes: 'Evidence is incomplete.',
+    });
+    expect(state.validationHistory[1]).toMatchObject({
+      id: 'v-1',
+      status: 'approved',
+      notes: 'Single approval first.',
+    });
+  });
+});

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -12,6 +12,7 @@ interface ConfirmationModalProps {
   initialDecision?: 'approve' | 'reject';
   initialNotes?: string;
   evidenceUrl?: string;
+  summary?: string;
 }
 
 /**
@@ -32,6 +33,7 @@ export function ConfirmationModal({
   initialDecision,
   initialNotes = '',
   evidenceUrl,
+  summary,
 }: ConfirmationModalProps) {
   const [decision, setDecision] = useState<'approve' | 'reject' | null>(initialDecision || null);
   const [notes, setNotes] = useState(initialNotes);
@@ -89,6 +91,11 @@ export function ConfirmationModal({
                   <Text role="body" as="span" className="font-semibold text-gray-700 dark:text-gray-300">
                     Final Decision
                   </Text>
+                  {summary && (
+                    <Text role="caption" as="p" className="text-gray-600 dark:text-gray-300">
+                      {summary}
+                    </Text>
+                  )}
                   <div className="grid grid-cols-2 gap-4">
                     <button
                       onClick={() => setDecision('approve')}

--- a/src/pages/PendingValidations.tsx
+++ b/src/pages/PendingValidations.tsx
@@ -1,21 +1,85 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { ConfirmationModal } from '../components/ConfirmationModal';
 import { CountdownDeadline } from '../components/CountdownDeadline';
 import { Text } from '../components/Text';
 import { useVerifierStore } from '../Zustand/Store';
 
 export default function PendingValidations() {
   const navigate = useNavigate();
-  const { pendingValidations } = useVerifierStore();
+  const { pendingValidations, batchApprove, batchReject } = useVerifierStore();
+  const selectAllRef = useRef<HTMLInputElement>(null);
   
-  // Optional: Simple state to handle sorting by days remaining
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [confirmAction, setConfirmAction] = useState<'approve' | 'reject' | null>(null);
 
-  const sortedValidations = [...pendingValidations].sort((a, b) => {
+  const sortedValidations = useMemo(() => [...pendingValidations].sort((a, b) => {
     return sortOrder === 'asc' 
       ? a.daysRemaining - b.daysRemaining 
       : b.daysRemaining - a.daysRemaining;
-  });
+  }), [pendingValidations, sortOrder]);
+
+  const visibleIds = useMemo(() => sortedValidations.map((task) => task.id), [sortedValidations]);
+  const selectedCount = selectedIds.size;
+  const allVisibleSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedIds.has(id));
+  const someVisibleSelected = visibleIds.some((id) => selectedIds.has(id)) && !allVisibleSelected;
+
+  useEffect(() => {
+    setSelectedIds((current) => {
+      const pendingIds = new Set(pendingValidations.map((task) => task.id));
+      const next = new Set([...current].filter((id) => pendingIds.has(id)));
+      return next.size === current.size ? current : next;
+    });
+  }, [pendingValidations]);
+
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = someVisibleSelected;
+    }
+  }, [someVisibleSelected]);
+
+  const toggleTaskSelection = (id: string) => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const toggleAllVisible = () => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (allVisibleSelected) {
+        visibleIds.forEach((id) => next.delete(id));
+      } else {
+        visibleIds.forEach((id) => next.add(id));
+      }
+      return next;
+    });
+  };
+
+  const executeBatchAction = (decision: 'approve' | 'reject', notes: string) => {
+    const ids = [...selectedIds].filter((id) => pendingValidations.some((task) => task.id === id));
+
+    if (decision === 'approve') {
+      batchApprove(ids, notes);
+    } else {
+      batchReject(ids, notes);
+    }
+
+    setSelectedIds(new Set());
+    setConfirmAction(null);
+  };
+
+  const actionLabel = confirmAction === 'approve' ? 'approved' : 'rejected';
+  const batchSummary = confirmAction
+    ? `${selectedCount} ${selectedCount === 1 ? 'validation' : 'validations'} will be ${actionLabel}.`
+    : undefined;
 
   return (
     <div className="flex flex-col gap-6 p-6">
@@ -41,6 +105,33 @@ export default function PendingValidations() {
         </button>
       </header>
 
+      <section
+        aria-label="Batch validation actions"
+        className="sticky top-0 z-10 flex flex-col gap-3 rounded-lg border border-gray-200 bg-white/95 p-4 shadow-sm backdrop-blur md:flex-row md:items-center md:justify-between"
+      >
+        <Text role="body" as="p" className="font-medium text-gray-700">
+          {selectedCount} {selectedCount === 1 ? 'validation' : 'validations'} selected
+        </Text>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => setConfirmAction('approve')}
+            disabled={selectedCount === 0}
+            className="px-4 py-2 rounded bg-green-600 text-sm font-medium text-white transition hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Batch Approve
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirmAction('reject')}
+            disabled={selectedCount === 0}
+            className="px-4 py-2 rounded bg-red-600 text-sm font-medium text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Batch Reject
+          </button>
+        </div>
+      </section>
+
       <section className="bg-white border rounded-lg shadow-sm overflow-x-auto">
         {sortedValidations.length === 0 ? (
           <div className="p-12 text-center text-gray-500">
@@ -51,6 +142,16 @@ export default function PendingValidations() {
           <table className="w-full text-left border-collapse">
             <thead>
               <tr className="bg-gray-50 border-b border-gray-200">
+                <th className="p-4 font-medium text-sm text-gray-600">
+                  <input
+                    ref={selectAllRef}
+                    type="checkbox"
+                    aria-label="Select all pending validations"
+                    checked={allVisibleSelected}
+                    onChange={toggleAllVisible}
+                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                </th>
                 <th className="p-4 font-medium text-sm text-gray-600">Vault & Milestone</th>
                 <th className="p-4 font-medium text-sm text-gray-600">Owner</th>
                 <th className="p-4 font-medium text-sm text-gray-600">Amount at Stake</th>
@@ -61,6 +162,15 @@ export default function PendingValidations() {
             <tbody>
               {sortedValidations.map((task) => (
                 <tr key={task.id} className="border-b border-gray-100 hover:bg-gray-50 transition">
+                  <td className="p-4">
+                    <input
+                      type="checkbox"
+                      aria-label={`Select ${task.vaultName}`}
+                      checked={selectedIds.has(task.id)}
+                      onChange={() => toggleTaskSelection(task.id)}
+                      className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                    />
+                  </td>
                   <td className="p-4">
                     <Text role="body" as="p" className="font-semibold text-gray-800">{task.vaultName}</Text>
                     <Text role="body" as="p" className="text-sm text-gray-500 mt-1">{task.milestone}</Text>
@@ -93,6 +203,14 @@ export default function PendingValidations() {
           </table>
         )}
       </section>
+
+      <ConfirmationModal
+        isOpen={confirmAction !== null}
+        onClose={() => setConfirmAction(null)}
+        onConfirm={executeBatchAction}
+        initialDecision={confirmAction ?? undefined}
+        summary={batchSummary}
+      />
     </div>
   );
 }

--- a/src/pages/__tests__/PendingValidations.test.tsx
+++ b/src/pages/__tests__/PendingValidations.test.tsx
@@ -1,14 +1,40 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import PendingValidations from '../PendingValidations';
-import { useVerifierStore } from '../../Zustand/Store';
+import { useVerifierStore, type ValidationTask } from '../../Zustand/Store';
+
+vi.mock('focus-trap-react', () => ({
+  default: ({
+    children,
+    focusTrapOptions,
+  }: {
+    children: React.ReactNode;
+    focusTrapOptions?: { onDeactivate?: () => void };
+  }) => (
+    <div
+      data-testid="focus-trap"
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          focusTrapOptions?.onDeactivate?.();
+        }
+      }}
+    >
+      {children}
+    </div>
+  ),
+}));
 
 vi.mock('../../Zustand/Store', () => ({
   useVerifierStore: vi.fn(),
 }));
 
 const mockNavigate = vi.fn();
+const mockApproveValidation = vi.fn();
+const mockRejectValidation = vi.fn();
+const mockBatchApprove = vi.fn();
+const mockBatchReject = vi.fn();
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return {
@@ -17,13 +43,13 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-const makeTasks = () => [
+const makeTasks = (): ValidationTask[] => [
   {
     id: 'v-1',
     vaultName: 'Alpha Vault',
     owner: '0xAAAA',
     amount: '10,000 USDC',
-    deadline: '2026-07-01',
+    deadline: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),
     daysRemaining: 10,
     status: 'pending' as const,
     milestone: 'Phase 1',
@@ -33,7 +59,7 @@ const makeTasks = () => [
     vaultName: 'Beta Vault',
     owner: '0xBBBB',
     amount: '5,000 USDC',
-    deadline: '2026-06-20',
+    deadline: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
     daysRemaining: 2,
     status: 'pending' as const,
     milestone: 'Phase 2',
@@ -43,12 +69,23 @@ const makeTasks = () => [
     vaultName: 'Gamma Vault',
     owner: '0xCCCC',
     amount: '20,000 USDC',
-    deadline: '2026-07-10',
+    deadline: new Date(Date.now() + 20 * 24 * 60 * 60 * 1000).toISOString(),
     daysRemaining: 20,
     status: 'pending' as const,
     milestone: 'Phase 3',
   },
 ];
+
+function mockVerifierStore(pendingValidations: ValidationTask[] = makeTasks()) {
+  vi.mocked(useVerifierStore).mockReturnValue({
+    pendingValidations,
+    validationHistory: [],
+    approveValidation: mockApproveValidation,
+    rejectValidation: mockRejectValidation,
+    batchApprove: mockBatchApprove,
+    batchReject: mockBatchReject,
+  });
+}
 
 function renderPage() {
   return render(
@@ -61,7 +98,7 @@ function renderPage() {
 describe('PendingValidations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: makeTasks() });
+    mockVerifierStore();
   });
 
   it('renders the page heading', () => {
@@ -70,14 +107,14 @@ describe('PendingValidations', () => {
   });
 
   it('shows "All caught up!" when there are no pending validations', () => {
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+    mockVerifierStore([]);
     renderPage();
     expect(screen.getByText('All caught up!')).toBeInTheDocument();
     expect(screen.getByText(/no pending validations/i)).toBeInTheDocument();
   });
 
   it('does not render the table when queue is empty', () => {
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+    mockVerifierStore([]);
     renderPage();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
@@ -93,7 +130,7 @@ describe('PendingValidations', () => {
     renderPage();
     expect(screen.getByRole('button', { name: /High to Low/i })).toBeInTheDocument();
 
-    // ascending: v-2 (2 days) → v-1 (10 days) → v-3 (20 days)
+    // ascending: v-2 (2 days) ??v-1 (10 days) ??v-3 (20 days)
     const vaultCells = screen.getAllByText(/Vault$/);
     expect(vaultCells[0].textContent).toBe('Beta Vault');
     expect(vaultCells[1].textContent).toBe('Alpha Vault');
@@ -106,7 +143,7 @@ describe('PendingValidations', () => {
 
     expect(screen.getByRole('button', { name: /Low to High/i })).toBeInTheDocument();
 
-    // descending: v-3 (20 days) → v-1 (10 days) → v-2 (2 days)
+    // descending: v-3 (20 days) ??v-1 (10 days) ??v-2 (2 days)
     const vaultCells = screen.getAllByText(/Vault$/);
     expect(vaultCells[0].textContent).toBe('Gamma Vault');
     expect(vaultCells[1].textContent).toBe('Alpha Vault');
@@ -120,7 +157,7 @@ describe('PendingValidations', () => {
 
     expect(screen.getByRole('button', { name: /High to Low/i })).toBeInTheDocument();
 
-    // back to ascending: v-2 → v-1 → v-3
+    // back to ascending: v-2 ??v-1 ??v-3
     const vaultCells = screen.getAllByText(/Vault$/);
     expect(vaultCells[0].textContent).toBe('Beta Vault');
     expect(vaultCells[1].textContent).toBe('Alpha Vault');
@@ -142,38 +179,97 @@ describe('PendingValidations', () => {
   });
 
   it('renders a single task without crashing', () => {
-    (useVerifierStore as any).mockReturnValue({
-      pendingValidations: [makeTasks()[0]],
-    });
+    mockVerifierStore([makeTasks()[0]]);
     renderPage();
     expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
     expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 row
   });
 
   it('handles ties in daysRemaining (stable relative order preserved)', () => {
-    (useVerifierStore as any).mockReturnValue({
-      pendingValidations: [
-        { ...makeTasks()[0], id: 'v-a', daysRemaining: 5 },
-        { ...makeTasks()[1], id: 'v-b', daysRemaining: 5 },
-      ],
-    });
+    mockVerifierStore([
+      { ...makeTasks()[0], id: 'v-a', daysRemaining: 5 },
+      { ...makeTasks()[1], id: 'v-b', daysRemaining: 5 },
+    ]);
     renderPage();
     const rows = screen.getAllByRole('row').slice(1);
     expect(rows).toHaveLength(2);
-    // both show 5 days left — just assert they render without error
-    expect(screen.getAllByText('5 days left')).toHaveLength(2);
+    expect(within(rows[0]).getByText('Alpha Vault')).toBeInTheDocument();
+    expect(within(rows[1]).getByText('Beta Vault')).toBeInTheDocument();
   });
 
-  it('shows daysRemaining in red for tasks with 3 or fewer days', () => {
+  it('shows urgent deadline tone for tasks with fewer than 24 hours remaining', () => {
     renderPage();
-    // v-2 has daysRemaining: 2 — should have red styling
-    const urgentSpan = screen.getByText('2 days left');
-    expect(urgentSpan.className).toContain('text-red-600');
+    const betaRow = screen.getByRole('checkbox', { name: /Select Beta Vault/i }).closest('tr');
+    expect(betaRow?.querySelector('[data-tone="urgent"]')).toBeInTheDocument();
   });
 
-  it('shows daysRemaining in green for tasks with more than 3 days', () => {
+  it('shows normal deadline tone for tasks with more than 24 hours remaining', () => {
     renderPage();
-    const safeSpan = screen.getByText('10 days left');
-    expect(safeSpan.className).toContain('text-green-600');
+    const alphaRow = screen.getByRole('checkbox', { name: /Select Alpha Vault/i }).closest('tr');
+    expect(alphaRow?.querySelector('[data-tone="normal"]')).toBeInTheDocument();
+  });
+
+  it('disables batch actions until at least one validation is selected', () => {
+    renderPage();
+    expect(screen.getByText('0 validations selected')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Batch Approve/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Batch Reject/i })).toBeDisabled();
+  });
+
+  it('selects one validation and marks the header checkbox indeterminate', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Select Beta Vault/i }));
+
+    const selectAll = screen.getByRole('checkbox', { name: /Select all pending validations/i }) as HTMLInputElement;
+    expect(screen.getByText('1 validation selected')).toBeInTheDocument();
+    expect(selectAll.checked).toBe(false);
+    expect(selectAll.indeterminate).toBe(true);
+    expect(screen.getByRole('button', { name: /Batch Approve/i })).toBeEnabled();
+  });
+
+  it('selects and clears all visible validations from the header checkbox', () => {
+    renderPage();
+
+    const selectAll = screen.getByRole('checkbox', { name: /Select all pending validations/i });
+    fireEvent.click(selectAll);
+
+    expect(screen.getByText('3 validations selected')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /Select Alpha Vault/i })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Select Beta Vault/i })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Select Gamma Vault/i })).toBeChecked();
+
+    fireEvent.click(selectAll);
+    expect(screen.getByText('0 validations selected')).toBeInTheDocument();
+  });
+
+  it('confirms a batch approve with the selected validation ids', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Select Beta Vault/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /Select Alpha Vault/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Batch Approve/i }));
+
+    expect(screen.getByText('2 validations will be approved.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Confirm Approve/i }));
+
+    expect(mockBatchApprove).toHaveBeenCalledWith(['v-2', 'v-1'], '');
+    expect(mockBatchReject).not.toHaveBeenCalled();
+  });
+
+  it('confirms a batch reject with required notes', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Select Gamma Vault/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Batch Reject/i }));
+
+    expect(screen.getByText('1 validation will be rejected.')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText(/Reason for rejection is required/i), {
+      target: { value: 'Evidence does not match the milestone scope.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Confirm Reject/i }));
+
+    expect(mockBatchReject).toHaveBeenCalledWith(['v-3'], 'Evidence does not match the milestone scope.');
+    expect(mockBatchApprove).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add `batchApprove` and `batchReject` store mutators that reuse the existing single-validation transitions
- add keyboard-accessible row selection, select-all indeterminate state, and a disabled/enabled batch action bar on `PendingValidations`
- reuse `ConfirmationModal` for confirmed batch decisions and show the affected validation count
- cover the new flow with RTL tests plus real Zustand store unit tests

Closes #178

## Validation
- `npx vitest run src/pages/__tests__/PendingValidations.test.tsx src/Zustand/__tests__/Store.test.ts --coverage=false`
- `npx eslint src/Zustand/Store.ts src/pages/PendingValidations.tsx src/pages/__tests__/PendingValidations.test.tsx src/Zustand/__tests__/Store.test.ts src/components/ConfirmationModal.tsx`

## Notes
- `npm run build` currently fails on existing repo-wide TypeScript/test configuration errors outside this change, including missing Vitest globals in existing test files and unrelated stale test typings.