### PR TITLE
feat(a11y): add accessible table semantics to PendingValidations and …

### DIFF
--- a/src/pages/PendingValidations.tsx
+++ b/src/pages/PendingValidations.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { CountdownDeadline } from '../components/CountdownDeadline';
 import { Text } from '../components/Text';
 import { useVerifierStore } from '../Zustand/Store';
 
@@ -48,14 +47,14 @@ export default function PendingValidations() {
             <Text role="body" as="p" className="mt-2">There are no pending validations in your queue.</Text>
           </div>
         ) : (
-          <table className="w-full text-left border-collapse">
+          <table className="w-full text-left border-collapse" aria-label="Pending Validations">
             <thead>
               <tr className="bg-gray-50 border-b border-gray-200">
-                <th className="p-4 font-medium text-sm text-gray-600">Vault & Milestone</th>
-                <th className="p-4 font-medium text-sm text-gray-600">Owner</th>
-                <th className="p-4 font-medium text-sm text-gray-600">Amount at Stake</th>
-                <th className="p-4 font-medium text-sm text-gray-600">Deadline</th>
-                <th className="p-4 font-medium text-sm text-gray-600 text-right">Actions</th>
+                <th scope="col" className="p-4 font-medium text-sm text-gray-600">Vault & Milestone</th>
+                <th scope="col" className="p-4 font-medium text-sm text-gray-600">Owner</th>
+                <th scope="col" className="p-4 font-medium text-sm text-gray-600">Amount at Stake</th>
+                <th scope="col" className="p-4 font-medium text-sm text-gray-600" aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>Deadline</th>
+                <th scope="col" className="p-4 font-medium text-sm text-gray-600 text-right">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -76,7 +75,12 @@ export default function PendingValidations() {
                   <td className="p-4">
                     <div className="flex flex-col">
                       <Text role="body" as="p" className="text-sm">{task.deadline}</Text>
-                      <CountdownDeadline deadline={task.deadline} />
+                      <span className={`text-sm font-medium ${task.daysRemaining <= 3 ? 'text-red-600' : 'text-green-600'}`}>
+                        {task.daysRemaining} days left
+                      </span>
+                      {task.daysRemaining <= 3 && (
+                        <span className="sr-only">Urgent</span>
+                      )}
                     </div>
                   </td>
                   <td className="p-4 text-right">

--- a/src/pages/VaultTransactions.tsx
+++ b/src/pages/VaultTransactions.tsx
@@ -593,14 +593,33 @@ interface SectionProps {
 }
 
 function Section({ title, accent, count, children }: SectionProps) {
+  const hasRows = count > 0;
   return (
     <section className="vt-section">
       <div className="vt-section-header">
-        <span className="vt-section-dot" style={{ background: accent }} />
+        <span className="vt-section-dot" style={{ background: accent }} aria-hidden="true" />
         <span className="vt-section-title">{title}</span>
         <span className="vt-section-count">{count}</span>
       </div>
-      <div className="vt-tx-list">{children}</div>
+      <div
+        className="vt-tx-list"
+        role={hasRows ? "table" : undefined}
+        aria-label={hasRows ? `${title} transactions` : undefined}
+      >
+        {hasRows && (
+          <div role="rowgroup">
+            <div role="row" className="vt-sr-only">
+              <span role="columnheader">Transaction Type</span>
+              <span role="columnheader">Vault &amp; Details</span>
+              <span role="columnheader">Amount</span>
+              <span role="columnheader">Status</span>
+            </div>
+          </div>
+        )}
+        <div role={hasRows ? "rowgroup" : undefined}>
+          {children}
+        </div>
+      </div>
     </section>
   );
 }
@@ -619,15 +638,16 @@ function TxRow({ tx, onSelect, onCopy, copiedId, children }: TxRowProps) {
   const Icon = meta.icon;
 
   return (
-    <div className="vt-tx-row" onClick={() => onSelect(tx)}>
+    <div className="vt-tx-row" role="row" onClick={() => onSelect(tx)}>
       <div
+        role="cell"
         className="vt-tx-icon"
         style={{ background: meta.bg, border: `1px solid ${meta.border}` }}
       >
         <Icon color={meta.color} />
       </div>
 
-      <div className="vt-tx-main">
+      <div role="cell" className="vt-tx-main">
         <div className="vt-tx-top">
           <span className="vt-tx-type" style={{ color: meta.color }}>
             {meta.label}
@@ -659,7 +679,7 @@ function TxRow({ tx, onSelect, onCopy, copiedId, children }: TxRowProps) {
         </div>
       </div>
 
-      <div className="vt-tx-amount">
+      <div role="cell" className="vt-tx-amount">
         {tx.amount > 0 && (
           <span className="vt-tx-amount-val">
             {fmtAmount(tx.amount)}
@@ -669,18 +689,18 @@ function TxRow({ tx, onSelect, onCopy, copiedId, children }: TxRowProps) {
         <span className="vt-tx-fee">Fee: {tx.fee.toFixed(5)}</span>
       </div>
 
-      <div className="vt-tx-right">
+      <div role="cell" className="vt-tx-right">
         <span
           className="vt-tx-status"
           style={{ color: status.color, background: status.bg }}
         >
-          <span className="vt-status-dot" style={{ background: status.dot }} />
+          <span className="vt-status-dot" style={{ background: status.dot }} aria-hidden="true" />
           {status.label}
         </span>
         <span className="vt-tx-time">{fmtTime(tx.timestamp)}</span>
       </div>
 
-      {children}
+      {children && <div role="cell">{children}</div>}
     </div>
   );
 }
@@ -1308,5 +1328,10 @@ const CSS = `
     .vt-stats > :last-child { grid-column: span 1; }
     .vt-header { flex-direction: column; align-items: flex-start; }
     .vt-modal-row2 { grid-template-columns: 1fr; }
+  }
+  .vt-sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0;
+    margin: -1px; overflow: hidden; clip: rect(0,0,0,0);
+    white-space: nowrap; border: 0;
   }
 `;

--- a/src/pages/__tests__/PendingValidations.test.tsx
+++ b/src/pages/__tests__/PendingValidations.test.tsx
@@ -176,4 +176,61 @@ describe('PendingValidations', () => {
     const safeSpan = screen.getByText('10 days left');
     expect(safeSpan.className).toContain('text-green-600');
   });
+
+  describe('accessible table semantics', () => {
+    it('table has an accessible name', () => {
+      renderPage();
+      expect(screen.getByRole('table', { name: /Pending Validations/i })).toBeInTheDocument();
+    });
+
+    it('all column headers have scope="col"', () => {
+      renderPage();
+      const headers = screen.getAllByRole('columnheader');
+      expect(headers.length).toBeGreaterThan(0);
+      headers.forEach(th => {
+        expect(th).toHaveAttribute('scope', 'col');
+      });
+    });
+
+    it('Deadline column header exposes aria-sort="ascending" by default', () => {
+      renderPage();
+      const deadlineHeader = screen.getByRole('columnheader', { name: /Deadline/i });
+      expect(deadlineHeader).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('aria-sort becomes "descending" after toggling sort to Low to High', () => {
+      renderPage();
+      fireEvent.click(screen.getByRole('button', { name: /High to Low/i }));
+      const deadlineHeader = screen.getByRole('columnheader', { name: /Deadline/i });
+      expect(deadlineHeader).toHaveAttribute('aria-sort', 'descending');
+    });
+
+    it('toggling sort twice restores aria-sort to "ascending"', () => {
+      renderPage();
+      fireEvent.click(screen.getByRole('button', { name: /High to Low/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Low to High/i }));
+      const deadlineHeader = screen.getByRole('columnheader', { name: /Deadline/i });
+      expect(deadlineHeader).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('urgent rows (≤3 days) include a non-color sr-only urgency cue', () => {
+      renderPage();
+      // v-2 has daysRemaining: 2 which is ≤ 3
+      const urgentCue = screen.getByText('Urgent');
+      expect(urgentCue.className).toContain('sr-only');
+    });
+
+    it('non-urgent rows do not include an urgency cue', () => {
+      renderPage();
+      // Only v-2 (daysRemaining: 2) is urgent; v-1 and v-3 are not
+      const urgentCues = screen.getAllByText('Urgent');
+      expect(urgentCues).toHaveLength(1);
+    });
+
+    it('empty table state renders no table role', () => {
+      (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+      renderPage();
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/__tests__/VaultTransactions.test.tsx
+++ b/src/pages/__tests__/VaultTransactions.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import VaultTransactions from '../VaultTransactions';
+
+function renderPage() {
+  return render(<VaultTransactions />);
+}
+
+describe('VaultTransactions', () => {
+  describe('core rendering', () => {
+    it('renders the page heading', () => {
+      renderPage();
+      expect(screen.getByRole('heading', { name: /Transaction History/i })).toBeInTheDocument();
+    });
+
+    it('renders the export button', () => {
+      renderPage();
+      expect(screen.getByRole('button', { name: /Export CSV/i })).toBeInTheDocument();
+    });
+
+    it('renders all three status sections from mock data', () => {
+      renderPage();
+      // Mock data has pending, failed, and confirmed transactions
+      expect(screen.getAllByText('Pending').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Failed').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Confirmed').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('accessible table semantics', () => {
+    it('each non-empty status section is announced as a table', () => {
+      renderPage();
+      const tables = screen.getAllByRole('table');
+      // Mock data has Pending (2 tx), Failed (1 tx), Confirmed (7 tx)
+      expect(tables.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('every table has an accessible name', () => {
+      renderPage();
+      const tables = screen.getAllByRole('table');
+      tables.forEach(table => {
+        expect(table).toHaveAccessibleName();
+      });
+    });
+
+    it('each table section has a descriptive label including its status', () => {
+      renderPage();
+      expect(screen.getByRole('table', { name: /Pending transactions/i })).toBeInTheDocument();
+      expect(screen.getByRole('table', { name: /Failed transactions/i })).toBeInTheDocument();
+      expect(screen.getByRole('table', { name: /Confirmed transactions/i })).toBeInTheDocument();
+    });
+
+    it('column headers are present in each table', () => {
+      renderPage();
+      const headers = screen.getAllByRole('columnheader');
+      // 3 sections × 4 headers each
+      expect(headers.length).toBeGreaterThanOrEqual(12);
+    });
+
+    it('transaction data rows are announced as table rows', () => {
+      renderPage();
+      const rows = screen.getAllByRole('row');
+      // At minimum: 3 hidden header rows + 10 data rows
+      expect(rows.length).toBeGreaterThanOrEqual(13);
+    });
+
+    it('status is conveyed via visible text, not color only', () => {
+      renderPage();
+      // Each tx row's status span includes a text label
+      expect(screen.getAllByText('Confirmed').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Pending').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Failed').length).toBeGreaterThan(0);
+    });
+
+    it('decorative status dots are hidden from screen readers', () => {
+      const { container } = renderPage();
+      const dots = container.querySelectorAll('.vt-status-dot');
+      expect(dots.length).toBeGreaterThan(0);
+      dots.forEach(dot => {
+        expect(dot).toHaveAttribute('aria-hidden', 'true');
+      });
+    });
+
+    it('decorative section accent dots are hidden from screen readers', () => {
+      const { container } = renderPage();
+      const dots = container.querySelectorAll('.vt-section-dot');
+      expect(dots.length).toBeGreaterThan(0);
+      dots.forEach(dot => {
+        expect(dot).toHaveAttribute('aria-hidden', 'true');
+      });
+    });
+  });
+
+  describe('sort controls', () => {
+    it('sort button defaults to newest-first', () => {
+      renderPage();
+      expect(screen.getByRole('button', { name: /Newest/i })).toBeInTheDocument();
+    });
+
+    it('clicking sort toggles to oldest-first', () => {
+      renderPage();
+      fireEvent.click(screen.getByRole('button', { name: /Newest/i }));
+      expect(screen.getByRole('button', { name: /Oldest/i })).toBeInTheDocument();
+    });
+
+    it('clicking sort twice returns to newest-first', () => {
+      renderPage();
+      fireEvent.click(screen.getByRole('button', { name: /Newest/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Oldest/i }));
+      expect(screen.getByRole('button', { name: /Newest/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('filters', () => {
+    it('clear button appears when a filter is applied', () => {
+      renderPage();
+      expect(screen.queryByRole('button', { name: /Clear/i })).not.toBeInTheDocument();
+      const selects = screen.getAllByRole('combobox');
+      fireEvent.change(selects[0], { target: { value: 'create' } });
+      expect(screen.getByRole('button', { name: /Clear/i })).toBeInTheDocument();
+    });
+
+    it('clearing filters removes the clear button', () => {
+      renderPage();
+      const selects = screen.getAllByRole('combobox');
+      fireEvent.change(selects[0], { target: { value: 'create' } });
+      fireEvent.click(screen.getByRole('button', { name: /Clear/i }));
+      expect(screen.queryByRole('button', { name: /Clear/i })).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
…VaultTransactions

- PendingValidations: add aria-label to table, scope="col" on all th elements, aria-sort on Deadline header reflecting live sort state, replace CountdownDeadline with daysRemaining display using color + sr-only "Urgent" cue (WCAG 1.4.1)
- VaultTransactions: add role="table"/aria-label per status section, visually-hidden columnheader row, role="row"/"cell" on TxRow, aria-hidden on decorative dots, .vt-sr-only utility class
- Extend PendingValidations.test.tsx with 7 a11y assertions (scope, aria-sort toggle round-trip, urgency cue)
- Add VaultTransactions.test.tsx with 14 tests covering table roles, accessible names, columnheaders, status text labels, and aria-hidden dots

closes #207 