### PR TITLE
fix: remove duplicate test script and document canonical test commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Root package scripts:
 | `npm run build` | Run TypeScript build mode and create a Vite production build |
 | `npm run preview` | Preview the production build locally |
 | `npm run lint` | Run ESLint across the frontend |
-| `npm run test` | Run the Vitest suite with coverage |
+| `npm run test` | Run the Vitest suite with coverage (CI) |
+| `npm run test:watch` | Run Vitest in watch mode for interactive development |
 
 Design-system package scripts:
 
@@ -130,8 +131,16 @@ Design-system package scripts:
 Frontend tests use Vitest, the DOM test setup in `src/setupTests.ts`, and
 Testing Library.
 
+**CI / one-off run (with coverage):**
+
 ```bash
-npm run test
+npm test
+```
+
+**Interactive watch mode (local development):**
+
+```bash
+npm run test:watch
 ```
 
 For targeted frontend checks during development, run Vitest directly:

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "vitest",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run --coverage"
+    "test": "vitest run --coverage",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@stellar/freighter-api": "^6.0.1",


### PR DESCRIPTION
## Summary

Closes #214 

Remove the duplicate `"test"` script key from `package.json` and document the canonical test commands. In JSON the second key silently wins, making it impossible for a contributor reading the file to tell which command actually runs. This fix collapses to a single unambiguous script and adds an explicit watch-mode variant.

## Changes

### `package.json`
- Removed `"test": "vitest"` (duplicate, silently overwritten)
- Kept `"test": "vitest run --coverage"` as the canonical CI command
- Added `"test:watch": "vitest"` for interactive local development

### `README.md`
- Updated the Scripts table to distinguish `test` (CI with coverage) from `test:watch` (interactive watch mode)
- Restructured the Testing section with separate code blocks for each command so it's clear which to use when

## Verification

- `npm test` — runs `vitest run --coverage`, all 27 test files executed with coverage (6 pre-existing test failures unrelated to this change)
- `npm run test:watch` — launches Vitest in watch mode (confirmed via `--help`)
