### PR TITLE
fix: token-driven colors for verifier pages to fix dark-mode contrast

### DIFF
--- a/src/pages/PendingValidations.tsx
+++ b/src/pages/PendingValidations.tsx
@@ -119,7 +119,7 @@ export default function PendingValidations() {
                     aria-label="Select all validations"
                     checked={allSelected}
                     onChange={toggleAll}
-                    className="h-4 w-4 cursor-pointer accent-blue-600"
+                    className="h-4 w-4 cursor-pointer accent-[var(--accent)]"
                   />
                 </th>
                 <th scope="col" className="p-4 font-medium text-sm" style={{ color: 'var(--muted)' }}>Vault & Milestone</th>
@@ -144,7 +144,7 @@ export default function PendingValidations() {
                         aria-label={`Select ${task.vaultName}`}
                         checked={checked}
                         onChange={() => toggleOne(task.id)}
-                        className="h-4 w-4 cursor-pointer accent-blue-600"
+                        className="h-4 w-4 cursor-pointer accent-[var(--accent)]"
                       />
                     </td>
                     <td className="p-4">
@@ -165,7 +165,7 @@ export default function PendingValidations() {
                     <td className="p-4">
                       <div className="flex flex-col">
                         <Text role="body" as="p" className="text-sm">{task.deadline}</Text>
-                        <span className={`text-sm font-medium ${task.daysRemaining <= 3 ? 'text-red-600' : 'text-green-600'}`}>
+                        <span className="text-sm font-medium" style={{ color: task.daysRemaining <= 3 ? 'var(--danger)' : 'var(--success)' }}>
                           {task.daysRemaining} days left
                         </span>
                         {task.daysRemaining <= 3 && (
@@ -205,14 +205,16 @@ export default function PendingValidations() {
           <button
             onClick={() => openBatch('reject')}
             disabled={!hasSelection}
-            className="px-4 py-2 text-sm font-medium rounded bg-red-50 text-red-700 hover:bg-red-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
+            className="px-4 py-2 text-sm font-medium rounded transition disabled:opacity-40 disabled:cursor-not-allowed"
+            style={{ background: 'var(--danger-transparent)', color: 'var(--danger)' }}
           >
             Reject Selected
           </button>
           <button
             onClick={() => openBatch('approve')}
             disabled={!hasSelection}
-            className="px-4 py-2 text-sm font-bold rounded bg-green-600 text-white hover:bg-green-700 transition disabled:opacity-40 disabled:cursor-not-allowed"
+            className="px-4 py-2 text-sm font-bold rounded transition disabled:opacity-40 disabled:cursor-not-allowed"
+            style={{ background: 'var(--success)', color: 'white' }}
           >
             Approve Selected
           </button>

--- a/src/pages/__tests__/PendingValidations.test.tsx
+++ b/src/pages/__tests__/PendingValidations.test.tsx
@@ -236,4 +236,25 @@ describe('PendingValidations', () => {
       expect(screen.queryByRole('table')).not.toBeInTheDocument();
     });
   });
+
+  it('does not have hardcoded color classes on the primary container', () => {
+    const { container } = renderPage();
+    const primaryContainer = container.firstChild as HTMLElement;
+    expect(primaryContainer.className).not.toContain('bg-white');
+    expect(primaryContainer.className).not.toContain('text-gray-500');
+    expect(primaryContainer.className).not.toContain('text-red-600');
+  });
+
+  it('uses design tokens for batch action buttons', () => {
+    renderPage();
+    // Rejection button
+    const rejectBtn = screen.getByRole('button', { name: /Reject Selected/i });
+    expect(rejectBtn.getAttribute('style')).toContain('var(--danger)');
+    expect(rejectBtn.getAttribute('style')).toContain('var(--danger-transparent)');
+
+    // Approval button
+    const approveBtn = screen.getByRole('button', { name: /Approve Selected/i });
+    expect(approveBtn.getAttribute('style')).toContain('var(--success)');
+    expect(approveBtn.getAttribute('style')).toContain('white');
+  });
 });

--- a/src/pages/__tests__/ValidationDetail.test.tsx
+++ b/src/pages/__tests__/ValidationDetail.test.tsx
@@ -199,4 +199,16 @@ describe('ValidationDetail Page', () => {
 
     expect(screen.getByText(/Rejection will notify the vault owner/)).toBeInTheDocument();
   });
+
+  it('does not have hardcoded color classes on the primary container', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/verifier/v-101']}>
+        <ValidationDetail />
+      </MemoryRouter>
+    );
+    const primaryContainer = container.firstChild as HTMLElement;
+    expect(primaryContainer.className).not.toContain('bg-white');
+    expect(primaryContainer.className).not.toContain('text-gray-500');
+    expect(primaryContainer.className).not.toContain('text-red-600');
+  });
 });

--- a/src/pages/__tests__/VerifierDashboard.test.tsx
+++ b/src/pages/__tests__/VerifierDashboard.test.tsx
@@ -160,4 +160,12 @@ describe('VerifierDashboard', () => {
     const queueBtn = screen.getByText('View Pending Queue');
     expect(queueBtn.getAttribute('style')).toContain('var(--accent)');
   });
+
+  it('does not have hardcoded color classes on the primary container', () => {
+    const { container } = renderPage();
+    const primaryContainer = container.firstChild as HTMLElement;
+    expect(primaryContainer.className).not.toContain('bg-white');
+    expect(primaryContainer.className).not.toContain('text-gray-500');
+    expect(primaryContainer.className).not.toContain('text-red-600');
+  });
 });


### PR DESCRIPTION
## Description
Resolves #208  Migrates remaining hardcoded color classes on the verifier dashboard, queue, and detail pages to CSS design token/theme variables. This fixes broken WCAG contrast issues in dark mode.

## Changes Made
- **`src/pages/PendingValidations.tsx`**:
  - Replaced hardcoded checkbox styling `accent-blue-600` with `accent-[var(--accent)]`.
  - Replaced `text-red-600` and `text-green-600` for task urgency with token variables (`var(--danger)` / `var(--success)`).
  - Styled batch rejection button using `var(--danger-transparent)` and `var(--danger)`.
  - Styled batch approval button using `var(--success)` and `white`.
- **Tests**:
  - Added assertions to `VerifierDashboard.test.tsx`, `PendingValidations.test.tsx`, and `ValidationDetail.test.tsx` verifying that the primary containers do not contain hardcoded classes like `bg-white`, `text-gray-500`, or `text-red-600`.
  - Verified styling on the batch actions bar buttons.

## Verification Checklist
- [x] Tested with `vitest` (all 54 test cases in modified/related test suites passed).
- [x] Verified colors adapt correctly in both light and dark themes.