### PR TITLE
test: cover getAllTokens partial-failure merging (Add unit tests for design-system getAllTokens partial-failure merging)

### DIFF
--- a/design-system/src/__tests__/token-loader.test.ts
+++ b/design-system/src/__tests__/token-loader.test.ts
@@ -55,26 +55,110 @@ describe('token-loader', () => {
 
     it('should continue and warn if a file fails to load', () => {
         mockedFs.readFileSync.mockImplementation((path) => {
+            if (path.toString().includes('typography.json')) throw new Error('File not found');
             if (path.toString().includes('colors.json')) return '{"color": "red"}';
+            if (path.toString().includes('spacing.json')) return '{"space": "4px"}';
+            if (path.toString().includes('shadows.json')) return '{"shadow": "1px"}';
+            if (path.toString().includes('motion.json')) return '{"motion": "ease"}';
+            if (path.toString().includes('borders.json')) return '{"border": "1px"}';
+            return '{}';
+        });
+
+        const allTokens = getAllTokens();
+
+        // The failed file is omitted, every other file is still merged.
+        expect(allTokens).toEqual({
+            "color": "red",
+            "space": "4px",
+            "shadow": "1px",
+            "motion": "ease",
+            "border": "1px"
+        });
+        expect(allTokens).not.toHaveProperty('font');
+    });
+
+    it('should warn with the name of the file that failed to load', () => {
+        mockedFs.readFileSync.mockImplementation((path) => {
             if (path.toString().includes('typography.json')) throw new Error('File not found');
             return '{}';
         });
 
-        const allTokens = getAllTokens();
-        expect(allTokens).toEqual({"color": "red"});
-        expect(console.warn).toHaveBeenCalled();
+        getAllTokens();
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(
+            'Failed to load typography.json:',
+            expect.any(Error)
+        );
     });
     
     it('should continue and warn if a file has malformed JSON', () => {
         mockedFs.readFileSync.mockImplementation((path) => {
-            if (path.toString().includes('colors.json')) return '{"color": "red"}';
             if (path.toString().includes('typography.json')) return '{"invalid": }';
+            if (path.toString().includes('colors.json')) return '{"color": "red"}';
+            if (path.toString().includes('spacing.json')) return '{"space": "4px"}';
+            if (path.toString().includes('shadows.json')) return '{"shadow": "1px"}';
+            if (path.toString().includes('motion.json')) return '{"motion": "ease"}';
+            if (path.toString().includes('borders.json')) return '{"border": "1px"}';
             return '{}';
         });
 
         const allTokens = getAllTokens();
-        expect(allTokens).toEqual({"color": "red"});
-        expect(console.warn).toHaveBeenCalled();
+
+        // A parse error is caught just like a read error: the bad file is dropped.
+        expect(allTokens).toEqual({
+            "color": "red",
+            "space": "4px",
+            "shadow": "1px",
+            "motion": "ease",
+            "border": "1px"
+        });
+        expect(console.warn).toHaveBeenCalledWith(
+            'Failed to load typography.json:',
+            expect.any(SyntaxError)
+        );
+    });
+
+    it('should let later files override earlier keys via Object.assign', () => {
+        // colors.json is merged first, borders.json last; the shared "token"
+        // key must reflect the last file processed.
+        mockedFs.readFileSync.mockImplementation((path) => {
+            if (path.toString().includes('colors.json')) return '{"token": "from-colors"}';
+            if (path.toString().includes('borders.json')) return '{"token": "from-borders"}';
+            return '{}';
+        });
+
+        const allTokens = getAllTokens();
+
+        expect(allTokens).toEqual({"token": "from-borders"});
+    });
+
+    it('should still merge a file ordered after a failing one', () => {
+        mockedFs.readFileSync.mockImplementation((path) => {
+            // colors (first) fails, borders (last) must still be merged.
+            if (path.toString().includes('colors.json')) throw new Error('File not found');
+            if (path.toString().includes('borders.json')) return '{"border": "1px"}';
+            return '{}';
+        });
+
+        const allTokens = getAllTokens();
+
+        expect(allTokens).toEqual({"border": "1px"});
+        expect(console.warn).toHaveBeenCalledWith(
+            'Failed to load colors.json:',
+            expect.any(Error)
+        );
+    });
+
+    it('should return an empty object and warn once per file when all files fail', () => {
+        mockedFs.readFileSync.mockImplementation(() => {
+            throw new Error('File not found');
+        });
+
+        const allTokens = getAllTokens();
+
+        expect(allTokens).toEqual({});
+        expect(console.warn).toHaveBeenCalledTimes(6);
     });
   });
 });


### PR DESCRIPTION
Closes #332 

### Summary
`getAllTokens` in `design-system/src/utils/token-loader.ts` iterates the six
token files, merges each via `Object.assign`, and tolerates per-file failures
by catching the error and logging a `console.warn`. The existing suite covered
the happy path and a basic failure case, but the assertions did not actually
prove that the surviving files are still merged or that the warning identifies
the failed file.

This PR extends `design-system/src/__tests__/token-loader.test.ts` to lock down
the failure-tolerant merge behavior. No production code is changed.

### Changes
- Strengthen the single-file-failure test so the other five files return real
  data and are asserted to merge, with the failed file's key absent.
- Add a test asserting `console.warn` is called with the failing file's name.
- Cover malformed JSON the same way, asserting the caught error is a
  `SyntaxError` (parse error path).
- Add an ordering test proving later files override earlier keys via
  `Object.assign`, including when an earlier file in the order fails.
- Add the all-files-fail edge case: result is an empty object with exactly one
  warning per file.

### Verification
- `cd design-system && npm test` — 34 passed, 4 suites, no regressions
  (previously 30).
- Coverage on `token-loader.ts`: 100% statements / branches / functions / lines.

### Notes
- Test-only change; behavior of `getAllTokens` and `loadTokens` is unchanged.
- Diff is scoped to a single test file to keep review straightforward.
