### PR TITLE
feat: add date-range and milestone filters to validation history

### DIFF
--- a/design-system/documentation/validation-history.md
+++ b/design-system/documentation/validation-history.md
@@ -7,9 +7,14 @@ pagination for completed milestone decisions.
 
 - Outcome filter: `All outcomes`, `Approved`, or `Rejected`.
 - Search: matches `vaultName` and `owner` text from each validation task.
+- From date: filters to records with a `deadline` on or after the given ISO date (inclusive, open-ended when blank).
+- To date: filters to records with a `deadline` on or before the given ISO date (inclusive, open-ended when blank).
+- Milestone: case-insensitive substring match against each record's `milestone` field (blank = no filter).
 - Page size: verifier-selectable page size values of 5, 10, or 25.
 - Pagination: Previous and Next buttons expose explicit `aria-label` text and
   disabled states at the first and last pages.
+
+All filter changes reset pagination to page 1.
 
 ## Empty States
 

--- a/src/pages/ValidationHistory.tsx
+++ b/src/pages/ValidationHistory.tsx
@@ -17,6 +17,9 @@ export default function ValidationHistory() {
   const { validationHistory } = useVerifierStore();
   const [statusFilter, setStatusFilter] = useState<ValidationHistoryStatusFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const [fromDate, setFromDate] = useState('');
+  const [toDate, setToDate] = useState('');
+  const [milestoneFilter, setMilestoneFilter] = useState('');
   const [pageSize, setPageSize] = useState(5);
   const [page, setPage] = useState(1);
 
@@ -26,8 +29,8 @@ export default function ValidationHistory() {
   const rejectedCount = validationHistory.filter((t) => t.status === 'rejected').length;
   const approvalRate = total > 0 ? Math.round((approvedCount / total) * 100) : 0;
   const filteredHistory = useMemo(
-    () => filterValidationHistory(validationHistory, { status: statusFilter, query: searchQuery }),
-    [validationHistory, statusFilter, searchQuery],
+    () => filterValidationHistory(validationHistory, { status: statusFilter, query: searchQuery, from: fromDate || undefined, to: toDate || undefined, milestone: milestoneFilter || undefined }),
+    [validationHistory, statusFilter, searchQuery, fromDate, toDate, milestoneFilter],
   );
   const pagination = paginate(filteredHistory, page, pageSize);
 
@@ -40,6 +43,10 @@ export default function ValidationHistory() {
     setSearchQuery(query);
     setPage(1);
   };
+
+  const updateFromDate = (value: string) => { setFromDate(value); setPage(1); };
+  const updateToDate = (value: string) => { setToDate(value); setPage(1); };
+  const updateMilestoneFilter = (value: string) => { setMilestoneFilter(value); setPage(1); };
 
   const updatePageSize = (size: number) => {
     setPageSize(size);
@@ -97,6 +104,57 @@ export default function ValidationHistory() {
             value={searchQuery}
             onChange={(event) => updateSearchQuery(event.target.value)}
             placeholder="Search vault or owner"
+            style={{
+              background: 'var(--bg)',
+              color: 'var(--text)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: '0.65rem 0.75rem',
+            }}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <Text role="caption" as="span" style={{ color: 'var(--muted)' }}>From</Text>
+          <input
+            type="date"
+            aria-label="Filter validation history from date"
+            value={fromDate}
+            onChange={(event) => updateFromDate(event.target.value)}
+            style={{
+              background: 'var(--bg)',
+              color: 'var(--text)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: '0.65rem 0.75rem',
+            }}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <Text role="caption" as="span" style={{ color: 'var(--muted)' }}>To</Text>
+          <input
+            type="date"
+            aria-label="Filter validation history to date"
+            value={toDate}
+            onChange={(event) => updateToDate(event.target.value)}
+            style={{
+              background: 'var(--bg)',
+              color: 'var(--text)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: '0.65rem 0.75rem',
+            }}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <Text role="caption" as="span" style={{ color: 'var(--muted)' }}>Milestone</Text>
+          <input
+            aria-label="Filter validation history by milestone"
+            value={milestoneFilter}
+            onChange={(event) => updateMilestoneFilter(event.target.value)}
+            placeholder="Milestone"
             style={{
               background: 'var(--bg)',
               color: 'var(--text)',

--- a/src/pages/__tests__/ValidationHistory.test.tsx
+++ b/src/pages/__tests__/ValidationHistory.test.tsx
@@ -195,6 +195,114 @@ describe('ValidationHistory', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/verifier');
   });
 
+  describe('date range filters', () => {
+    it('filters to only items on or after the from date', () => {
+      renderHistory();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history from date'), {
+        target: { value: '2026-01-05' },
+      });
+
+      expect(screen.getByText('Epsilon Pool')).toBeInTheDocument();
+      expect(screen.getByText('Zeta Treasury')).toBeInTheDocument();
+      expect(screen.queryByText('Alpha Vault')).not.toBeInTheDocument();
+      expect(screen.getByText('Showing 2 of 2 matching validations.')).toBeInTheDocument();
+    });
+
+    it('filters to only items on or before the to date', () => {
+      renderHistory();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history to date'), {
+        target: { value: '2026-01-01' },
+      });
+
+      expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
+      expect(screen.queryByText('Beta Reserve')).not.toBeInTheDocument();
+    });
+
+    it('shows no-match state when date range excludes all items', () => {
+      renderHistory();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history from date'), {
+        target: { value: '2030-01-01' },
+      });
+
+      expect(screen.getByText('No matching validations')).toBeInTheDocument();
+    });
+
+    it('resets to page 1 when from date changes', () => {
+      renderHistory();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Go to next validation history page' }));
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history from date'), {
+        target: { value: '2026-01-01' },
+      });
+
+      expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+    });
+  });
+
+  describe('milestone filter', () => {
+    it('filters by milestone substring case-insensitively', () => {
+      renderHistory();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history by milestone'), {
+        target: { value: 'LAUNCH' },
+      });
+
+      expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
+      expect(screen.queryByText('Beta Reserve')).not.toBeInTheDocument();
+      expect(screen.getByText('Showing 1 of 1 matching validations.')).toBeInTheDocument();
+    });
+
+    it('shows no-match state when milestone matches nothing', () => {
+      renderHistory();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history by milestone'), {
+        target: { value: 'nonexistent' },
+      });
+
+      expect(screen.getByText('No matching validations')).toBeInTheDocument();
+    });
+
+    it('resets to page 1 when milestone changes', () => {
+      renderHistory();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Go to next validation history page' }));
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history by milestone'), {
+        target: { value: 'D' },
+      });
+
+      // 'D' matches Delivery (v-003) and Design (v-004) and Docs (v-005) — 3 items, 1 page at default page size 5
+      expect(screen.queryByText('Page 2 of 2')).not.toBeInTheDocument();
+    });
+  });
+
+  it('combines date range and milestone with status/search filters', () => {
+    renderHistory();
+
+    fireEvent.change(screen.getByLabelText('Filter validation history by outcome'), {
+      target: { value: 'approved' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter validation history from date'), {
+      target: { value: '2026-01-01' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter validation history to date'), {
+      target: { value: '2026-01-01' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter validation history by milestone'), {
+      target: { value: 'Launch' },
+    });
+
+    expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
+    expect(screen.queryByText('Beta Reserve')).not.toBeInTheDocument();
+    expect(screen.getByText('Showing 1 of 1 matching validations.')).toBeInTheDocument();
+  });
+
   describe('CSV export', () => {
     beforeEach(() => {
       mockDownloadCsv.mockClear();

--- a/src/utils/__tests__/paginate.test.ts
+++ b/src/utils/__tests__/paginate.test.ts
@@ -68,6 +68,52 @@ describe('filterValidationHistory', () => {
     ]);
   });
 
+  describe('date range filters', () => {
+    it('filters by from date (inclusive)', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', from: '2026-01-02' }).map((t) => t.id)).toEqual(['v-2', 'v-3']);
+    });
+
+    it('filters by to date (inclusive)', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', to: '2026-01-02' }).map((t) => t.id)).toEqual(['v-1', 'v-2']);
+    });
+
+    it('filters by both from and to (inclusive range)', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', from: '2026-01-02', to: '2026-01-02' }).map((t) => t.id)).toEqual(['v-2']);
+    });
+
+    it('returns empty when range matches nothing', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', from: '2027-01-01' })).toEqual([]);
+    });
+
+    it('returns all items when from and to are omitted', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '' })).toHaveLength(3);
+    });
+  });
+
+  describe('milestone filter', () => {
+    it('filters by milestone substring case-insensitively', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', milestone: 'AUDIT' }).map((t) => t.id)).toEqual(['v-2']);
+    });
+
+    it('returns empty when no milestone matches', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', milestone: 'nonexistent' })).toEqual([]);
+    });
+
+    it('treats whitespace-only milestone as no filter', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', milestone: '   ' })).toHaveLength(3);
+    });
+  });
+
+  it('combines date range, milestone, status, and query filters', () => {
+    expect(
+      filterValidationHistory(history, { status: 'approved', query: '', from: '2026-01-01', to: '2026-01-01', milestone: 'launch' }).map((t) => t.id),
+    ).toEqual(['v-1']);
+    // date matches v-1 and v-2, but status=approved removes v-2
+    expect(
+      filterValidationHistory(history, { status: 'approved', query: '', from: '2026-01-01', to: '2026-01-02' }).map((t) => t.id),
+    ).toEqual(['v-1']);
+  });
+
   describe('properties', () => {
     const taskArb: fc.Arbitrary<ValidationTask> = fc.record({
       id: fc.uuid(),

--- a/src/utils/paginate.ts
+++ b/src/utils/paginate.ts
@@ -5,6 +5,9 @@ export type ValidationHistoryStatusFilter = 'all' | 'approved' | 'rejected';
 export interface ValidationHistoryFilterOptions {
   status: ValidationHistoryStatusFilter;
   query: string;
+  from?: string;
+  to?: string;
+  milestone?: string;
 }
 
 export interface PaginationResult<T> {
@@ -17,9 +20,10 @@ export interface PaginationResult<T> {
 
 export function filterValidationHistory(
   tasks: ValidationTask[],
-  { status, query }: ValidationHistoryFilterOptions,
+  { status, query, from, to, milestone }: ValidationHistoryFilterOptions,
 ): ValidationTask[] {
   const normalizedQuery = query.trim().toLowerCase();
+  const normalizedMilestone = milestone?.trim().toLowerCase() ?? '';
 
   return tasks.filter((task) => {
     const matchesStatus = status === 'all' || task.status === status;
@@ -27,8 +31,13 @@ export function filterValidationHistory(
       normalizedQuery.length === 0 ||
       task.vaultName.toLowerCase().includes(normalizedQuery) ||
       task.owner.toLowerCase().includes(normalizedQuery);
+    const matchesFrom = !from || task.deadline >= from;
+    const matchesTo = !to || task.deadline <= to;
+    const matchesMilestone =
+      normalizedMilestone.length === 0 ||
+      task.milestone.toLowerCase().includes(normalizedMilestone);
 
-    return matchesStatus && matchesQuery;
+    return matchesStatus && matchesQuery && matchesFrom && matchesTo && matchesMilestone;
   });
 }
 


### PR DESCRIPTION
PR Description:
  
  ## Summary
  
Extends the ValidationHistory verifier page with date-range and milestone filters.
  
  ## Changes
  
  ### `src/utils/paginate.ts`
  - Added optional `from`, `to`, and `milestone` fields to `ValidationHistoryFilterOptions`
  - `from`/`to`: inclusive ISO date comparison against `task.deadline` (open-ended when omitted)
  - `milestone`: case-insensitive substring match (blank = no filter)
  
  ### `src/pages/ValidationHistory.tsx`
  - Added `fromDate`, `toDate`, `milestoneFilter` state
  - All three update handlers reset pagination to page 1 (consistent with existing status/search behaviour)
  - Added From date input, To date input, and Milestone text input to the filter section with accessible `aria-label` attributes
  
  ### `src/utils/__tests__/paginate.test.ts`
  - Added tests for from/to inclusive bounds, open-ended ranges, no-match cases, whitespace milestone handling, and combined filters
  
  ### `src/pages/__tests__/ValidationHistory.test.tsx`
  - Added UI-level tests for date range filtering, milestone filtering, no-match empty state, page reset on filter change, and combined filter scenario
  
  ### `design-system/documentation/validation-history.md`
  - Updated Controls section to document the new from/to/milestone filters and page-reset behaviour
  
  ## Testing
  
  ```bash
  npx vitest run src/pages/__tests__/ValidationHistory.test.tsx src/utils/__tests__/paginate.test.ts
  
  38 tests pass (17 page + 21 utility). No regressions in ValidationHistory or paginate tests.
  
  ---
    Closes #282 