### PR TITLE
test: add wallet connect-to-disconnect integration coverage

### DIFF
--- a/src/components/Wallet/__tests__/walletLifecycle.integration.test.tsx
+++ b/src/components/Wallet/__tests__/walletLifecycle.integration.test.tsx
@@ -1,0 +1,217 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { WalletProvider, useWallet } from '../../../context/WalletContext';
+import { WalletConnectButton } from '../WalletConnectButton';
+import { USDC_ISSUERS } from '../../../utils/horizon';
+
+const freighterMocks = vi.hoisted(() => ({
+    isAllowed: vi.fn(),
+    setAllowed: vi.fn(),
+    requestAccess: vi.fn(),
+    getAddress: vi.fn(),
+    getNetworkDetails: vi.fn(),
+}));
+
+vi.mock('@stellar/freighter-api', () => freighterMocks);
+
+function mockResponse(status: number, body: unknown) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: vi.fn().mockResolvedValue(body),
+    } as unknown as Response;
+}
+
+function ErrorProbe() {
+    const { error } = useWallet();
+    return error ? <div data-testid="wallet-error">{error}</div> : null;
+}
+
+function renderWalletTree() {
+    return render(
+        <WalletProvider>
+            <ErrorProbe />
+            <WalletConnectButton />
+        </WalletProvider>,
+    );
+}
+
+describe('Wallet lifecycle integration', () => {
+    const originalFetch = globalThis.fetch;
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.useRealTimers();
+        freighterMocks.isAllowed.mockResolvedValue(false);
+        freighterMocks.setAllowed.mockResolvedValue(undefined);
+        freighterMocks.requestAccess.mockResolvedValue(true);
+        freighterMocks.getAddress.mockResolvedValue({ address: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890', error: null });
+        freighterMocks.getNetworkDetails.mockResolvedValue({ network: 'TESTNET' });
+        globalThis.fetch = vi.fn();
+    });
+
+    afterAll(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    test('shows connect button before wallet is connected', () => {
+        renderWalletTree();
+
+        expect(screen.getByRole('button', { name: /connect wallet/i })).toBeInTheDocument();
+        expect(screen.queryByText('GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890')).not.toBeInTheDocument();
+    });
+
+    test('connects wallet, loads balance, and shows dropdown with address and balance', async () => {
+        vi.mocked(globalThis.fetch).mockResolvedValue(
+            mockResponse(200, {
+                balances: [
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: USDC_ISSUERS.TESTNET,
+                        balance: '12.5000000',
+                    },
+                ],
+            }),
+        );
+
+        renderWalletTree();
+
+        fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }));
+
+        expect(await screen.findByText('Freighter')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('Freighter'));
+
+        await waitFor(() => expect(screen.getByRole('button', { name: /gabc/i })).toBeInTheDocument());
+
+        fireEvent.click(screen.getByRole('button', { name: /gabc/i }));
+
+        expect(await screen.findByText('12.5000000')).toBeInTheDocument();
+        expect(screen.getByText('USDC')).toBeInTheDocument();
+
+        const truncatedAddress = 'GABC...7890';
+        expect(screen.getByText(truncatedAddress)).toBeInTheDocument();
+
+        expect(screen.queryByRole('button', { name: /connect wallet/i })).not.toBeInTheDocument();
+    });
+
+    test('shows isConnecting state during connection', async () => {
+        let resolveRequestAccess: (value: boolean) => void = () => undefined;
+        freighterMocks.requestAccess.mockImplementation(
+            () =>
+                new Promise<boolean>((resolve) => {
+                    resolveRequestAccess = resolve;
+                }),
+        );
+
+        vi.mocked(globalThis.fetch).mockResolvedValue(
+            mockResponse(200, {
+                balances: [
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: USDC_ISSUERS.TESTNET,
+                        balance: '5.0000000',
+                    },
+                ],
+            }),
+        );
+
+        renderWalletTree();
+
+        fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }));
+        fireEvent.click(await screen.findByText('Freighter'));
+
+        const freighterButton = await screen.findByRole('button', { name: /freighter/i });
+        expect(freighterButton).toBeDisabled();
+
+        resolveRequestAccess(true);
+
+        await waitFor(() => expect(screen.getByRole('button', { name: /gabc/i })).toBeInTheDocument());
+
+        fireEvent.click(screen.getByRole('button', { name: /gabc/i }));
+
+        expect(await screen.findByText('5.0000000')).toBeInTheDocument();
+    });
+
+    test('shows no_trustline state when fetchUsdcBalance returns no trustline', async () => {
+        vi.mocked(globalThis.fetch).mockResolvedValue(
+            mockResponse(200, {
+                balances: [{ asset_type: 'native', balance: '10.0000000' }],
+            }),
+        );
+
+        renderWalletTree();
+
+        fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }));
+        fireEvent.click(await screen.findByText('Freighter'));
+
+        await waitFor(() => expect(screen.getByRole('button', { name: /gabc/i })).toBeInTheDocument());
+
+        fireEvent.click(screen.getByRole('button', { name: /gabc/i }));
+
+        expect(await screen.findByText('0.00')).toBeInTheDocument();
+        expect(screen.getByText('No USDC trustline on this network')).toBeInTheDocument();
+    });
+
+    test('shows error state when fetchUsdcBalance rejects', async () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse(500, {}));
+
+        renderWalletTree();
+
+        fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }));
+        fireEvent.click(await screen.findByText('Freighter'));
+
+        await waitFor(() => expect(screen.getByRole('button', { name: /gabc/i })).toBeInTheDocument());
+
+        fireEvent.click(screen.getByRole('button', { name: /gabc/i }));
+
+        expect(await screen.findByText('Balance unavailable')).toBeInTheDocument();
+
+        consoleError.mockRestore();
+    });
+
+    test('shows error state when freighter denies access', async () => {
+        freighterMocks.requestAccess.mockResolvedValue(false);
+
+        renderWalletTree();
+
+        fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }));
+        fireEvent.click(await screen.findByText('Freighter'));
+
+        expect(await screen.findByTestId('wallet-error')).toHaveTextContent('Wallet access denied.');
+        expect(await screen.findByRole('button', { name: /connect wallet/i })).toBeInTheDocument();
+    });
+
+    test('disconnect resets address and balance to null', async () => {
+        vi.mocked(globalThis.fetch).mockResolvedValue(
+            mockResponse(200, {
+                balances: [
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: USDC_ISSUERS.TESTNET,
+                        balance: '12.5000000',
+                    },
+                ],
+            }),
+        );
+
+        renderWalletTree();
+
+        fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }));
+        fireEvent.click(await screen.findByText('Freighter'));
+
+        await waitFor(() => expect(screen.getByRole('button', { name: /gabc/i })).toBeInTheDocument());
+
+        fireEvent.click(screen.getByRole('button', { name: /gabc/i }));
+
+        expect(await screen.findByText('12.5000000')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: /disconnect/i }));
+
+        expect(await screen.findByRole('button', { name: /connect wallet/i })).toBeInTheDocument();
+        expect(screen.queryByText('12.5000000')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Closes #364
Summary
Added an integration test that exercises the full wallet lifecycle — connect → balance load → dropdown state → disconnect — using the real WalletProvider with all three wallet components together.
What's tested

Connect button is visible before wallet is connected
Successful connect populates truncated address and balance in the dropdown
isConnecting state is surfaced during connection
no_trustline balance state renders correctly in the dropdown
Balance fetch error surfaces the error state in the dropdown
Freighter access denial surfaces an error in the UI
Disconnect clears address and balance and restores the connect button

Approach

Real WalletProvider wraps all components — no mocked context
@stellar/freighter-api and fetchUsdcBalance are mocked following existing test patterns
All async assertions use findBy* / waitFor — no arbitrary timeouts
Mocks reset in beforeEach

Test result
✓ src/components/Wallet/__tests__/walletLifecycle.integration.test.tsx (7 tests) 2213ms
Tests  7 passed (7)