### PR TITLE
test: cover verifier batchApprove/batchReject transitions

### DIFF
--- a/src/Zustand/__tests__/Store.test.ts
+++ b/src/Zustand/__tests__/Store.test.ts
@@ -65,6 +65,24 @@ describe('verifier store — batch mutators', () => {
     expect(validationHistory).toHaveLength(3);
   });
 
+  it('handles duplicate ids without creating duplicate history entries', () => {
+    useVerifierStore.getState().batchApprove(['a', 'a', 'b']);
+
+    const { pendingValidations, validationHistory } = useVerifierStore.getState();
+    expect(pendingValidations.map((t) => t.id)).toEqual(['c']);
+    expect(validationHistory.filter((t) => t.id === 'a')).toHaveLength(1);
+    expect(validationHistory).toHaveLength(2);
+  });
+
+  it('all-unknown ids is a no-op', () => {
+    useVerifierStore.getState().batchApprove(['x', 'y', 'z']);
+    useVerifierStore.getState().batchReject(['x', 'y', 'z']);
+
+    const { pendingValidations, validationHistory } = useVerifierStore.getState();
+    expect(pendingValidations).toHaveLength(3);
+    expect(validationHistory).toHaveLength(0);
+  });
+
   it('does not regress the single-task mutators', () => {
     useVerifierStore.getState().approveValidation('a', 'single ok');
     useVerifierStore.getState().rejectValidation('b', 'single no');


### PR DESCRIPTION
Description:
  
  ## Summary
  
  Extends `src/Zustand/__tests__/Store.test.ts` with edge-case coverage for the
  `batchApprove` and `batchReject` store mutators.
  
  ## What's added
  
  The existing suite already covered the core happy-path and ignore-unknown cases.
  This PR adds the two missing edge cases called out in #335:
  
  - **Duplicate ids** — passing the same id twice processes it once; no duplicate
    history entry is created.
  - **All-unknown ids** — a batch of entirely non-existent ids is a no-op; pending
    and history are unchanged.
  
  ## Test results
  
  ```bash
  npx vitest run src/Zustand/__tests__/Store.test.ts
  # Tests: 8 passed, 8 total
  
  Checklist
  
  - [x] No changes to Store.ts or any other source file
  - [x] No regressions in existing store tests
  - [x] 
  
Closes #335 