### PR TITLE
test: add property-based coverage for paginate and history filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint": "^9.13.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
+    "fast-check": "^4.8.0",
     "globals": "^15.11.0",
     "jsdom": "^29.1.1",
     "typescript": "~5.6.2",

--- a/src/utils/__tests__/paginate.test.ts
+++ b/src/utils/__tests__/paginate.test.ts
@@ -1,3 +1,4 @@
+import fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
 import type { ValidationTask } from '../../Zustand/Store';
 import { filterValidationHistory, paginate } from '../paginate';
@@ -58,6 +59,75 @@ describe('filterValidationHistory', () => {
   it('combines status and query filters', () => {
     expect(filterValidationHistory(history, { status: 'rejected', query: 'alpha' })).toEqual([]);
   });
+
+  it('treats a whitespace-only query as no query', () => {
+    expect(filterValidationHistory(history, { status: 'all', query: '   ' }).map((t) => t.id)).toEqual([
+      'v-1',
+      'v-2',
+      'v-3',
+    ]);
+  });
+
+  describe('properties', () => {
+    const taskArb: fc.Arbitrary<ValidationTask> = fc.record({
+      id: fc.uuid(),
+      vaultName: fc.string({ minLength: 1, maxLength: 20 }),
+      owner: fc.string({ minLength: 1, maxLength: 20 }),
+      amount: fc.string(),
+      deadline: fc.string(),
+      daysRemaining: fc.integer({ min: 0, max: 365 }),
+      status: fc.constantFrom<ValidationTask['status']>('pending', 'approved', 'rejected'),
+      milestone: fc.string(),
+    });
+
+    const toMixedCase = (value: string) =>
+      value
+        .split('')
+        .map((char, index) => (index % 2 === 0 ? char.toUpperCase() : char.toLowerCase()))
+        .join('');
+
+    it('with status "all", returns exactly the tasks matching the query', () => {
+      fc.assert(
+        fc.property(
+          fc.array(taskArb, { maxLength: 20 }),
+          fc.string({ maxLength: 10 }),
+          (tasks, query) => {
+            const result = filterValidationHistory(tasks, { status: 'all', query });
+            const normalizedQuery = query.trim().toLowerCase();
+            const expected = tasks.filter(
+              (task) =>
+                normalizedQuery.length === 0 ||
+                task.vaultName.toLowerCase().includes(normalizedQuery) ||
+                task.owner.toLowerCase().includes(normalizedQuery),
+            );
+
+            expect(result).toEqual(expected);
+          },
+        ),
+      );
+    });
+
+    it('matches vaultName and owner case-insensitively', () => {
+      fc.assert(
+        fc.property(
+          fc.array(taskArb, { minLength: 1, maxLength: 20 }),
+          fc.nat(),
+          fc.boolean(),
+          (tasks, indexSeed, useOwner) => {
+            const index = indexSeed % tasks.length;
+            const target = tasks[index];
+            const field = useOwner ? target.owner : target.vaultName;
+            fc.pre(field.trim().length > 0);
+
+            const query = toMixedCase(field);
+            const result = filterValidationHistory(tasks, { status: 'all', query });
+
+            expect(result.some((task) => task.id === target.id)).toBe(true);
+          },
+        ),
+      );
+    });
+  });
 });
 
 describe('paginate', () => {
@@ -77,6 +147,72 @@ describe('paginate', () => {
       currentPage: 1,
       pageSize: 1,
       pageCount: 3,
+    });
+  });
+
+  it('handles an empty array without throwing', () => {
+    expect(paginate([], 1, 10)).toMatchObject({
+      items: [],
+      currentPage: 1,
+      pageCount: 1,
+      totalItems: 0,
+      pageSize: 10,
+    });
+  });
+
+  describe('properties', () => {
+    const itemsArb = fc.array(fc.integer(), { maxLength: 50 });
+
+    it('keeps currentPage within [1, pageCount] and items within pageSize', () => {
+      fc.assert(
+        fc.property(
+          itemsArb,
+          fc.double({ min: -1000, max: 1000, noNaN: true }),
+          fc.double({ min: -1000, max: 1000, noNaN: true }),
+          (items, page, pageSize) => {
+            const result = paginate(items, page, pageSize);
+
+            expect(result.currentPage).toBeGreaterThanOrEqual(1);
+            expect(result.currentPage).toBeLessThanOrEqual(result.pageCount);
+            expect(result.items.length).toBeLessThanOrEqual(result.pageSize);
+            expect(result.pageSize).toBeGreaterThanOrEqual(1);
+            expect(Number.isInteger(result.pageSize)).toBe(true);
+            expect(Number.isInteger(result.currentPage)).toBe(true);
+          },
+        ),
+      );
+    });
+
+    it('never throws for negative, zero, or fractional page/pageSize', () => {
+      fc.assert(
+        fc.property(
+          itemsArb,
+          fc.double({ min: -1000, max: 1000, noNaN: true }),
+          fc.double({ min: -1000, max: 1000, noNaN: true }),
+          (items, page, pageSize) => {
+            expect(() => paginate(items, page, pageSize)).not.toThrow();
+          },
+        ),
+      );
+    });
+
+    it('pages through every item exactly once', () => {
+      fc.assert(
+        fc.property(
+          itemsArb,
+          fc.integer({ min: 1, max: 20 }),
+          (items, pageSize) => {
+            const pageCount = paginate(items, 1, pageSize).pageCount;
+            const collected: number[] = [];
+
+            for (let page = 1; page <= pageCount; page += 1) {
+              collected.push(...paginate(items, page, pageSize).items);
+            }
+
+            expect(collected).toEqual(items);
+          },
+        ),
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add fast-check property-based tests for `paginate`, asserting `1 <= currentPage <= pageCount`, `items.length <= pageSize`, that paging through every page reconstructs the input array exactly once, and that negative/zero/fractional `page`/`pageSize` never throw and clamp sanely.
- Add fast-check property-based tests for `filterValidationHistory`, asserting that `status: 'all'` returns exactly the tasks matching the query, and that matching against `vaultName`/`owner` is case-insensitive.
- Add a couple of explicit edge-case tests (empty array, whitespace-only query) alongside the existing example-based tests.
- Add `fast-check` as a dev dependency.

Closes #330

## Test plan
- [x] `npm run test` — all tests in `src/utils/__tests__/paginate.test.ts` pass (12 tests)
- [x] Coverage on `src/utils/paginate.ts` is 100% (statements/branches/functions/lines)
- [x] `npx eslint src/utils/__tests__/paginate.test.ts` — clean