### PR TITLE
test: enforce coverage thresholds in vitest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,21 @@ For targeted frontend checks during development, run Vitest directly:
 npx vitest run src/pages/__tests__/Vaults.test.tsx
 ```
 
+### Coverage
+
+Coverage thresholds are enforced in CI via `vitest.config.ts`:
+`statements: 50`, `branches: 80`, `functions: 65`, `lines: 50`. If new
+code drops coverage below these floors, `npm test` exits with a
+non-zero code and the CI run fails. To check current coverage locally,
+run:
+
+```bash
+npm test
+```
+
+The HTML report is written to `coverage/` — open `coverage/index.html`
+in a browser for a detailed view.
+
 Design-system tests use Jest:
 
 ```bash

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,14 @@ export default defineConfig({
     setupFiles: './src/setupTests.ts',
     include: ['src/**/*.test.{ts,tsx}'],
     coverage: {
-      reporter: ['text', 'html'],
+      reporter: ['text', 'html', 'json-summary'],
+      reportsDirectory: './coverage',
+      thresholds: {
+        statements: 50,
+        branches: 80,
+        functions: 65,
+        lines: 50,
+      },
     },
     // Exclude node_modules and lib from test collection
     exclude: [...configDefaults.exclude, 'node_modules', 'dist']


### PR DESCRIPTION
## Summary

Adds coverage threshold gates to `vitest.config.ts` and documents the policy in the contributor testing guide.

## Changes

- **vitest.config.ts**: Added `coverage.thresholds` with `statements: 50`, `branches: 80`, `functions: 65`, `lines: 50` — set just below current coverage levels so CI passes today and ratchets up over time. Also added `json-summary` reporter and `reportsDirectory` for CI tooling.
- **README.md**: Added a "Coverage" subsection under Testing explaining the threshold policy, how to run coverage locally (`npm test`), and how to view the HTML report (`coverage/index.html`).

## Testing

- Verified `npm run test` passes against current coverage levels
- Verified the gate trips (exit code 1) when thresholds are set above current coverage (e.g., `statements: 99.9`)
- No regressions in the existing test suite

Closes #340