### PR TITLE
[#316] Add drag-and-drop and file-type validation to the EvidenceUpload component

### DIFF
--- a/src/components/EvidenceUpload.tsx
+++ b/src/components/EvidenceUpload.tsx
@@ -1,9 +1,26 @@
-import { type ChangeEvent, useEffect, useId, useMemo, useState } from 'react'
+import { type ChangeEvent, type DragEvent, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { Field } from './Field'
 import { Text } from './Text'
 import { normalizeEvidenceUrl } from '../utils/url'
 
 type EvidenceUploadStatus = 'empty' | 'invalid' | 'valid'
+
+const ACCEPTED_FILE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'text/plain',
+  'video/mp4',
+  'video/webm',
+]
+
+const ACCEPTED_FILE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.pdf', '.txt', '.mp4', '.webm']
+
+function isAcceptedFileType(file: File): boolean {
+  return ACCEPTED_FILE_TYPES.includes(file.type)
+}
 
 interface EvidenceUploadProps {
   id?: string
@@ -12,6 +29,8 @@ interface EvidenceUploadProps {
   required?: boolean
   onChange?: (evidenceUrl: string | undefined) => void
   onSubmit?: (evidenceUrl: string) => void
+  onFileSelect?: (file: File) => void
+  acceptedFileTypes?: string[]
 }
 
 export function EvidenceUpload({
@@ -21,11 +40,18 @@ export function EvidenceUpload({
   required = false,
   onChange,
   onSubmit,
+  onFileSelect,
+  acceptedFileTypes = ACCEPTED_FILE_TYPES,
 }: EvidenceUploadProps) {
   const generatedId = useId()
   const fieldId = id || `evidence-upload-${generatedId}`
   const [rawValue, setRawValue] = useState(value)
   const [touched, setTouched] = useState(false)
+  const [isDragOver, setIsDragOver] = useState(false)
+  const [dragError, setDragError] = useState<string | undefined>(undefined)
+  const [droppedFile, setDroppedFile] = useState<File | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
   const normalizedUrl = useMemo(() => normalizeEvidenceUrl(rawValue), [rawValue])
   const hasInput = rawValue.trim().length > 0
   const status: EvidenceUploadStatus = !hasInput ? 'empty' : normalizedUrl ? 'valid' : 'invalid'
@@ -42,6 +68,8 @@ export function EvidenceUpload({
     const nextUrl = normalizeEvidenceUrl(nextValue)
 
     setRawValue(nextValue)
+    setDroppedFile(null)
+    setDragError(undefined)
     onChange?.(nextUrl ?? undefined)
   }
 
@@ -51,6 +79,86 @@ export function EvidenceUpload({
     if (normalizedUrl) {
       onSubmit?.(normalizedUrl)
     }
+  }
+
+  const processFile = (file: File) => {
+    const effectiveTypes = acceptedFileTypes.length > 0 ? acceptedFileTypes : ACCEPTED_FILE_TYPES
+
+    if (!effectiveTypes.includes(file.type)) {
+      setDragError(
+        `File type not accepted. Allowed types: ${ACCEPTED_FILE_EXTENSIONS.join(', ')}.`
+      )
+      setDroppedFile(null)
+      return
+    }
+
+    setDragError(undefined)
+    setDroppedFile(file)
+    onFileSelect?.(file)
+  }
+
+  const handleDragEnter = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setIsDragOver(true)
+  }
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setIsDragOver(true)
+  }
+
+  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    // Only clear if leaving the drop zone entirely (not entering a child)
+    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+      setIsDragOver(false)
+    }
+  }
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setIsDragOver(false)
+
+    const files = event.dataTransfer.files
+    if (files.length === 0) return
+
+    if (files.length > 1) {
+      setDragError('Only one file can be attached at a time.')
+      return
+    }
+
+    processFile(files[0])
+  }
+
+  const handleFileInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files
+    if (!files || files.length === 0) return
+    processFile(files[0])
+    // Reset input so the same file can be selected again
+    event.target.value = ''
+  }
+
+  const handleBrowseClick = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleRemoveFile = () => {
+    setDroppedFile(null)
+    setDragError(undefined)
+  }
+
+  const dropZoneStyles: React.CSSProperties = {
+    border: `2px dashed ${isDragOver ? 'var(--accent)' : dragError ? 'var(--danger)' : 'var(--border)'}`,
+    borderRadius: 'var(--radius)',
+    padding: 'var(--spacing-4)',
+    textAlign: 'center' as const,
+    background: isDragOver ? 'var(--surface-raised)' : 'var(--surface)',
+    transition: 'border-color 0.15s ease, background 0.15s ease',
+    cursor: 'pointer',
   }
 
   return (
@@ -86,6 +194,86 @@ export function EvidenceUpload({
           Evidence link accepted: {normalizedUrl}
         </Text>
       )}
+
+      {/* Drag-and-drop zone */}
+      <div
+        data-testid="evidence-drop-zone"
+        aria-label="Drop evidence file here or click to browse"
+        role="button"
+        tabIndex={0}
+        aria-dropeffect="copy"
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        onClick={handleBrowseClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            handleBrowseClick()
+          }
+        }}
+        style={dropZoneStyles}
+      >
+        {isDragOver ? (
+          <Text role="caption" as="span" style={{ color: 'var(--accent)' }}>
+            Drop file to attach
+          </Text>
+        ) : droppedFile ? (
+          <Text role="caption" as="span" style={{ color: 'var(--success)' }}>
+            File attached: {droppedFile.name}
+          </Text>
+        ) : (
+          <Text role="caption" as="span" style={{ color: 'var(--muted)' }}>
+            Drag and drop a file here, or{' '}
+            <span style={{ color: 'var(--accent)', textDecoration: 'underline' }}>browse</span>
+            <br />
+            Accepted types: {ACCEPTED_FILE_EXTENSIONS.join(', ')}
+          </Text>
+        )}
+      </div>
+
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPTED_FILE_EXTENSIONS.join(',')}
+        onChange={handleFileInputChange}
+        aria-hidden="true"
+        tabIndex={-1}
+        style={{ display: 'none' }}
+      />
+
+      {dragError && (
+        <Text
+          role="caption"
+          as="span"
+          style={{ color: 'var(--danger)' }}
+          data-testid="drag-error"
+        >
+          {dragError}
+        </Text>
+      )}
+
+      {droppedFile && (
+        <button
+          type="button"
+          onClick={handleRemoveFile}
+          style={{
+            alignSelf: 'flex-start',
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--muted)',
+            cursor: 'pointer',
+            fontSize: '0.875rem',
+            padding: 0,
+            textDecoration: 'underline',
+          }}
+        >
+          Remove file
+        </button>
+      )}
+
       {onSubmit && (
         <button
           type="button"

--- a/src/components/__tests__/EvidenceUpload.test.tsx
+++ b/src/components/__tests__/EvidenceUpload.test.tsx
@@ -49,4 +49,178 @@ describe('EvidenceUpload', () => {
 
     expect(handleSubmit).toHaveBeenCalledWith('https://example.com/proof')
   })
+
+  describe('drag-and-drop', () => {
+    it('renders a drop zone with accessible label', () => {
+      render(<EvidenceUpload />)
+
+      const dropZone = screen.getByTestId('evidence-drop-zone')
+      expect(dropZone).toBeInTheDocument()
+      expect(dropZone).toHaveAttribute('aria-label', 'Drop evidence file here or click to browse')
+      expect(dropZone).toHaveAttribute('role', 'button')
+    })
+
+    it('shows drag-over state when dragging over the drop zone', () => {
+      render(<EvidenceUpload />)
+
+      const dropZone = screen.getByTestId('evidence-drop-zone')
+      fireEvent.dragEnter(dropZone)
+      expect(screen.getByText(/Drop file to attach/)).toBeInTheDocument()
+    })
+
+    it('shows idle state after dragging leaves the drop zone', () => {
+      render(<EvidenceUpload />)
+
+      const dropZone = screen.getByTestId('evidence-drop-zone')
+      fireEvent.dragEnter(dropZone)
+      fireEvent.dragLeave(dropZone)
+      expect(screen.getByText(/Drag and drop a file here/)).toBeInTheDocument()
+    })
+
+    it('accepts a valid file type on drop and calls onFileSelect', () => {
+      const handleFileSelect = vi.fn()
+      render(<EvidenceUpload onFileSelect={handleFileSelect} />)
+
+      const dropZone = screen.getByTestId('evidence-drop-zone')
+      const file = new File(['content'], 'proof.pdf', { type: 'application/pdf' })
+
+      fireEvent.drop(dropZone, {
+        dataTransfer: { files: [file] },
+      })
+
+      expect(handleFileSelect).toHaveBeenCalledWith(file)
+      expect(screen.getByText(/File attached: proof\.pdf/)).toBeInTheDocument()
+    })
+
+    it('rejects disallowed file types with an error message', () => {
+      const handleFileSelect = vi.fn()
+      render(<EvidenceUpload onFileSelect={handleFileSelect} />)
+
+      const dropZone = screen.getByTestId('evidence-drop-zone')
+      const file = new File(['content'], 'malware.exe', { type: 'application/x-msdownload' })
+
+      fireEvent.drop(dropZone, {
+        dataTransfer: { files: [file] },
+      })
+
+      expect(handleFileSelect).not.toHaveBeenCalled()
+      expect(screen.getByTestId('drag-error')).toBeInTheDocument()
+      expect(screen.getByText(/File type not accepted/)).toBeInTheDocument()
+    })
+
+    it('rejects multiple files dropped at once', () => {
+      render(<EvidenceUpload />)
+
+      const dropZone = screen.getByTestId('evidence-drop-zone')
+      const file1 = new File(['a'], 'proof.pdf', { type: 'application/pdf' })
+      const file2 = new File(['b'], 'proof2.pdf', { type: 'application/pdf' })
+
+      fireEvent.drop(dropZone, {
+        dataTransfer: { files: [file1, file2] },
+      })
+
+      expect(screen.getByText(/Only one file can be attached at a time/)).toBeInTheDocument()
+    })
+
+    it('allows removing an attached file', () => {
+      render(<EvidenceUpload onFileSelect={vi.fn()} />)
+
+      const dropZone = screen.getByTestId('evidence-drop-zone')
+      const file = new File(['content'], 'proof.png', { type: 'image/png' })
+
+      fireEvent.drop(dropZone, {
+        dataTransfer: { files: [file] },
+      })
+
+      expect(screen.getByText(/File attached: proof\.png/)).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Remove file' }))
+      expect(screen.queryByText(/File attached/)).not.toBeInTheDocument()
+      expect(screen.getByText(/Drag and drop a file here/)).toBeInTheDocument()
+    })
+
+    it('prevents default drag behavior to enable drop', () => {
+      render(<EvidenceUpload />)
+      const dropZone = screen.getByTestId('evidence-drop-zone')
+
+      const dragOverEvent = new Event('dragover', { bubbles: true, cancelable: true })
+      dropZone.dispatchEvent(dragOverEvent)
+
+      // dragover default should be prevented to allow drop
+      expect(dragOverEvent.defaultPrevented).toBe(true)
+    })
+  })
+
+  describe('file type validation', () => {
+    const validTypes = [
+      { name: 'image.jpg', type: 'image/jpeg' },
+      { name: 'image.png', type: 'image/png' },
+      { name: 'image.gif', type: 'image/gif' },
+      { name: 'image.webp', type: 'image/webp' },
+      { name: 'document.pdf', type: 'application/pdf' },
+      { name: 'notes.txt', type: 'text/plain' },
+      { name: 'video.mp4', type: 'video/mp4' },
+      { name: 'video.webm', type: 'video/webm' },
+    ]
+
+    validTypes.forEach(({ name, type }) => {
+      it(`accepts ${type} files`, () => {
+        const handleFileSelect = vi.fn()
+        render(<EvidenceUpload onFileSelect={handleFileSelect} />)
+
+        const dropZone = screen.getByTestId('evidence-drop-zone')
+        const file = new File(['content'], name, { type })
+
+        fireEvent.drop(dropZone, { dataTransfer: { files: [file] } })
+
+        expect(handleFileSelect).toHaveBeenCalledWith(file)
+        expect(screen.queryByTestId('drag-error')).not.toBeInTheDocument()
+      })
+    })
+
+    const invalidTypes = [
+      { name: 'script.js', type: 'application/javascript' },
+      { name: 'archive.zip', type: 'application/zip' },
+      { name: 'binary.exe', type: 'application/x-msdownload' },
+    ]
+
+    invalidTypes.forEach(({ name, type }) => {
+      it(`rejects ${type} files`, () => {
+        const handleFileSelect = vi.fn()
+        render(<EvidenceUpload onFileSelect={handleFileSelect} />)
+
+        const dropZone = screen.getByTestId('evidence-drop-zone')
+        const file = new File(['content'], name, { type })
+
+        fireEvent.drop(dropZone, { dataTransfer: { files: [file] } })
+
+        expect(handleFileSelect).not.toHaveBeenCalled()
+        expect(screen.getByTestId('drag-error')).toBeInTheDocument()
+      })
+    })
+
+    it('accepts custom acceptedFileTypes when provided', () => {
+      const handleFileSelect = vi.fn()
+      render(
+        <EvidenceUpload
+          onFileSelect={handleFileSelect}
+          acceptedFileTypes={['text/plain']}
+        />
+      )
+
+      const dropZone = screen.getByTestId('evidence-drop-zone')
+
+      // Accepted type
+      const txtFile = new File(['content'], 'notes.txt', { type: 'text/plain' })
+      fireEvent.drop(dropZone, { dataTransfer: { files: [txtFile] } })
+      expect(handleFileSelect).toHaveBeenCalledWith(txtFile)
+
+      handleFileSelect.mockClear()
+
+      // Now drop a pdf which is not in custom accepted list
+      const pdfFile = new File(['content'], 'proof.pdf', { type: 'application/pdf' })
+      fireEvent.drop(dropZone, { dataTransfer: { files: [pdfFile] } })
+      expect(handleFileSelect).not.toHaveBeenCalled()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Adds drag-and-drop file upload and file-type validation to the `EvidenceUpload` component as described in issue #316.

## Changes

### `EvidenceUpload.tsx`
- Added a drag-and-drop zone with visual drag-over feedback
- File-type validation against an allowlist: `image/jpeg`, `image/png`, `image/gif`, `image/webp`, `application/pdf`, `text/plain`, `video/mp4`, `video/webm`
- Error messages for rejected file types and multi-file drops
- Hidden file `<input>` for browse-click interaction (keyboard accessible via Enter/Space)
- **Remove file** button to clear an attached file
- New `onFileSelect` callback prop so parents receive the validated `File` object
- New `acceptedFileTypes` prop for customising the allowed MIME-type list
- Full backward compatibility — all existing URL-input behaviour is unchanged

### `EvidenceUpload.test.tsx`
- 20 new test cases covering drag-and-drop states, file-type acceptance/rejection, multi-file rejection, custom `acceptedFileTypes`, and the remove-file flow
- All 24 tests pass (4 original + 20 new)

Closes #316