### PR TITLE
feature/validation history csv export

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Root package scripts:
 | `npm run build` | Run TypeScript build mode and create a Vite production build |
 | `npm run preview` | Preview the production build locally |
 | `npm run lint` | Run ESLint across the frontend |
-| `npm run test` | Run the Vitest suite with coverage |
+| `npm run test` | Run the Vitest suite with coverage (CI) |
+| `npm run test:watch` | Run Vitest in watch mode for interactive development |
 
 Design-system package scripts:
 
@@ -130,8 +131,16 @@ Design-system package scripts:
 Frontend tests use Vitest, the DOM test setup in `src/setupTests.ts`, and
 Testing Library.
 
+**CI / one-off run (with coverage):**
+
 ```bash
-npm run test
+npm test
+```
+
+**Interactive watch mode (local development):**
+
+```bash
+npm run test:watch
 ```
 
 For targeted frontend checks during development, run Vitest directly:

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "vitest",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run --coverage"
+    "test": "vitest run --coverage",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@stellar/freighter-api": "^6.0.1",

--- a/src/pages/ValidationHistory.tsx
+++ b/src/pages/ValidationHistory.tsx
@@ -7,6 +7,7 @@ import {
   paginate,
 } from '../utils/paginate';
 import type { ValidationHistoryStatusFilter } from '../utils/paginate';
+import { downloadCsv, toCsv } from '../utils/csv';
 
 const PAGE_SIZE_OPTIONS = [5, 10, 25];
 
@@ -144,6 +145,25 @@ export default function ValidationHistory() {
             ))}
           </select>
         </label>
+
+        <div className="flex flex-col gap-1 self-end">
+          <Text role="caption" as="span" style={{ color: 'var(--muted)' }}>&nbsp;</Text>
+          <button
+            aria-label="Export filtered validation history as CSV"
+            onClick={() => downloadCsv(toCsv(filteredHistory), 'validation-history.csv')}
+            style={{
+              background: 'var(--bg)',
+              color: 'var(--text)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: '0.65rem 0.75rem',
+              cursor: 'pointer',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            Export CSV
+          </button>
+        </div>
       </section>
 
       {/* History Log */}

--- a/src/pages/__tests__/ValidationHistory.test.tsx
+++ b/src/pages/__tests__/ValidationHistory.test.tsx
@@ -4,6 +4,15 @@ import type { ValidationTask } from '../../Zustand/Store';
 import { useVerifierStore } from '../../Zustand/Store';
 import ValidationHistory from '../ValidationHistory';
 
+const { mockDownloadCsv } = vi.hoisted(() => ({
+  mockDownloadCsv: vi.fn(),
+}));
+
+vi.mock('../../utils/csv', async () => {
+  const actual = await vi.importActual('../../utils/csv');
+  return { ...actual, downloadCsv: mockDownloadCsv };
+});
+
 vi.mock('../../Zustand/Store', () => ({
   useVerifierStore: vi.fn(),
 }));
@@ -184,5 +193,60 @@ describe('ValidationHistory', () => {
     fireEvent.click(screen.getByRole('button', { name: /back to dashboard/i }));
 
     expect(mockNavigate).toHaveBeenCalledWith('/verifier');
+  });
+
+  describe('CSV export', () => {
+    beforeEach(() => {
+      mockDownloadCsv.mockClear();
+    });
+
+    it('exports all items when no filter is active', () => {
+      renderHistory();
+
+      const btn = screen.getByRole('button', { name: /export.*csv/i });
+      fireEvent.click(btn);
+
+      expect(mockDownloadCsv).toHaveBeenCalledTimes(1);
+      const [csv, filename] = mockDownloadCsv.mock.calls[0];
+      expect(filename).toBe('validation-history.csv');
+      expect(csv).toContain('ID,Status,Vault Name,Owner,Amount,Deadline,Milestone,Notes');
+      for (const task of baseHistory) {
+        expect(csv).toContain(task.id);
+      }
+    });
+
+    it('exports only the filtered set when status filter is applied', () => {
+      renderHistory();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history by outcome'), {
+        target: { value: 'approved' },
+      });
+
+      const btn = screen.getByRole('button', { name: /export.*csv/i });
+      fireEvent.click(btn);
+
+      const [csv] = mockDownloadCsv.mock.calls[0];
+      expect(csv).toContain('v-001');
+      expect(csv).toContain('v-003');
+      expect(csv).toContain('v-005');
+      expect(csv).toContain('v-006');
+      expect(csv).not.toContain('v-002');
+      expect(csv).not.toContain('v-004');
+    });
+
+    it('exports only the filtered set when search query is active', () => {
+      renderHistory();
+
+      fireEvent.change(screen.getByLabelText('Search validation history by vault or owner'), {
+        target: { value: 'delta' },
+      });
+
+      const btn = screen.getByRole('button', { name: /export.*csv/i });
+      fireEvent.click(btn);
+
+      const [csv] = mockDownloadCsv.mock.calls[0];
+      expect(csv).toContain('v-004');
+      expect(csv).not.toContain('v-001');
+    });
   });
 });

--- a/src/utils/__tests__/csv.test.ts
+++ b/src/utils/__tests__/csv.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ValidationTask } from '../../Zustand/Store';
+import { downloadCsv, toCsv } from '../csv';
+
+const baseTask = (overrides: Partial<ValidationTask> = {}): ValidationTask => ({
+  id: 'v-001',
+  vaultName: 'Alpha Vault',
+  owner: 'GOWNER...ALPHA',
+  amount: '1,000 USDC',
+  deadline: '2026-01-01',
+  daysRemaining: 0,
+  status: 'approved',
+  milestone: 'Launch',
+  ...overrides,
+});
+
+describe('toCsv', () => {
+  const HEADER = 'ID,Status,Vault Name,Owner,Amount,Deadline,Milestone,Notes';
+
+  it('returns just the header row for an empty array', () => {
+    expect(toCsv([])).toBe(HEADER);
+  });
+
+  it('produces a single data row with no special characters', () => {
+    const task = baseTask();
+    const result = toCsv([task]);
+    const lines = result.split('\r\n');
+    expect(lines[0]).toBe(HEADER);
+    expect(lines[1]).toBe("v-001,approved,Alpha Vault,GOWNER...ALPHA,\"1,000 USDC\",2026-01-01,Launch,");
+    expect(lines).toHaveLength(2);
+  });
+
+  it('escapes commas by wrapping the field in double quotes', () => {
+    const task = baseTask({ vaultName: 'Alpha, Vault & Co.' });
+    const result = toCsv([task]);
+    expect(result).toContain('"Alpha, Vault & Co."');
+  });
+
+  it('escapes double quotes by doubling them', () => {
+    const task = baseTask({ vaultName: 'Alpha "Main" Vault' });
+    const result = toCsv([task]);
+    expect(result).toContain('"Alpha ""Main"" Vault"');
+  });
+
+  it('escapes newlines by wrapping the field in double quotes', () => {
+    const task = baseTask({ notes: 'Line one\nLine two' });
+    const result = toCsv([task]);
+    expect(result).toContain('"Line one\nLine two"');
+  });
+
+  it('escapes carriage returns by wrapping the field in double quotes', () => {
+    const task = baseTask({ notes: 'Line one\r\nLine two' });
+    const result = toCsv([task]);
+    expect(result).toContain('"Line one\r\nLine two"');
+  });
+
+  it('handles fields with mixed special characters', () => {
+    const task = baseTask({
+      vaultName: 'Test, Co.',
+      notes: 'He said "hello"\nNext line',
+    });
+    const result = toCsv([task]);
+    expect(result).toContain('"Test, Co."');
+    expect(result).toContain('"He said ""hello""\nNext line"');
+  });
+
+  it('handles undefined notes as empty string', () => {
+    const task = baseTask({ notes: undefined });
+    const result = toCsv([task]);
+    const lines = result.split('\r\n');
+    const cells = lines[1].split(',');
+    expect(cells[cells.length - 1]).toBe('');
+  });
+
+  it('handles multiple rows', () => {
+    const tasks = [
+      baseTask({ id: 'v-001', vaultName: 'Alpha' }),
+      baseTask({ id: 'v-002', vaultName: 'Beta' }),
+    ];
+    const result = toCsv(tasks);
+    const lines = result.split('\r\n');
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toContain('v-001');
+    expect(lines[2]).toContain('v-002');
+  });
+
+  it('preserves Unicode in vault names', () => {
+    const task = baseTask({ vaultName: 'Café & réservé' });
+    const result = toCsv([task]);
+    expect(result).toContain('Café & réservé');
+  });
+
+  it('preserves Unicode in notes', () => {
+    const task = baseTask({ notes: '验证通过 ✓' });
+    const result = toCsv([task]);
+    expect(result).toContain('验证通过 ✓');
+  });
+
+  it('separates rows with CRLF', () => {
+    const tasks = [
+      baseTask({ id: 'v-001' }),
+      baseTask({ id: 'v-002' }),
+    ];
+    const result = toCsv(tasks);
+    const parts = result.split('\r\n');
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toBe(HEADER);
+    expect(parts[1]).toContain('v-001');
+    expect(parts[2]).toContain('v-002');
+  });
+
+  it('preserves the stable header column order', () => {
+    const result = toCsv([]);
+    expect(result).toBe('ID,Status,Vault Name,Owner,Amount,Deadline,Milestone,Notes');
+  });
+});
+
+describe('downloadCsv', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is a no-op when document is undefined', () => {
+    const orig = global.document;
+    (global as any).document = undefined;
+    expect(() => downloadCsv('a,b', 'test.csv')).not.toThrow();
+    (global as any).document = orig;
+  });
+
+  it('creates a blob and triggers a download', () => {
+    const appendChild = vi.fn();
+    const removeChild = vi.fn();
+    const click = vi.fn();
+    const setAttribute = vi.fn();
+
+    const createElement = vi.fn(() => ({
+      setAttribute,
+      click,
+      style: {},
+    }));
+
+    const origDocument = global.document;
+    const origURL = global.URL;
+    (global as any).document = {
+      createElement,
+      body: { appendChild, removeChild },
+    };
+    (global as any).URL = {
+      createObjectURL: vi.fn(() => 'blob:mock'),
+      revokeObjectURL: vi.fn(),
+    };
+
+    downloadCsv('a,b,c', 'test.csv');
+
+    expect(createElement).toHaveBeenCalledWith('a');
+    expect(setAttribute).toHaveBeenCalledWith('download', 'test.csv');
+    expect(appendChild).toHaveBeenCalled();
+    expect(click).toHaveBeenCalled();
+    expect(removeChild).toHaveBeenCalled();
+
+    (global as any).document = origDocument;
+    (global as any).URL = origURL;
+  });
+});

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,45 @@
+import type { ValidationTask } from '../Zustand/Store';
+
+const HEADERS: string[] = ['ID', 'Status', 'Vault Name', 'Owner', 'Amount', 'Deadline', 'Milestone', 'Notes'];
+
+function escapeCell(value: string): string {
+  if (value.includes('"') || value.includes(',') || value.includes('\n') || value.includes('\r')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function toRow(task: ValidationTask): string {
+  const cells = [
+    task.id,
+    task.status,
+    task.vaultName,
+    task.owner,
+    task.amount,
+    task.deadline,
+    task.milestone,
+    task.notes ?? '',
+  ];
+  return cells.map(escapeCell).join(',');
+}
+
+export function toCsv(tasks: ValidationTask[]): string {
+  const headerRow = HEADERS.join(',');
+  if (tasks.length === 0) return headerRow;
+  const rows = tasks.map(toRow);
+  return [headerRow, ...rows].join('\r\n');
+}
+
+export function downloadCsv(csv: string, filename: string): void {
+  if (typeof document === 'undefined' || typeof URL === 'undefined') return;
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.setAttribute('href', url);
+  link.setAttribute('download', filename);
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary

Closes #179 

Add an "Export CSV" button to the Validation History page that serialises the
currently filtered (not just the visible page) validation history into a
downloadable, RFC-4180-compliant CSV file. The CSV serialisation is extracted
into a pure helper so it is testable without the DOM, and the download trigger
is wrapped in a small adapter that is safe in jsdom during tests.

## Changes

### New files

**`src/utils/csv.ts`** — CSV helper module with two exports:

- `toCsv(tasks)` — Pure function that converts a `ValidationTask[]` into an
  RFC-4180-compliant CSV string. Escapes double-quotes by doubling, wraps
  fields containing `"`, `,`, `\n`, or `\r` in double-quotes. Header row in
  stable order: `ID,Status,Vault Name,Owner,Amount,Deadline,Milestone,Notes`.
- `downloadCsv(csv, filename)` — Small adapter that creates a `Blob`, generates
  an object URL, creates an anchor element, triggers a download, and cleans up.
  Guards against missing `document`/`URL` to avoid crashing in jsdom.

**`src/utils/__tests__/csv.test.ts`** — 15 tests covering:
- Empty array (header only)
- Commas, double-quotes, newlines, CRLF in field values
- Mixed special characters
- Undefined notes → empty string
- Multiple rows, CRLF row separators
- Unicode in vault names and notes
- Stable column order assertion
- `downloadCsv` no-op when `document` is undefined
- `downloadCsv` document-manipulation path

### Modified files

**`src/pages/ValidationHistory.tsx`**
- Import `toCsv` and `downloadCsv` from `../utils/csv`
- Added "Export CSV" button in the filter controls section
- Button calls `downloadCsv(toCsv(filteredHistory), 'validation-history.csv')`
- Uses `filteredHistory` (the full set matching `statusFilter` + `searchQuery`),
  not the paginated visible page

**`src/pages/__tests__/ValidationHistory.test.tsx`**
- Mock `downloadCsv` from `../../utils/csv` using `vi.hoisted` for correct
  hoisting behaviour
- 3 new tests under `CSV export` describe block:
  1. Exports all items when no filter is active
  2. Exports only approved items when status filter applied
  3. Exports only matching items when search query active

## Verification

- **24/24 tests pass** across the two affected files (15 csv util tests + 9 ValidationHistory tests including 6 pre-existing)
- **100% coverage** on `src/utils/csv.ts` (statements, branches, functions, lines)
- **98.38% coverage** on `src/pages/ValidationHistory.tsx` — no regressions on filtering/pagination
- Pre-existing test failures (WalletConnectButton text matching, Analytics Suspense timing, PendingValidations text matchers, VaultDetail missing WalletProvider) are unchanged

## Screenshot
<img width="1562" height="441" alt="image" src="https://github.com/user-attachments/assets/8de76db2-3053-49f7-a2d7-114c19f12fc6" />
