### PR TITLE
security: neutralize spreadsheet formula injection in CSV export

### DIFF
--- a/design-system/documentation/validation-history.md
+++ b/design-system/documentation/validation-history.md
@@ -27,3 +27,16 @@ The surface uses semantic tokens:
 - `--muted` for labels and helper text.
 - `--success` for approved status.
 - `--danger` for rejected status.
+
+## Security Considerations
+
+### CSV Injection Mitigation
+To prevent spreadsheet formula injection vulnerabilities, the exported CSV utility (`src/utils/csv.ts`) neutralizes cell contents that begin with formula-triggering characters:
+- `=` (equals sign)
+- `+` (plus sign)
+- `-` (minus sign)
+- `@` (at sign)
+- `\t` (tab character)
+- `\r` (carriage return character)
+
+Before applying standard quotes and formatting, any cell starting with one of these characters is prefixed with a single quote (`'`), in accordance with OWASP CSV Injection guidelines. This ensures spreadsheet software (like Microsoft Excel or Google Sheets) treats the value as literal text rather than executing it as a formula.

--- a/src/utils/__tests__/csv.test.ts
+++ b/src/utils/__tests__/csv.test.ts
@@ -113,6 +113,57 @@ describe('toCsv', () => {
     const result = toCsv([]);
     expect(result).toBe('ID,Status,Vault Name,Owner,Amount,Deadline,Milestone,Notes');
   });
+
+  describe('CSV injection mitigation', () => {
+    it('escapes cells starting with =', () => {
+      const task = baseTask({ vaultName: '=cmd' });
+      const result = toCsv([task]);
+      expect(result).toContain("v-001,approved,'=cmd,");
+    });
+
+    it('escapes cells starting with +', () => {
+      const task = baseTask({ vaultName: '+1-1' });
+      const result = toCsv([task]);
+      expect(result).toContain("v-001,approved,'+1-1,");
+    });
+
+    it('escapes cells starting with -', () => {
+      const task = baseTask({ vaultName: '-1+1' });
+      const result = toCsv([task]);
+      expect(result).toContain("v-001,approved,'-1+1,");
+    });
+
+    it('escapes cells starting with @', () => {
+      const task = baseTask({ vaultName: '@SUM' });
+      const result = toCsv([task]);
+      expect(result).toContain("v-001,approved,'@SUM,");
+    });
+
+    it('escapes cells starting with tab', () => {
+      const task = baseTask({ vaultName: '\tcmd' });
+      const result = toCsv([task]);
+      expect(result).toContain("v-001,approved,'\tcmd,");
+    });
+
+    it('escapes cells starting with CR', () => {
+      const task = baseTask({ vaultName: '\rcmd' });
+      const result = toCsv([task]);
+      // Should prepend ' and since it has a CR, also escape and quote it
+      expect(result).toContain('v-001,approved,"\'\rcmd",');
+    });
+
+    it('does not escape benign positive numbers', () => {
+      const task = baseTask({ vaultName: '123' });
+      const result = toCsv([task]);
+      expect(result).toContain('v-001,approved,123,');
+    });
+
+    it('does not escape empty cells or cells starting with normal characters', () => {
+      const task = baseTask({ vaultName: 'Alpha Vault', notes: '' });
+      const result = toCsv([task]);
+      expect(result).toContain('v-001,approved,Alpha Vault,GOWNER...ALPHA,"1,000 USDC",2026-01-01,Launch,');
+    });
+  });
 });
 
 describe('downloadCsv', () => {

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -3,6 +3,9 @@ import type { ValidationTask } from '../Zustand/Store';
 const HEADERS: string[] = ['ID', 'Status', 'Vault Name', 'Owner', 'Amount', 'Deadline', 'Milestone', 'Notes'];
 
 function escapeCell(value: string): string {
+  if (value.length > 0 && /^[=+\-@\t\r]/.test(value)) {
+    value = `'${value}`;
+  }
   if (value.includes('"') || value.includes(',') || value.includes('\n') || value.includes('\r')) {
     return `"${value.replace(/"/g, '""')}"`;
   }


### PR DESCRIPTION
this pr closes #343

## Description
This pull request mitigates a security vulnerability where validation notes or vault names starting with formula-triggering characters (such as `=`, `+`, `-`, `@`, `\t`, or `\r`) are executed as spreadsheet formulas when exported to Excel or Google Sheets. Per OWASP guidelines, these fields are now prefixed with a safe guard (a single quote `'`) before any cell quoting is done.

## Changes
- **Core Escaping Logic**: Modified `escapeCell` in [csv.ts](file:///c:/Users/HP/Disciplr-Frontend/src/utils/csv.ts) to prepend a `'` if a cell value starts with `=`, `+`, `-`, `@`, `\t`, or `\r`.
- **Test Coverage**: Added comprehensive test cases in [csv.test.ts](file:///c:/Users/HP/Disciplr-Frontend/src/utils/__tests__/csv.test.ts) covering formula injection payloads (`=cmd`, `-1+1`, `@SUM`, tabs, carriage returns) and verifying that benign positive numbers and standard strings remain unaffected.
- **Documentation**: Updated the security considerations in [validation-history.md](file:///c:/Users/HP/Disciplr-Frontend/design-system/documentation/validation-history.md) to explain the CSV Injection mitigation.

## Verification
- Run `npx vitest run src/utils/__tests__/csv.test.ts --coverage`
- Result: 23/23 tests passed.
- Coverage on `src/utils/csv.ts`: **100%** (Statement, Branch, Function, and Line).