### PR TITLE
test: cover typography utility role classes

### DIFF
--- a/src/utils/__tests__/README.md
+++ b/src/utils/__tests__/README.md
@@ -1,0 +1,12 @@
+# Utility test contracts
+
+The typography utility tests lock the shared `Text` role contract:
+
+- each `TypographyRole` maps to its exact `text-*` design-token class;
+- `classifyTypography` returns the base class unchanged when no extra classes
+  are supplied;
+- extra class strings are appended after the base typography class without
+  mutating the caller-provided class list.
+
+These assertions keep role names, design-token class names, and shared text
+component styling aligned during future refactors.

--- a/src/utils/__tests__/typography.test.ts
+++ b/src/utils/__tests__/typography.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyTypography,
+  getTypographyClass,
+  type TypographyRole,
+} from '../typography';
+
+const roleClassCases: Array<[TypographyRole, string]> = [
+  ['display', 'text-display'],
+  ['title', 'text-title'],
+  ['subtitle', 'text-subtitle'],
+  ['body', 'text-body'],
+  ['caption', 'text-caption'],
+  ['mono', 'text-mono'],
+];
+
+describe('getTypographyClass', () => {
+  it.each(roleClassCases)('maps %s to %s', (role, expectedClass) => {
+    expect(getTypographyClass(role)).toBe(expectedClass);
+  });
+});
+
+describe('classifyTypography', () => {
+  it('returns only the base role class when additional classes are omitted', () => {
+    expect(classifyTypography('body')).toBe('text-body');
+  });
+
+  it('returns only the base role class when additional classes are an empty string', () => {
+    expect(classifyTypography('body', '')).toBe('text-body');
+  });
+
+  it('joins a single additional class with one space', () => {
+    expect(classifyTypography('body', 'font-semibold')).toBe(
+      'text-body font-semibold',
+    );
+  });
+
+  it('preserves multiple additional classes after the base role class', () => {
+    expect(classifyTypography('title', 'tracking-tight text-slate-900')).toBe(
+      'text-title tracking-tight text-slate-900',
+    );
+  });
+});


### PR DESCRIPTION
Closes #319

## Summary
- Add focused Vitest coverage for every `TypographyRole` -> `text-*` class mapping.
- Cover `classifyTypography` with omitted, empty, single, and multi-class `additionalClasses` inputs.
- Document the utility role contract in `src/utils/__tests__/README.md`.

## Verification
- `npm test -- --run src/utils/__tests__/typography.test.ts` => 10 passed.
- `npm run build` currently fails on existing repository-wide TypeScript/test issues unrelated to this change, including missing Vitest globals in older tests and pre-existing component/test type mismatches.