### PR TITLE
feat: add verifier and analytics nav links with active state

### DIFF
--- a/design-system/documentation/getting-started.md
+++ b/design-system/documentation/getting-started.md
@@ -54,6 +54,15 @@ git diff --check
 For documentation-only changes, verify every referenced file, CSS variable, and
 component path exists before opening the PR.
 
+## Navigation Structure
+
+The site-wide navigation is defined in `src/components/Layout.tsx` for desktop headers and `src/components/MobileDrawer.tsx` for mobile viewports.
+
+1. **Active State with NavLink**: Use the custom `NavLink` component (`src/components/NavLink.tsx`) for navigation entries. It extends standard `Link` properties and automatically handles active state styling and accessibility features.
+2. **Subroute Activation**: For nested views (such as `/verifier/queue` or `/verifier/history` under `/verifier`), the parent `NavLink` remains active by matching paths using `.startsWith()`.
+3. **Accessibility**: `NavLink` sets `aria-current="page"` when active to assist screen readers and keyboard navigation (consistent with WCAG 2.1 AA).
+4. **Token-Based Styling**: Nav links use CSS variables for theme colors. Active states receive `color: var(--accent)`, and inactive states default to `color: var(--muted)` (header) or `color: var(--text)` (mobile drawer).
+
 ## Related Documentation
 
 - `documentation/token-catalog.md` maps token groups to consumers.

--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -55,7 +55,15 @@
   outline: 2px solid var(--accent);
 }
 
+.header-link {
+  color: var(--muted);
+}
+
 .header-link.active {
+  color: var(--accent);
+}
+
+.header-brand .header-link[aria-label="Disciplr home"] {
   color: var(--accent);
 }
 
@@ -205,6 +213,10 @@
 }
 
 .mobile-drawer-link:hover {
+  color: var(--accent);
+}
+
+.mobile-drawer-link.active {
   color: var(--accent);
 }
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from "react-router-dom";
 import { Menu } from "lucide-react";
 import { WalletConnectButton } from "./Wallet/WalletConnectButton";
 import MobileDrawer from "./MobileDrawer";
+import NavLink from "./NavLink";
 import { Text } from "./Text";
 import "./Layout.css";
 
@@ -14,7 +15,6 @@ export default function Layout({ children }: LayoutProps) {
   const [isDrawerOpen, setDrawerOpen] = useState(false);
   const toggleDrawer = () => setDrawerOpen(prev => !prev);
   const location = useLocation();
-  const isTransactionsActive = location.pathname === "/transactions";
   const backgroundA11yProps = isDrawerOpen
     ? ({ "aria-hidden": true, inert: "" } as HTMLAttributes<HTMLElement> & { inert: "" })
     : {};
@@ -30,14 +30,10 @@ export default function Layout({ children }: LayoutProps) {
               Disciplr
             </Text>
           </Link>
-          <Link
+          <NavLink
             to="/transactions"
-            className={`header-link${isTransactionsActive ? " active" : ""}`}
-            style={{
-              color: isTransactionsActive ? "var(--accent)" : "var(--muted)",
-            }}
-            aria-label="Transactions"
-            aria-current={isTransactionsActive ? "page" : undefined}
+            className="header-link"
+            ariaLabel="Transactions"
           >
             <span className="header-transactions-label">Transactions</span>
             <span
@@ -47,36 +43,37 @@ export default function Layout({ children }: LayoutProps) {
             >
               ↗
             </span>
-          </Link>
+          </NavLink>
         </div>
 
         <nav className="desktop-nav" {...backgroundA11yProps}>
           <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
-            <Link
+            <NavLink
               to="/"
               className="header-link"
-              style={{
-                color:
-                  location.pathname === "/" ? "var(--accent)" : "var(--muted)",
-              }}
             >
               <Text role="caption" as="span">
                 Home
               </Text>
-            </Link>
+            </NavLink>
 
-            <Link
-              to="/analytics"
-              style={{
-                color:
-                  location.pathname === "/analytics"
-                    ? "var(--accent)"
-                    : "var(--muted)",
-                textDecoration: "none",
-              }}
+            <NavLink
+              to="/verifier"
+              className="header-link"
             >
-              Analytics
-            </Link>
+              <Text role="caption" as="span">
+                Verifier
+              </Text>
+            </NavLink>
+
+            <NavLink
+              to="/analytics"
+              className="header-link"
+            >
+              <Text role="caption" as="span">
+                Analytics
+              </Text>
+            </NavLink>
 
             <Link
               to="/vaults/create"

--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { X } from 'lucide-react';
 import FocusTrap from 'focus-trap-react';
+import NavLink from './NavLink';
 import { WalletConnectButton } from './Wallet/WalletConnectButton';
 
 interface MobileDrawerProps {
@@ -77,18 +78,21 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
           <button className="mobile-drawer-close" onClick={onClose} aria-label="Close navigation drawer">
             <X size={24} />
           </button>
-          <Link to="/" className="mobile-drawer-link" onClick={onClose}>
+          <NavLink to="/" className="mobile-drawer-link" onClick={onClose}>
             Home
-          </Link>
-          <Link to="/transactions" className="mobile-drawer-link" onClick={onClose}>
+          </NavLink>
+          <NavLink to="/transactions" className="mobile-drawer-link" onClick={onClose}>
             Transactions
-          </Link>
-          <Link to="/analytics" className="mobile-drawer-link" onClick={onClose}>
+          </NavLink>
+          <NavLink to="/verifier" className="mobile-drawer-link" onClick={onClose}>
+            Verifier
+          </NavLink>
+          <NavLink to="/analytics" className="mobile-drawer-link" onClick={onClose}>
             Analytics
-          </Link>
-          <Link to="/vaults/create" className="mobile-drawer-link" onClick={onClose}>
+          </NavLink>
+          <NavLink to="/vaults/create" className="mobile-drawer-link" onClick={onClose}>
             Create Vault
-          </Link>
+          </NavLink>
           <WalletConnectButton />
         </nav>
       </div>

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -1,18 +1,24 @@
 import { Link, useLocation } from 'react-router-dom';
 
-interface NavLinkProps {
-  to: string;
-  className?: string;
-  children: React.ReactNode;
+interface NavLinkProps extends React.ComponentPropsWithoutRef<typeof Link> {
   ariaLabel?: string;
 }
 
-export default function NavLink({ to, className = '', children, ariaLabel }: NavLinkProps) {
+export default function NavLink({ to, className = '', children, ariaLabel, ...props }: NavLinkProps) {
   const location = useLocation();
-  const isActive = location.pathname === to;
+  const toStr = typeof to === 'string' ? to : (to as any)?.pathname || '';
+  const isActive = toStr === '/'
+    ? location.pathname === '/'
+    : location.pathname.startsWith(toStr);
   const combinedClass = `${className} ${isActive ? 'active' : ''}`.trim();
   return (
-    <Link to={to} className={combinedClass} aria-label={ariaLabel} aria-current={isActive ? 'page' : undefined}>
+    <Link
+      to={to}
+      className={combinedClass}
+      aria-label={ariaLabel}
+      aria-current={isActive ? 'page' : undefined}
+      {...props}
+    >
       {children}
     </Link>
   );

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -32,4 +32,60 @@ describe('Layout component navigation', () => {
     expect(link).not.toHaveAttribute('aria-current');
     expect(link).not.toHaveClass('active');
   });
+
+  test('verifier link receives active class and aria-current when on /verifier', () => {
+    render(
+      <MemoryRouter initialEntries={['/verifier']}>
+        <Layout>
+          <div>Content</div>
+        </Layout>
+      </MemoryRouter>
+    );
+    const link = screen.getByRole('link', { name: /verifier/i });
+    expect(link).toHaveAttribute('aria-current', 'page');
+    expect(link).toHaveClass('active');
+  });
+
+  test('verifier link is active on verifier subroutes', () => {
+    render(
+      <MemoryRouter initialEntries={['/verifier/queue']}>
+        <Layout>
+          <div>Content</div>
+        </Layout>
+      </MemoryRouter>
+    );
+    const link = screen.getByRole('link', { name: /verifier/i });
+    expect(link).toHaveAttribute('aria-current', 'page');
+    expect(link).toHaveClass('active');
+  });
+
+  test('analytics link receives active class and aria-current when on /analytics', () => {
+    render(
+      <MemoryRouter initialEntries={['/analytics']}>
+        <Layout>
+          <div>Content</div>
+        </Layout>
+      </MemoryRouter>
+    );
+    const link = screen.getByRole('link', { name: /analytics/i });
+    expect(link).toHaveAttribute('aria-current', 'page');
+    expect(link).toHaveClass('active');
+  });
+
+  test('verifier and analytics links are not active on home route', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Layout>
+          <div>Content</div>
+        </Layout>
+      </MemoryRouter>
+    );
+    const verifierLink = screen.getByRole('link', { name: /verifier/i });
+    expect(verifierLink).not.toHaveAttribute('aria-current');
+    expect(verifierLink).not.toHaveClass('active');
+
+    const analyticsLink = screen.getByRole('link', { name: /analytics/i });
+    expect(analyticsLink).not.toHaveAttribute('aria-current');
+    expect(analyticsLink).not.toHaveClass('active');
+  });
 });

--- a/src/components/__tests__/MobileDrawer.test.tsx
+++ b/src/components/__tests__/MobileDrawer.test.tsx
@@ -165,3 +165,45 @@ describe('Layout drawer integration', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
   });
 });
+
+describe('MobileDrawer active links', () => {
+  test('verifier link receives active class and aria-current when on /verifier or subroutes', () => {
+    render(
+      <MemoryRouter initialEntries={['/verifier/queue']}>
+        <MobileDrawer isOpen onClose={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    const verifierLink = screen.getByRole('link', { name: /verifier/i });
+    expect(verifierLink).toHaveAttribute('aria-current', 'page');
+    expect(verifierLink).toHaveClass('active');
+  });
+
+  test('analytics link receives active class and aria-current when on /analytics', () => {
+    render(
+      <MemoryRouter initialEntries={['/analytics']}>
+        <MobileDrawer isOpen onClose={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    const analyticsLink = screen.getByRole('link', { name: /analytics/i });
+    expect(analyticsLink).toHaveAttribute('aria-current', 'page');
+    expect(analyticsLink).toHaveClass('active');
+  });
+
+  test('verifier and analytics links are not active on home route', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <MobileDrawer isOpen onClose={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    const verifierLink = screen.getByRole('link', { name: /verifier/i });
+    expect(verifierLink).not.toHaveAttribute('aria-current');
+    expect(verifierLink).not.toHaveClass('active');
+
+    const analyticsLink = screen.getByRole('link', { name: /analytics/i });
+    expect(analyticsLink).not.toHaveAttribute('aria-current');
+    expect(analyticsLink).not.toHaveClass('active');
+  });
+});


### PR DESCRIPTION
closes #277 

This pull request introduces discoverable navigation links for the Verifier (/verifier) and Analytics (/analytics) routes in both the desktop header and the mobile navigation drawer. Previously, these routes were configured in the application router but lacked top-level links, making them unreachable without manually typing the URL. This update ensures that both areas are easily discoverable and receive consistent active-state highlighting depending on the user's current location.

To support this integration, the custom NavLink component was refactored to extend standard router Link properties, allowing it to accept attributes like onClick to handle closing the mobile drawer. The path matching within NavLink was also updated to support subroute activation so that the parent Verifier link remains highlighted when users navigate to nested views like /verifier/queue or /verifier/history. The exact same navigation structure is mirrored inside the mobile drawer, ensuring parity between viewport layouts.

All navigation links are styled using the design system's CSS variables (such as var(--accent) for active states and var(--muted) or var(--text) for inactive states) to avoid hardcoded values. In addition, the header layout matches accessibility standards by assigning aria-current="page" to active links. Comprehensive unit tests have been added to the test suites for both Layout and MobileDrawer to verify the routing behavior, subroute matching, active classes, and ARIA attributes.