### PR TITLE
feat: add expired state and onExpire to CountdownDeadline

### DIFF
--- a/design-system/documentation/countdown-deadline.md
+++ b/design-system/documentation/countdown-deadline.md
@@ -4,14 +4,49 @@
 
 ## Thresholds
 
-| State | Threshold | Tone |
-| --- | --- | --- |
-| Normal | More than 24 hours remaining | `--muted` |
-| Urgent | More than 0 and less than 24 hours remaining | `--warning` |
-| Expired | Deadline is now or in the past | `--danger` |
-| Invalid | Deadline cannot be parsed as a date | `--danger` |
+| State | Threshold | Tone | Color token |
+| --- | --- | --- | --- |
+| Normal | More than 24 hours remaining | `normal` | `--muted` |
+| Urgent | More than 0 and less than 24 hours remaining | `urgent` | `--warning` |
+| Expired / Overdue | Deadline is now or in the past | `expired` | `--danger` |
+| Invalid | Deadline cannot be parsed as a date | `invalid` | `--danger` |
 
 The component sets `title` and `aria-label` to include the absolute deadline and uses `aria-live="off"` so the interval updates do not create noisy announcements for assistive technology users.
+
+## Expired / Overdue state
+
+When the deadline has passed, the component renders an **"Overdue"** label styled with `--danger` tokens and `data-tone="expired"`.
+
+```tsx
+// deadline already in the past — renders "Overdue" in danger color
+<CountdownDeadline deadline="2026-01-01T00:00:00Z" />
+```
+
+## `onExpire` callback
+
+Use the optional `onExpire` prop to react when a countdown crosses zero **during the component's lifetime**.
+
+```tsx
+<CountdownDeadline
+  deadline={vault.deadline}
+  onExpire={() => refetchVerifierQueue()}
+/>
+```
+
+**Behaviour guarantees:**
+
+- Fired **at most once** per mount — repeated ticks after expiry do not re-fire.
+- **Not** fired when the component mounts with a deadline already in the past (no retroactive callbacks). This prevents spurious side-effects when a page loads with stale data.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `deadline` | `string` | — | ISO 8601 date string |
+| `intervalMs` | `number` | `60000` | Polling interval in milliseconds |
+| `prefix` | `string` | — | Optional text prepended to the label, e.g. `"Due:"` |
+| `style` | `CSSProperties` | — | Inline styles forwarded to the inner `<span>` |
+| `onExpire` | `() => void` | — | Called once when countdown crosses zero mid-session |
 
 ## Usage
 

--- a/src/components/CountdownDeadline.tsx
+++ b/src/components/CountdownDeadline.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, useEffect, useState } from 'react';
+import { type CSSProperties, useEffect, useRef, useState } from 'react';
 import { Text } from './Text';
 
 export type DeadlineTone = 'normal' | 'urgent' | 'expired' | 'invalid';
@@ -39,7 +39,7 @@ export function timeRemaining(deadline: string, now: Date | number = Date.now())
   if (msRemaining <= 0) {
     return {
       tone: 'expired',
-      label: 'Expired',
+      label: 'Overdue',
       msRemaining,
       absoluteLabel,
     };
@@ -71,6 +71,7 @@ interface CountdownDeadlineProps {
   intervalMs?: number;
   prefix?: string;
   style?: CSSProperties;
+  onExpire?: () => void;
 }
 
 export function CountdownDeadline({
@@ -78,6 +79,7 @@ export function CountdownDeadline({
   intervalMs = 60000,
   prefix,
   style,
+  onExpire,
 }: CountdownDeadlineProps) {
   const [now, setNow] = useState(() => Date.now());
   const remaining = timeRemaining(deadline, now);
@@ -87,6 +89,16 @@ export function CountdownDeadline({
     expired: 'var(--danger)',
     invalid: 'var(--danger)',
   }[remaining.tone];
+
+  const firedRef = useRef(remaining.tone === 'expired');
+
+  useEffect(() => {
+    if (remaining.tone === 'expired' && !firedRef.current) {
+      firedRef.current = true;
+      onExpire?.();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [remaining.tone]);
 
   useEffect(() => {
     const timer = window.setInterval(() => setNow(Date.now()), intervalMs);

--- a/src/components/__tests__/CountdownDeadline.test.tsx
+++ b/src/components/__tests__/CountdownDeadline.test.tsx
@@ -19,9 +19,9 @@ describe('timeRemaining', () => {
     });
   });
 
-  it('marks exactly-now and past deadlines as expired', () => {
+  it('marks exactly-now and past deadlines as overdue', () => {
     expect(timeRemaining('2026-06-18T12:00:00Z', now).tone).toBe('expired');
-    expect(timeRemaining('2026-06-18T11:59:00Z', now).label).toBe('Expired');
+    expect(timeRemaining('2026-06-18T11:59:00Z', now).label).toBe('Overdue');
   });
 
   it('handles invalid deadline strings', () => {
@@ -80,5 +80,54 @@ describe('CountdownDeadline', () => {
     unmount();
 
     expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it('shows "Overdue" label with danger color when deadline has passed', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-18T12:00:00Z'));
+
+    render(<CountdownDeadline deadline="2026-06-17T00:00:00Z" />);
+
+    const el = screen.getByText('Overdue');
+    expect(el).toHaveAttribute('data-tone', 'expired');
+    expect(el).toHaveStyle({ color: 'var(--danger)' });
+  });
+
+  it('does not fire onExpire when already expired on mount', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-18T12:00:00Z'));
+    const onExpire = vi.fn();
+
+    render(<CountdownDeadline deadline="2026-06-17T00:00:00Z" onExpire={onExpire} />);
+
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+
+  it('fires onExpire exactly once when countdown crosses zero', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-18T12:00:00Z'));
+    const onExpire = vi.fn();
+
+    render(
+      <CountdownDeadline
+        deadline="2026-06-18T12:01:00Z"
+        intervalMs={60000}
+        onExpire={onExpire}
+      />
+    );
+
+    expect(onExpire).not.toHaveBeenCalled();
+
+    act(() => { vi.advanceTimersByTime(60000); });
+    expect(onExpire).toHaveBeenCalledTimes(1);
+
+    act(() => { vi.advanceTimersByTime(60000); });
+    expect(onExpire).toHaveBeenCalledTimes(1); // still once
+  });
+
+  it('handles an invalid deadline without crashing', () => {
+    vi.useFakeTimers();
+    render(<CountdownDeadline deadline="not-a-date" />);
+    expect(screen.getByText('Invalid deadline')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Closes #315

Adds an explicit expired/overdue rendering and an optional `onExpire` callback to `CountdownDeadline`.

## Changes

- `CountdownDeadline.tsx` - `expired` tone renders "Overdue" with `--danger` tokens; `onExpire` prop fires once when countdown crosses zero mid-session (not on mount if already expired)
- `CountdownDeadline.test.tsx` - 11 tests covering: overdue render, `onExpire` fires once, no double-fire on mount, invalid deadline, fake-timer interval cleanup
- `design-system/documentation/countdown-deadline.md` - documents expired state, `onExpire` behaviour guarantees, and full props table

## Tests

All 11 tests pass (`vitest run`).