### PR TITLE
a11y: add focus-visible affordances to header controls

### DIFF
--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -51,12 +51,55 @@
 
 .header-link:focus-visible,
 .header-nav a:focus-visible,
-.header-nav button:focus-visible {
+.header-nav button:focus-visible,
+.theme-toggle:focus-visible {
   outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.header-link {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.header-link:hover,
+.header-link:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 2px;
+  font-weight: 600;
 }
 
 .header-link.active {
   color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 2px;
+  font-weight: 700;
+}
+
+.theme-toggle {
+  background: transparent;
+  border: var(--border-width-1) solid var(--border);
+  border-radius: var(--radius-full);
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--text);
+  transition: background-color var(--duration-normal) var(--ease-in-out), border-color var(--duration-normal) var(--ease-in-out);
+}
+
+.theme-toggle:hover {
+  background: var(--hover);
+  border-color: var(--accent);
+}
+
+.theme-toggle:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 24%, transparent);
 }
 
 /* ─── "Create Vault" pill ─────────────────────────────────────────────────── */

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -33,9 +33,6 @@ export default function Layout({ children }: LayoutProps) {
           <Link
             to="/transactions"
             className={`header-link${isTransactionsActive ? " active" : ""}`}
-            style={{
-              color: isTransactionsActive ? "var(--accent)" : "var(--muted)",
-            }}
             aria-label="Transactions"
             aria-current={isTransactionsActive ? "page" : undefined}
           >
@@ -54,11 +51,7 @@ export default function Layout({ children }: LayoutProps) {
           <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
             <Link
               to="/"
-              className="header-link"
-              style={{
-                color:
-                  location.pathname === "/" ? "var(--accent)" : "var(--muted)",
-              }}
+              className={`header-link${location.pathname === "/" ? " active" : ""}`}
             >
               <Text role="caption" as="span">
                 Home
@@ -67,29 +60,12 @@ export default function Layout({ children }: LayoutProps) {
 
             <Link
               to="/analytics"
-              style={{
-                color:
-                  location.pathname === "/analytics"
-                    ? "var(--accent)"
-                    : "var(--muted)",
-                textDecoration: "none",
-              }}
+              className={`header-link${location.pathname === "/analytics" ? " active" : ""}`}
             >
               Analytics
             </Link>
 
-            <Link
-              to="/vaults/create"
-              style={{
-                color: "var(--surface)",
-                background: "var(--accent)",
-                padding: "0.5rem 1rem",
-                borderRadius: "9999px",
-                textDecoration: "none",
-                fontWeight: 500,
-                fontSize: "0.875rem",
-              }}
-            >
+            <Link to="/vaults/create" className="header-link header-cta">
               Create Vault
             </Link>
             <WalletConnectButton />

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,12 +1,25 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useTheme } from '../context/ThemeContext';
+import './Layout.css';
 
 export default function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
 
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggleTheme();
+    }
+  };
+
   return (
     <button
+      type="button"
+      className="theme-toggle"
       onClick={toggleTheme}
+      onKeyDown={handleKeyDown}
       aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+      aria-pressed={theme === 'dark'}
       style={{
         background: 'transparent',
         border: 'var(--border-width-1) solid var(--border)',
@@ -19,14 +32,6 @@ export default function ThemeToggle() {
         cursor: 'pointer',
         color: 'var(--text)',
         transition: 'all var(--duration-normal) var(--ease-in-out)',
-      }}
-      onMouseEnter={(e) => {
-        e.currentTarget.style.background = 'var(--hover)';
-        e.currentTarget.style.borderColor = 'var(--accent)';
-      }}
-      onMouseLeave={(e) => {
-        e.currentTarget.style.background = 'transparent';
-        e.currentTarget.style.borderColor = 'var(--border)';
       }}
     >
       {theme === 'light' ? (

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import Layout from '../Layout';
 
 vi.mock('../Wallet/WalletConnectButton', () => ({
@@ -31,5 +31,28 @@ describe('Layout component navigation', () => {
     const link = screen.getByRole('link', { name: /transactions/i });
     expect(link).not.toHaveAttribute('aria-current');
     expect(link).not.toHaveClass('active');
+  });
+
+  test('header links share the common focusable classes for keyboard users', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Layout>
+          <div>Content</div>
+        </Layout>
+      </MemoryRouter>
+    );
+
+    const homeLink = screen.getByRole('link', { name: /^home$/i });
+    const analyticsLink = screen.getByRole('link', { name: /^analytics$/i });
+    const transactionsLink = screen.getByRole('link', { name: /^transactions$/i });
+
+    [homeLink, analyticsLink, transactionsLink].forEach((link) => {
+      link.focus();
+      expect(link).toHaveFocus();
+      expect(link).toHaveClass('header-link');
+    });
+
+    fireEvent.keyDown(transactionsLink, { key: 'Enter' });
+    expect(transactionsLink).toHaveAttribute('href', '/transactions');
   });
 });

--- a/src/components/__tests__/ThemeToggle.test.tsx
+++ b/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import ThemeToggle from '../ThemeToggle';
+
+const toggleTheme = vi.fn();
+
+vi.mock('../../context/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'light', toggleTheme }),
+}));
+
+describe('ThemeToggle accessibility', () => {
+  beforeEach(() => {
+    toggleTheme.mockReset();
+  });
+
+  test('is reachable and activates on Enter and Space', () => {
+    render(<ThemeToggle />);
+
+    const button = screen.getByRole('button', { name: /switch to dark mode/i });
+    button.focus();
+
+    expect(button).toHaveFocus();
+    expect(button).toHaveClass('theme-toggle');
+
+    fireEvent.keyDown(button, { key: 'Enter' });
+
+    expect(toggleTheme).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(button, { key: ' ' });
+
+    expect(toggleTheme).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
close #350 

## PR Document

**Branch:** `a11y/focus-visible-header`

**Title:** `a11y: add focus-visible affordances to header controls`

### Summary
This PR improves keyboard accessibility for the site header by adding visible `:focus-visible` styles to header links and the theme toggle button, removing inline hover-only state handling, and making the active header link distinguishable by more than color alone.

### What changed
- ThemeToggle.tsx
  - Added `className="theme-toggle"` for consistent styling.
  - Added keyboard activation support for `Enter` and `Space`.
  - Added `aria-pressed` semantics for toggle state.
  - Replaced inline hover handlers with CSS-driven hover/focus styling.

- Layout.tsx
  - Standardized header link styles via shared CSS classes.
  - Updated route links to use `header-link` / `active` classes instead of inline color-only styling.

- Layout.css
  - Added focus-visible styles for header links and the theme toggle.
  - Added stronger active link affordance via underline, weight, and color.
  - Added hover/focus styling to reinforce low-vision accessibility.

- Layout.test.tsx
  - Added keyboard focus/reachability assertions for header links.
  - Ensures header links can receive focus and are navigable via keyboard.

- ThemeToggle.test.tsx
  - New test coverage for theme toggle keyboard activation.
  - Verifies `Enter` and `Space` activate the toggle.

### Tests run
- `npx vitest run Layout.test.tsx src/components/__tests__/ThemeToggle.test.tsx`
  - Result: `2 files passed, 4 tests passed`

### Notes
- The task file task350.md was removed as requested.
- A broader `npm run test` run exposed unrelated pre-existing failures in other tests, so this PR remains scoped to the requested header accessibility changes only.