### PR TITLE
feat: add criteria checklist gate to ValidationDetail approval

### DIFF
--- a/src/Zustand/Store.ts
+++ b/src/Zustand/Store.ts
@@ -28,6 +28,7 @@ export type ValidationTask = {
   milestone: string;
   evidenceUrl?: string;
   notes?: string;
+  criteria?: string[];
 };
 
 type VerifierStoreType = {
@@ -51,6 +52,11 @@ const initialPending: ValidationTask[] = [
     status: 'pending',
     milestone: 'Beta Release Deployment',
     evidenceUrl: 'https://github.com/example/release-v1',
+    criteria: [
+      'Deployment URL is live and publicly accessible',
+      'All critical bugs from the backlog are resolved',
+      'Release notes are published',
+    ],
   },
   {
     id: 'v-102',
@@ -62,6 +68,10 @@ const initialPending: ValidationTask[] = [
     status: 'pending',
     milestone: 'Design System Figma Delivery',
     evidenceUrl: 'https://figma.com/example-link',
+    criteria: [
+      'Figma file is shared with the org',
+      'All component pages are complete',
+    ],
   }
 ];
 

--- a/src/pages/ValidationDetail.tsx
+++ b/src/pages/ValidationDetail.tsx
@@ -4,6 +4,7 @@ import { Text } from '../components/Text';
 import { useVerifierStore } from '../Zustand/Store';
 import { ConfirmationModal } from '../components/ConfirmationModal';
 import { SafeLink } from '../components/SafeLink';
+import { isCriteriaGateOpen } from '../utils/criteriaGate';
 
 export default function ValidationDetail() {
   const { vaultId } = useParams<{ vaultId: string }>();
@@ -14,6 +15,7 @@ export default function ValidationDetail() {
   const [notes, setNotes] = useState('');
   const [confirmAction, setConfirmAction] = useState<'approve' | 'reject' | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [checkedCriteria, setCheckedCriteria] = useState<Set<number>>(new Set());
 
   const task = pendingValidations.find((t) => t.id === vaultId);
 
@@ -39,6 +41,16 @@ export default function ValidationDetail() {
     setConfirmAction(action);
     setIsModalOpen(true);
   };
+
+  const toggleCriterion = (index: number) => {
+    setCheckedCriteria((prev) => {
+      const next = new Set(prev);
+      next.has(index) ? next.delete(index) : next.add(index);
+      return next;
+    });
+  };
+
+  const gateOpen = isCriteriaGateOpen(task.criteria, checkedCriteria);
 
   const executeAction = (decision: 'approve' | 'reject', modalNotes: string) => {
     if (decision === 'approve') {
@@ -134,6 +146,30 @@ export default function ValidationDetail() {
         <div className="flex flex-col gap-4">
           <section className="p-6 border rounded-lg shadow-sm flex flex-col h-full" style={{ background: 'var(--bg)', borderColor: 'var(--border)' }}>
             <Text role="display" as="h2" className="mb-4">Verification Actions</Text>
+
+            {task.criteria && task.criteria.length > 0 && (
+              <fieldset className="mb-6 flex flex-col gap-2">
+                <legend className="font-medium text-sm mb-2">
+                  <Text role="body" as="span">Milestone Criteria</Text>
+                </legend>
+                {task.criteria.map((criterion, i) => (
+                  <label
+                    key={i}
+                    className="flex items-start gap-2 text-sm cursor-pointer"
+                    style={{ color: 'var(--text)' }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checkedCriteria.has(i)}
+                      onChange={() => toggleCriterion(i)}
+                      aria-label={criterion}
+                      className="mt-0.5 accent-[var(--accent)] shrink-0"
+                    />
+                    {criterion}
+                  </label>
+                ))}
+              </fieldset>
+            )}
             
             <label className="flex flex-col gap-2 mb-6 flex-grow">
               <Text role="body" as="span" className="font-medium text-sm">Initial Verification Notes (Optional)</Text>
@@ -153,8 +189,15 @@ export default function ValidationDetail() {
             <div className="flex flex-col gap-3 mt-auto">
               <button
                 onClick={() => handleOpenModal('approve')}
+                disabled={!gateOpen}
+                aria-disabled={!gateOpen}
                 className="w-full py-3 font-bold rounded transition"
-                style={{ background: 'var(--success)', color: 'white' }}
+                style={{
+                  background: gateOpen ? 'var(--success)' : 'var(--muted)',
+                  color: 'white',
+                  cursor: gateOpen ? 'pointer' : 'not-allowed',
+                  opacity: gateOpen ? 1 : 0.5,
+                }}
               >
                 Approve Milestone
               </button>

--- a/src/pages/__tests__/ValidationDetail.test.tsx
+++ b/src/pages/__tests__/ValidationDetail.test.tsx
@@ -38,6 +38,13 @@ const mockPendingValidations = [
   },
 ];
 
+const mockPendingWithCriteria = [
+  {
+    ...mockPendingValidations[0],
+    criteria: ['Criterion A', 'Criterion B'],
+  },
+];
+
 describe('ValidationDetail Page', () => {
   const mockApproveValidation = vi.fn();
   const mockRejectValidation = vi.fn();
@@ -80,7 +87,17 @@ describe('ValidationDetail Page', () => {
     expect(screen.getByText('Validation Not Found')).toBeInTheDocument();
   });
 
-  it('opens confirmation modal when clicking approve', async () => {
+  it('approve button is enabled when task has no criteria', () => {
+    render(
+      <MemoryRouter initialEntries={['/verifier/v-101']}>
+        <ValidationDetail />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('button', { name: /Approve Milestone/i })).not.toBeDisabled();
+  });
+
+  it('opens confirmation modal when clicking approve (no criteria)', async () => {
     render(
       <MemoryRouter initialEntries={['/verifier/v-101']}>
         <ValidationDetail />
@@ -198,5 +215,125 @@ describe('ValidationDetail Page', () => {
     fireEvent.click(rejectBtn);
 
     expect(screen.getByText(/Rejection will notify the vault owner/)).toBeInTheDocument();
+  });
+
+  // --- Criteria gate tests ---
+
+  it('renders criteria checkboxes when task has criteria', () => {
+    (useVerifierStore as any).mockReturnValue({
+      pendingValidations: mockPendingWithCriteria,
+      approveValidation: mockApproveValidation,
+      rejectValidation: mockRejectValidation,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/verifier/v-101']}>
+        <ValidationDetail />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByLabelText('Criterion A')).toBeInTheDocument();
+    expect(screen.getByLabelText('Criterion B')).toBeInTheDocument();
+  });
+
+  it('approve button is disabled when criteria are present but unchecked', () => {
+    (useVerifierStore as any).mockReturnValue({
+      pendingValidations: mockPendingWithCriteria,
+      approveValidation: mockApproveValidation,
+      rejectValidation: mockRejectValidation,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/verifier/v-101']}>
+        <ValidationDetail />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('button', { name: /Approve Milestone/i })).toBeDisabled();
+  });
+
+  it('approve button remains disabled when only some criteria are checked', () => {
+    (useVerifierStore as any).mockReturnValue({
+      pendingValidations: mockPendingWithCriteria,
+      approveValidation: mockApproveValidation,
+      rejectValidation: mockRejectValidation,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/verifier/v-101']}>
+        <ValidationDetail />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByLabelText('Criterion A'));
+
+    expect(screen.getByRole('button', { name: /Approve Milestone/i })).toBeDisabled();
+  });
+
+  it('approve button is enabled when all criteria are checked', () => {
+    (useVerifierStore as any).mockReturnValue({
+      pendingValidations: mockPendingWithCriteria,
+      approveValidation: mockApproveValidation,
+      rejectValidation: mockRejectValidation,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/verifier/v-101']}>
+        <ValidationDetail />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByLabelText('Criterion A'));
+    fireEvent.click(screen.getByLabelText('Criterion B'));
+
+    expect(screen.getByRole('button', { name: /Approve Milestone/i })).not.toBeDisabled();
+  });
+
+  it('reject button is always enabled regardless of criteria', () => {
+    (useVerifierStore as any).mockReturnValue({
+      pendingValidations: mockPendingWithCriteria,
+      approveValidation: mockApproveValidation,
+      rejectValidation: mockRejectValidation,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/verifier/v-101']}>
+        <ValidationDetail />
+      </MemoryRouter>
+    );
+
+    // No criteria checked yet
+    expect(screen.getByRole('button', { name: /Reject Milestone/i })).not.toBeDisabled();
+  });
+
+  it('unchecking a criterion re-disables the approve button', () => {
+    (useVerifierStore as any).mockReturnValue({
+      pendingValidations: mockPendingWithCriteria,
+      approveValidation: mockApproveValidation,
+      rejectValidation: mockRejectValidation,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/verifier/v-101']}>
+        <ValidationDetail />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByLabelText('Criterion A'));
+    fireEvent.click(screen.getByLabelText('Criterion B'));
+    expect(screen.getByRole('button', { name: /Approve Milestone/i })).not.toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText('Criterion A'));
+    expect(screen.getByRole('button', { name: /Approve Milestone/i })).toBeDisabled();
+  });
+
+  it('does not render criteria section when task has no criteria', () => {
+    render(
+      <MemoryRouter initialEntries={['/verifier/v-101']}>
+        <ValidationDetail />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('Milestone Criteria')).not.toBeInTheDocument();
   });
 });

--- a/src/utils/__tests__/criteriaGate.test.ts
+++ b/src/utils/__tests__/criteriaGate.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { isCriteriaGateOpen } from '../criteriaGate';
+
+describe('isCriteriaGateOpen', () => {
+  it('returns true when criteria is undefined', () => {
+    expect(isCriteriaGateOpen(undefined, new Set())).toBe(true);
+  });
+
+  it('returns true when criteria is empty array', () => {
+    expect(isCriteriaGateOpen([], new Set())).toBe(true);
+  });
+
+  it('returns false when no criteria are checked', () => {
+    expect(isCriteriaGateOpen(['A', 'B'], new Set())).toBe(false);
+  });
+
+  it('returns false when only some criteria are checked', () => {
+    expect(isCriteriaGateOpen(['A', 'B', 'C'], new Set([0, 1]))).toBe(false);
+  });
+
+  it('returns true when all criteria are checked', () => {
+    expect(isCriteriaGateOpen(['A', 'B'], new Set([0, 1]))).toBe(true);
+  });
+
+  it('returns true for a single criterion that is checked', () => {
+    expect(isCriteriaGateOpen(['A'], new Set([0]))).toBe(true);
+  });
+
+  it('returns false for a single criterion that is unchecked', () => {
+    expect(isCriteriaGateOpen(['A'], new Set())).toBe(false);
+  });
+});

--- a/src/utils/criteriaGate.ts
+++ b/src/utils/criteriaGate.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns true when all criteria are checked (approve gate is open).
+ * Tasks with no criteria are always open.
+ */
+export function isCriteriaGateOpen(
+  criteria: string[] | undefined,
+  checked: Set<number>,
+): boolean {
+  if (!criteria || criteria.length === 0) return true;
+  return checked.size === criteria.length;
+}


### PR DESCRIPTION

  feat: add criteria checklist gate to ValidationDetail approval
  
  Summary
  
  Prevents careless one-click approvals by requiring a verifier to explicitly acknowledge each
  milestone criterion before the Approve action becomes available. Reject remains available at
  all times.
  
  Changes
  
  - src/utils/criteriaGate.ts — new utility isCriteriaGateOpen(criteria, checked) that derives
  gate state from the set of checked indices. Returns true when all criteria are checked, or when
  none are defined (zero-criteria tasks are always open).
  - src/Zustand/Store.ts — added optional criteria?: string[] to ValidationTask type; populated
  mock criteria for existing seed tasks.
  - src/pages/ValidationDetail.tsx — renders a <fieldset> of accessible, token-styled checkboxes
  when the task has criteria; Approve button is disabled until all are checked, Reject is
  unaffected.
  
  Tests
  
  - src/utils/__tests__/criteriaGate.test.ts — 7 unit tests covering: undefined/empty criteria
  (gate open), zero checked (closed), partial (closed), all checked (open), single item toggle.
  - src/pages/__tests__/ValidationDetail.test.tsx — all existing tests preserved; 7 new tests
  added for criteria gate behaviour (checkboxes render, approve disabled/partial/enabled, reject
  always enabled, unchecking re-disables, no checklist when no criteria).
  
  24/24 tests pass. No regressions.
  
  Edge cases covered
  
  ┌─────────────────────────────────────┬─────────────┬────────────┐
  │ Scenario                            │ Approve     │ Reject     │
  ├─────────────────────────────────────┼─────────────┼────────────┤
  │ Zero criteria                       │ ✅ enabled  │ ✅ enabled │
  ├─────────────────────────────────────┼─────────────┼────────────┤
  │ Criteria present, none checked      │ ❌ disabled │ ✅ enabled │
  ├─────────────────────────────────────┼─────────────┼────────────┤
  │ Criteria present, partially checked │ ❌ disabled │ ✅ enabled │
  ├─────────────────────────────────────┼─────────────┼────────────┤
  │ All criteria checked                │ ✅ enabled  │ ✅ enabled │
  └─────────────────────────────────────┴──────
closes #295