### PR TITLE
feat: add review-and-confirm step to CreateVault

### DIFF
--- a/src/components/CreateVaultReview.tsx
+++ b/src/components/CreateVaultReview.tsx
@@ -1,0 +1,159 @@
+import { Text } from "./Text";
+
+interface CreateVaultReviewProps {
+  amount: string;
+  deadline: string;
+  successAddress: string;
+  failureAddress: string;
+  verifierAddress?: string;
+  milestone?: string;
+  onBack?: () => void;
+  onConfirm?: () => void;
+}
+
+function AddressDisplay({ value, label }: { value: string; label: string }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+      <Text role="caption" as="span" style={{ color: "var(--muted)" }}>
+        {label}
+      </Text>
+      <Text
+        role="body"
+        as="code"
+        style={{
+          padding: "0.5rem 0.75rem",
+          borderRadius: "var(--radius)",
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          color: "var(--accent)",
+          wordBreak: "break-all",
+        }}
+      >
+        {value}
+      </Text>
+    </div>
+  );
+}
+
+export function CreateVaultReview({
+  amount,
+  deadline,
+  successAddress,
+  failureAddress,
+  verifierAddress,
+  milestone,
+  onBack,
+  onConfirm,
+}: CreateVaultReviewProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "1rem",
+        maxWidth: 480,
+        padding: "1.25rem",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius)",
+        background: "var(--surface)",
+      }}
+    >
+      <Text role="display" as="h2" style={{ marginBottom: "0.25rem" }}>
+        Review Vault Details
+      </Text>
+      <Text role="body" as="p" style={{ color: "var(--muted)" }}>
+        Confirm the vault details before creating it. This action is
+        irreversible once submitted.
+      </Text>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+        <div
+          style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}
+        >
+          <Text role="caption" as="span" style={{ color: "var(--muted)" }}>
+            Amount (USDC)
+          </Text>
+          <Text role="body" as="p">
+            {amount}
+          </Text>
+        </div>
+
+        <div
+          style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}
+        >
+          <Text role="caption" as="span" style={{ color: "var(--muted)" }}>
+            Deadline
+          </Text>
+          <Text role="body" as="p">
+            {deadline}
+          </Text>
+        </div>
+
+        <AddressDisplay value={successAddress} label="Success destination" />
+        <AddressDisplay value={failureAddress} label="Failure destination" />
+
+        {verifierAddress ? (
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}
+          >
+            <Text role="caption" as="span" style={{ color: "var(--muted)" }}>
+              Verifier address
+            </Text>
+            <Text role="body" as="p">
+              {verifierAddress}
+            </Text>
+          </div>
+        ) : null}
+
+        {milestone ? (
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}
+          >
+            <Text role="caption" as="span" style={{ color: "var(--muted)" }}>
+              Milestone
+            </Text>
+            <Text role="body" as="p">
+              {milestone}
+            </Text>
+          </div>
+        ) : null}
+      </div>
+
+      <div style={{ display: "flex", gap: "0.75rem", marginTop: "0.5rem" }}>
+        <button
+          type="button"
+          onClick={onBack}
+          style={{
+            background: "transparent",
+            color: "var(--text)",
+            padding: "0.75rem 1rem",
+            borderRadius: "var(--radius)",
+            border: "1px solid var(--border)",
+            cursor: "pointer",
+          }}
+        >
+          <Text role="caption" as="span">
+            Back to edit
+          </Text>
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          style={{
+            background: "var(--accent)",
+            color: "var(--bg)",
+            padding: "0.75rem 1rem",
+            borderRadius: "var(--radius)",
+            border: "none",
+            cursor: "pointer",
+            fontWeight: 600,
+          }}
+        >
+          <Text role="caption" as="span">
+            Confirm Vault
+          </Text>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/CreateVaultReview.test.tsx
+++ b/src/components/__tests__/CreateVaultReview.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CreateVaultReview } from "../CreateVaultReview";
+
+describe("CreateVaultReview", () => {
+  it("renders the vault summary and token-styled address details", () => {
+    const successAddress = `G${"A".repeat(55)}`;
+    const failureAddress = `G${"B".repeat(55)}`;
+    const verifierAddress = `G${"C".repeat(55)}`;
+
+    render(
+      <CreateVaultReview
+        amount="100.1234567"
+        deadline="2030-01-01T00:00"
+        successAddress={successAddress}
+        failureAddress={failureAddress}
+        verifierAddress={verifierAddress}
+        milestone="Deliverables approved"
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /review vault details/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("100.1234567")).toBeInTheDocument();
+    expect(screen.getByText("2030-01-01T00:00")).toBeInTheDocument();
+    expect(screen.getByText(successAddress)).toBeInTheDocument();
+    expect(screen.getByText(failureAddress)).toBeInTheDocument();
+    expect(screen.getByText("Verifier address")).toBeInTheDocument();
+    expect(screen.getByText("Milestone")).toBeInTheDocument();
+  });
+});

--- a/src/pages/CreateVault.tsx
+++ b/src/pages/CreateVault.tsx
@@ -1,125 +1,163 @@
-import { useState } from 'react'
-import { Text } from '../components/Text'
-import { Field } from '../components/Field'
-import type { CreateVaultErrors } from '../utils/vaultValidation'
+import { useState } from "react";
+import { Text } from "../components/Text";
+import { Field } from "../components/Field";
+import type { CreateVaultErrors } from "../utils/vaultValidation";
 import {
   hasCreateVaultErrors,
   validateCreateVault,
-} from '../utils/vaultValidation'
-import { EvidenceUpload } from '../components/EvidenceUpload'
+} from "../utils/vaultValidation";
+import { EvidenceUpload } from "../components/EvidenceUpload";
+import { CreateVaultReview } from "../components/CreateVaultReview";
 
 export default function CreateVault() {
-  const [amount, setAmount] = useState('')
-  const [deadline, setDeadline] = useState('')
-  const [successAddress, setSuccessAddress] = useState('')
-  const [failureAddress, setFailureAddress] = useState('')
-  const [errors, setErrors] = useState<CreateVaultErrors>({})
-  const [evidenceUrl, setEvidenceUrl] = useState<string | undefined>()
+  const [amount, setAmount] = useState("");
+  const [deadline, setDeadline] = useState("");
+  const [successAddress, setSuccessAddress] = useState("");
+  const [failureAddress, setFailureAddress] = useState("");
+  const [errors, setErrors] = useState<CreateVaultErrors>({});
+  const [evidenceUrl, setEvidenceUrl] = useState<string | undefined>();
+  const [showReview, setShowReview] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
+    e.preventDefault();
     const nextErrors = validateCreateVault({
       amount,
       deadline,
       successAddress,
       failureAddress,
-    })
-    setErrors(nextErrors)
-    if (hasCreateVaultErrors(nextErrors)) return
+    });
+    setErrors(nextErrors);
+    if (hasCreateVaultErrors(nextErrors)) return;
 
+    setShowReview(true);
+  };
+
+  const handleConfirm = () => {
     // Placeholder: will call backend / contract
-    console.log({ amount, deadline, successAddress, failureAddress, evidenceUrl })
-  }
+    console.log({
+      amount,
+      deadline,
+      successAddress,
+      failureAddress,
+      evidenceUrl,
+    });
+  };
+
+  const handleBackToEdit = () => {
+    setShowReview(false);
+  };
 
   return (
     <div>
-      <Text role="display" as="h1" style={{ marginBottom: '0.5rem' }}>
+      <Text role="display" as="h1" style={{ marginBottom: "0.5rem" }}>
         Create Vault
       </Text>
-      <Text role="body" as="p" style={{ color: 'var(--muted)', marginBottom: '2rem' }}>
-        Lock USDC with a deadline and milestone. Funds release on validation or redirect on failure.
-      </Text>
-      <form
-        onSubmit={handleSubmit}
-        noValidate
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '1.25rem',
-          maxWidth: 400,
-        }}
+      <Text
+        role="body"
+        as="p"
+        style={{ color: "var(--muted)", marginBottom: "2rem" }}
       >
-        <Field
-          label="Amount (USDC)"
-          type="text"
-          value={amount}
-          onChange={(e) => {
-            setAmount(e.target.value)
-            setErrors((current) => ({ ...current, amount: undefined }))
-          }}
-          placeholder="1000"
-          error={errors.amount}
-          required
+        Lock USDC with a deadline and milestone. Funds release on validation or
+        redirect on failure.
+      </Text>
+      {showReview ? (
+        <CreateVaultReview
+          amount={amount}
+          deadline={deadline}
+          successAddress={successAddress}
+          failureAddress={failureAddress}
+          onBack={handleBackToEdit}
+          onConfirm={handleConfirm}
         />
-        <Field
-          label="Deadline (ISO date)"
-          type="datetime-local"
-          value={deadline}
-          onChange={(e) => {
-            setDeadline(e.target.value)
-            setErrors((current) => ({ ...current, deadline: undefined }))
-          }}
-          error={errors.deadline}
-          required
-        />
-        <Field
-          label="Success destination (Stellar address)"
-          type="text"
-          value={successAddress}
-          onChange={(e) => {
-            setSuccessAddress(e.target.value)
-            setErrors((current) => ({ ...current, successAddress: undefined }))
-          }}
-          placeholder="G..."
-          error={errors.successAddress}
-          required
-        />
-        <Field
-          label="Failure destination (Stellar address)"
-          type="text"
-          value={failureAddress}
-          onChange={(e) => {
-            setFailureAddress(e.target.value)
-            setErrors((current) => ({ ...current, failureAddress: undefined }))
-          }}
-          placeholder="G..."
-          error={errors.failureAddress}
-          required
-        />
-        <EvidenceUpload onChange={setEvidenceUrl} />
-        <button
-          type="submit"
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          noValidate
           style={{
-            background: 'var(--accent)',
-            color: 'var(--bg)',
-            padding: '0.75rem 1.5rem',
-            borderRadius: 'var(--radius)',
-            border: 'none',
-            fontWeight: 600,
-            cursor: 'pointer',
-            marginTop: '0.5rem',
-            minHeight: '44px',
-            minWidth: '44px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
+            display: "flex",
+            flexDirection: "column",
+            gap: "1.25rem",
+            maxWidth: 400,
           }}
         >
-          <Text role="caption" as="span">
-            Create Vault
-          </Text>
-        </button>
-      </form>
+          <Field
+            label="Amount (USDC)"
+            type="text"
+            value={amount}
+            onChange={(e) => {
+              setAmount(e.target.value);
+              setErrors((current) => ({ ...current, amount: undefined }));
+            }}
+            placeholder="1000"
+            error={errors.amount}
+            required
+          />
+          <Field
+            label="Deadline (ISO date)"
+            type="datetime-local"
+            value={deadline}
+            onChange={(e) => {
+              setDeadline(e.target.value);
+              setErrors((current) => ({ ...current, deadline: undefined }));
+            }}
+            error={errors.deadline}
+            required
+          />
+          <Field
+            label="Success destination (Stellar address)"
+            type="text"
+            value={successAddress}
+            onChange={(e) => {
+              setSuccessAddress(e.target.value);
+              setErrors((current) => ({
+                ...current,
+                successAddress: undefined,
+              }));
+            }}
+            placeholder="G..."
+            error={errors.successAddress}
+            required
+          />
+          <Field
+            label="Failure destination (Stellar address)"
+            type="text"
+            value={failureAddress}
+            onChange={(e) => {
+              setFailureAddress(e.target.value);
+              setErrors((current) => ({
+                ...current,
+                failureAddress: undefined,
+              }));
+            }}
+            placeholder="G..."
+            error={errors.failureAddress}
+            required
+          />
+          <EvidenceUpload onChange={setEvidenceUrl} />
+          <button
+            type="submit"
+            style={{
+              background: "var(--accent)",
+              color: "var(--bg)",
+              padding: "0.75rem 1.5rem",
+              borderRadius: "var(--radius)",
+              border: "none",
+              fontWeight: 600,
+              cursor: "pointer",
+              marginTop: "0.5rem",
+              minHeight: "44px",
+              minWidth: "44px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Text role="caption" as="span">
+              Create Vault
+            </Text>
+          </button>
+        </form>
+      )}
     </div>
-  )
+  );
 }

--- a/src/pages/__tests__/CreateVault.test.tsx
+++ b/src/pages/__tests__/CreateVault.test.tsx
@@ -1,68 +1,114 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import CreateVault from '../CreateVault';
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import CreateVault from "../CreateVault";
 
-const successAddress = `G${'A'.repeat(55)}`;
-const failureAddress = `G${'B'.repeat(55)}`;
+const successAddress = `G${"A".repeat(55)}`;
+const failureAddress = `G${"B".repeat(55)}`;
 
 function fillField(label: RegExp, value: string) {
   fireEvent.change(screen.getByLabelText(label), { target: { value } });
 }
 
-describe('CreateVault', () => {
+describe("CreateVault", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('renders accessible inline errors and blocks invalid submissions', () => {
-    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  it("renders accessible inline errors and blocks invalid submissions", () => {
+    const consoleLog = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
     render(<CreateVault />);
 
-    fireEvent.click(screen.getByRole('button', { name: /create vault/i }));
+    fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
 
     expect(
-      screen.getByText('Enter a positive USDC amount with up to 7 decimal places.'),
+      screen.getByText(
+        "Enter a positive USDC amount with up to 7 decimal places.",
+      ),
     ).toBeInTheDocument();
-    expect(screen.getByText('Choose a future deadline.')).toBeInTheDocument();
-    expect(screen.getAllByText('Enter a valid Stellar public key starting with G.')).toHaveLength(2);
+    expect(screen.getByText("Choose a future deadline.")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Enter a valid Stellar public key starting with G."),
+    ).toHaveLength(2);
 
     const amount = screen.getByLabelText(/amount/i);
-    expect(amount).toHaveAttribute('aria-invalid', 'true');
-    expect(amount).toHaveAttribute('aria-describedby', 'field-amount-(usdc)-error');
+    expect(amount).toHaveAttribute("aria-invalid", "true");
+    expect(amount).toHaveAttribute(
+      "aria-describedby",
+      "field-amount-(usdc)-error",
+    );
     expect(consoleLog).not.toHaveBeenCalled();
   });
 
-  it('rejects identical destination addresses', () => {
+  it("rejects identical destination addresses", () => {
     render(<CreateVault />);
 
-    fillField(/amount/i, '100');
-    fillField(/deadline/i, '2030-01-01T00:00');
+    fillField(/amount/i, "100");
+    fillField(/deadline/i, "2030-01-01T00:00");
     fillField(/success destination/i, successAddress);
     fillField(/failure destination/i, successAddress);
-    fireEvent.click(screen.getByRole('button', { name: /create vault/i }));
+    fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
 
     expect(
-      screen.getByText('Failure destination must be different from success destination.'),
+      screen.getByText(
+        "Failure destination must be different from success destination.",
+      ),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText(/failure destination/i)).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByLabelText(/failure destination/i)).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
   });
 
-  it('submits valid vault parameters', () => {
-    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  it("shows the review step for valid values and confirms once", () => {
+    const consoleLog = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
     render(<CreateVault />);
 
-    fillField(/amount/i, '100.1234567');
-    fillField(/deadline/i, '2030-01-01T00:00');
+    fillField(/amount/i, "100.1234567");
+    fillField(/deadline/i, "2030-01-01T00:00");
     fillField(/success destination/i, successAddress);
     fillField(/failure destination/i, failureAddress);
-    fireEvent.click(screen.getByRole('button', { name: /create vault/i }));
+    fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
 
-    expect(screen.queryByText(/Enter a positive USDC amount/)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /review vault details/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Enter a positive USDC amount/),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /confirm vault/i }));
+
     expect(consoleLog).toHaveBeenCalledWith({
-      amount: '100.1234567',
-      deadline: '2030-01-01T00:00',
+      amount: "100.1234567",
+      deadline: "2030-01-01T00:00",
       successAddress,
       failureAddress,
     });
+    expect(consoleLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns to edit mode without losing entered values", () => {
+    render(<CreateVault />);
+
+    fillField(/amount/i, "55");
+    fillField(/deadline/i, "2030-02-02T00:00");
+    fillField(/success destination/i, successAddress);
+    fillField(/failure destination/i, failureAddress);
+    fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /back to edit/i }));
+
+    expect(screen.getByLabelText(/amount/i)).toHaveValue("55");
+    expect(screen.getByLabelText(/deadline/i)).toHaveValue("2030-02-02T00:00");
+    expect(screen.getByLabelText(/success destination/i)).toHaveValue(
+      successAddress,
+    );
+    expect(screen.getByLabelText(/failure destination/i)).toHaveValue(
+      failureAddress,
+    );
   });
 });


### PR DESCRIPTION
Closes #293 

I’m drafting a concise pull request description you can copy directly into GitHub, based on the changes that were just implemented.

## PR Title
feat: add review-and-confirm step to CreateVault

## PR Description

## Summary
This PR adds a review-and-confirm step to the Create Vault flow so users can verify their vault details before submission.

## What changed
- Added a new review screen for vault creation that displays:
  - amount
  - deadline
  - success destination address
  - failure destination address
- Wired the form submission to show the review step only when validation passes.
- Added a “Back to edit” action so users can return to the form without losing their entered values.
- Added a “Confirm Vault” action that triggers the existing placeholder submission flow.
- Added component and page tests covering:
  - valid submission entering review mode
  - back-to-edit behavior preserving form values
  - confirm action firing once

## Why
Previously, Create Vault submitted directly from the form without giving users a chance to review their high-stakes inputs. This change adds an explicit confirmation step to reduce mistakes before the irreversible submission action.

## Testing
Verified with:
- node vitest.mjs run CreateVault.test.tsx CreateVaultReview.test.tsx --reporter=basic

## Notes
- The review UI uses a token-styled address presentation for clarity.
- The submission behavior remains placeholder-based for now, as before.