### PR TITLE
Add a shared VaultStatus type module and replace duplicated status unions across pages

### DIFF
--- a/design-system/documentation/status-chip.md
+++ b/design-system/documentation/status-chip.md
@@ -36,6 +36,37 @@ The chip uses `color-mix` to automatically generate transparent background color
 | `approved` | Approved | `var(--success)` | `color-mix(in srgb, var(--success) 10%, transparent)` |
 | `rejected` | Rejected | `var(--danger)` | `color-mix(in srgb, var(--danger) 10%, transparent)` |
 
+## Shared status types (`src/types/vault.ts`)
+
+The status unions consumed by `StatusChip` and the vault pages live in a single
+module, `src/types/vault.ts`, so they can no longer drift apart:
+
+- `VaultStatus` — `'active' | 'pending_validation' | 'completed' | 'failed' | 'cancelled'`.
+  Every member is a valid `ChipStatus`, so any `VaultStatus` can be passed
+  straight to `<StatusChip status={...} />` without a fallback.
+- `MilestoneStatus` — `'pending' | 'validated' | 'failed'`.
+- `TxType` — `'create' | 'validate' | 'release' | 'redirect'`.
+- `TxStatus` — `'confirmed' | 'pending' | 'failed'`.
+- `VAULT_STATUS_ORDER` — a `readonly VaultStatus[]` giving the canonical display
+  order (most to least active) for consistent sorting. It contains every
+  `VaultStatus` member exactly once.
+
+```tsx
+import type { VaultStatus } from '../types/vault';
+import { VAULT_STATUS_ORDER } from '../types/vault';
+
+// Sort vaults by their canonical status order.
+vaults.sort(
+  (a, b) =>
+    VAULT_STATUS_ORDER.indexOf(a.status) - VAULT_STATUS_ORDER.indexOf(b.status),
+);
+```
+
+`Dashboard`, `Vaults`, `VaultDetail`, `VaultCard`, and `VaultTransactions` all
+import these unions instead of declaring their own. When adding a new
+`VaultStatus`, add it here and to `STATUS_CONFIG` in `StatusChip.tsx` so the
+chip can render it.
+
 ## Accessibility
 
 - The component exposes its status using an implicit `role="status"` and includes an accessible `aria-label` covering the underlying meaning, regardless of whether a custom `label` string is passed in or not.

--- a/src/components/VaultCard.tsx
+++ b/src/components/VaultCard.tsx
@@ -4,8 +4,9 @@ import { VaultProgressBar } from './VaultProgressBar';
 import React from 'react';
 import { CountdownDeadline } from './CountdownDeadline';
 import { StatusChip } from './StatusChip';
+import type { VaultStatus } from '../types/vault';
 
-export type VaultStatus = 'active' | 'pending_validation' | 'completed' | 'failed';
+export type { VaultStatus };
 
 export interface VaultCardProps {
   id: string;
@@ -79,19 +80,21 @@ function UrgencyBadge({ tier }: { tier: UrgencyTier }) {
 }
 
 function StatusBadge({ status }: { status: VaultStatus }) {
-  const config = {
+  const config: Record<VaultStatus, { label: string; bg: string; fg: string }> = {
     active: { label: 'Active', bg: 'var(--accent-transparent)', fg: 'var(--accent)' },
     pending_validation: { label: 'Pending', bg: 'var(--warning-transparent)', fg: 'var(--warning)' },
     completed: { label: 'Completed', bg: 'var(--success-transparent)', fg: 'var(--success)' },
     failed: { label: 'Failed', bg: 'var(--danger-transparent)', fg: 'var(--danger)' },
-  }[status];
+    cancelled: { label: 'Cancelled', bg: 'rgba(156,163,175,0.1)', fg: 'var(--muted)' },
+  };
+  const badge = config[status];
 
   return (
     <span
       style={{
-        background: config.bg,
-        color: config.fg,
-        border: `1px solid ${config.fg}`,
+        background: badge.bg,
+        color: badge.fg,
+        border: `1px solid ${badge.fg}`,
         borderRadius: 'var(--radius-full)',
         padding: '2px 8px',
         fontSize: 11,
@@ -102,7 +105,7 @@ function StatusBadge({ status }: { status: VaultStatus }) {
         gap: 4,
       }}
     >
-      {config.label}
+      {badge.label}
     </span>
   );
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,9 +1,7 @@
 import { Link } from 'react-router-dom'
 import { Text } from '../components/Text';
 import VaultCard from '../components/VaultCard';
-
-// ── Types ─────────────────────────────────────────────────────────────────────
-type VaultStatus = "active" | "pending_validation" | "completed" | "failed";
+import type { VaultStatus } from '../types/vault';
 
 interface VaultPreview {
   id: string;
@@ -137,6 +135,11 @@ const STATUS_CFG: Record<
     label: "Failed",
     color: "var(--danger)",
     bg: "rgba(239,68,68,0.1)",
+  },
+  cancelled: {
+    label: "Cancelled",
+    color: "var(--muted)",
+    bg: "rgba(156,163,175,0.1)",
   },
 };
 

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -8,17 +8,9 @@ import {
   type FundReleaseStatusProps,
 } from "../components/FundReleaseStatus";
 import { Text } from "../components/Text";
+import type { VaultStatus, MilestoneStatus, TxType } from "../types/vault";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
-type VaultStatus =
-  | "active"
-  | "completed"
-  | "failed"
-  | "cancelled"
-  | "pending_validation";
-
-type MilestoneStatus = "pending" | "validated" | "failed";
-
 interface Milestone {
   id: string;
   title: string;
@@ -31,7 +23,7 @@ interface Milestone {
 
 interface VaultTransaction {
   id: string;
-  type: "create" | "validate" | "release" | "redirect";
+  type: TxType;
   hash: string;
   timestamp: string;
   amount?: number;

--- a/src/pages/VaultTransactions.tsx
+++ b/src/pages/VaultTransactions.tsx
@@ -1,10 +1,8 @@
 import { useState, useMemo, useCallback, memo } from "react";
 import { windowRange, WINDOW_THRESHOLD } from "../utils/windowRange";
+import type { TxType, TxStatus } from "../types/vault";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
-type TxType = "create" | "validate" | "release" | "redirect";
-type TxStatus = "confirmed" | "pending" | "failed";
-
 interface Transaction {
   id: string;
   type: TxType;

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -1,7 +1,6 @@
 import { Link } from 'react-router-dom'
 import { Text } from '../components/Text'
-
-type VaultStatus = 'active' | 'completed' | 'failed' | 'cancelled' | 'pending_validation'
+import type { VaultStatus } from '../types/vault'
 
 const MOCK_VAULTS = [
   { id: '1', name: 'Alpha Vault',   amount: 12500,  currency: 'USDC', status: 'active' as VaultStatus,    deadline: '2024-07-15T10:00:00Z' },

--- a/src/types/__tests__/vault.test.ts
+++ b/src/types/__tests__/vault.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  VAULT_STATUS_ORDER,
+  type VaultStatus,
+  type MilestoneStatus,
+  type TxType,
+  type TxStatus,
+} from '../vault';
+import type { ChipStatus } from '../../components/StatusChip';
+
+describe('shared vault status types', () => {
+  describe('VAULT_STATUS_ORDER', () => {
+    it('lists every VaultStatus member', () => {
+      const expected: VaultStatus[] = [
+        'active',
+        'pending_validation',
+        'completed',
+        'failed',
+        'cancelled',
+      ];
+      expect([...VAULT_STATUS_ORDER].sort()).toEqual([...expected].sort());
+    });
+
+    it('has no duplicate entries', () => {
+      expect(new Set(VAULT_STATUS_ORDER).size).toBe(VAULT_STATUS_ORDER.length);
+    });
+
+    it('is ordered from most to least active', () => {
+      expect(VAULT_STATUS_ORDER).toEqual([
+        'active',
+        'pending_validation',
+        'completed',
+        'failed',
+        'cancelled',
+      ]);
+    });
+
+    it('can be used as a stable sort key', () => {
+      const shuffled: VaultStatus[] = ['cancelled', 'active', 'failed', 'pending_validation', 'completed'];
+      const sorted = [...shuffled].sort(
+        (a, b) => VAULT_STATUS_ORDER.indexOf(a) - VAULT_STATUS_ORDER.indexOf(b),
+      );
+      expect(sorted).toEqual([...VAULT_STATUS_ORDER]);
+    });
+  });
+
+  describe('VaultStatus / ChipStatus alignment', () => {
+    it('treats every VaultStatus as a valid ChipStatus', () => {
+      // Compile-time guarantee (VaultStatus must extend ChipStatus), exercised
+      // at runtime over the canonical order array. If a VaultStatus member were
+      // not assignable to ChipStatus, this assignment would fail to type-check.
+      const asChipStatuses: ChipStatus[] = VAULT_STATUS_ORDER.map((status) => status);
+      expect(asChipStatuses).toEqual([...VAULT_STATUS_ORDER]);
+    });
+  });
+
+  describe('union members', () => {
+    it('exposes the expected MilestoneStatus members', () => {
+      const milestoneStatuses: MilestoneStatus[] = ['pending', 'validated', 'failed'];
+      expect(new Set(milestoneStatuses).size).toBe(milestoneStatuses.length);
+    });
+
+    it('exposes the expected TxType members', () => {
+      const txTypes: TxType[] = ['create', 'validate', 'release', 'redirect'];
+      expect(new Set(txTypes).size).toBe(txTypes.length);
+    });
+
+    it('exposes the expected TxStatus members', () => {
+      const txStatuses: TxStatus[] = ['confirmed', 'pending', 'failed'];
+      expect(new Set(txStatuses).size).toBe(txStatuses.length);
+    });
+  });
+});

--- a/src/types/vault.ts
+++ b/src/types/vault.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared vault and validation status types.
+ *
+ * Single source of truth for the status unions that were previously redeclared
+ * (and had drifted out of sync) across Dashboard, Vaults, VaultDetail,
+ * VaultCard, and VaultTransactions. Every `VaultStatus` is a valid
+ * `ChipStatus` in `components/StatusChip.tsx`, so any vault status can be passed
+ * straight to `<StatusChip />`.
+ */
+
+/** Lifecycle state of a vault. Superset of every variant used across pages. */
+export type VaultStatus =
+  | 'active'
+  | 'pending_validation'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+/** State of an individual milestone within a vault. */
+export type MilestoneStatus = 'pending' | 'validated' | 'failed';
+
+/** On-chain transaction category. */
+export type TxType = 'create' | 'validate' | 'release' | 'redirect';
+
+/** Confirmation state of an on-chain transaction. */
+export type TxStatus = 'confirmed' | 'pending' | 'failed';
+
+/**
+ * Canonical display order for vault statuses, used for consistent sorting.
+ * Contains every `VaultStatus` member exactly once, ordered from most to least
+ * active.
+ */
+export const VAULT_STATUS_ORDER: readonly VaultStatus[] = [
+  'active',
+  'pending_validation',
+  'completed',
+  'failed',
+  'cancelled',
+] as const;


### PR DESCRIPTION
Closes #269 

### Summary
`VaultStatus` was redeclared independently in `Dashboard.tsx`, `Vaults.tsx`,
`VaultDetail.tsx`, and `VaultCard.tsx`, and the variants had drifted out of sync
(some included `cancelled`, others did not). This made it easy to render a status
that `StatusChip` could not map.

This PR introduces a single source of truth for the vault and validation status
unions and migrates every page and component to import it. It is a pure type
consolidation with no behavioural change.

### Changes
- Add `src/types/vault.ts` exporting `VaultStatus`, `MilestoneStatus`, `TxType`,
  and `TxStatus` (matching the superset already in use), plus a
  `VAULT_STATUS_ORDER` constant for consistent sorting.
- Migrate `Dashboard`, `Vaults`, `VaultDetail`, `VaultCard`, and
  `VaultTransactions` to import the shared unions instead of declaring their own.
- Widen the `VaultCard` and `Dashboard` status configs to the full union by
  adding the `cancelled` entry, so the exhaustive `Record`s stay type-complete.
  No existing data renders differently.
- Add `src/types/__tests__/vault.test.ts` covering order, no duplicates, full
  membership, sort-key behaviour, and `VaultStatus` to `ChipStatus` alignment.
- Document the shared module in `design-system/documentation/status-chip.md`.

### Type safety
Every `VaultStatus` member is a valid `ChipStatus`, so any vault status can be
passed directly to `<StatusChip />` without hitting the fallback. The alignment
is enforced at compile time and exercised at runtime in the new test.

### Verification
- New test suite: 8 of 8 pass, 100 percent coverage on `src/types/vault.ts`.
- `npx tsc --noEmit`: the touched source files introduce no new errors
  (confirmed by diffing against the unmodified tree; all remaining errors are
  pre-existing baseline noise unrelated to this change).
- No regressions: the only failing tests on this branch
  (`VaultCard.test.tsx:78`, `VaultTransactions.test.tsx:276`, and the empty
  `Vaults.test.tsx`) fail identically on the base branch and predate this work.

### Notes
- Scope limited to the type consolidation; unrelated lockfile and coverage
  artifacts were reverted to keep the diff focused.
