### PR TITLE
refactor: centralize logging behind a typed logger module

### DIFF
--- a/design-system/src/utils/logger.ts
+++ b/design-system/src/utils/logger.ts
@@ -1,0 +1,23 @@
+/**
+ * Minimal Node-compatible logger for the design-system package.
+ * Suppresses non-error levels when NODE_ENV=production.
+ */
+
+const isProd = () => process.env.NODE_ENV === 'production';
+
+/* eslint-disable no-console */
+export const logger = {
+  debug: (...args: unknown[]): void => {
+    if (!isProd()) console.debug(...args);
+  },
+  info: (...args: unknown[]): void => {
+    if (!isProd()) console.info(...args);
+  },
+  warn: (...args: unknown[]): void => {
+    if (!isProd()) console.warn(...args);
+  },
+  error: (...args: unknown[]): void => {
+    console.error(...args);
+  },
+};
+/* eslint-enable no-console */

--- a/design-system/src/utils/token-loader.ts
+++ b/design-system/src/utils/token-loader.ts
@@ -5,6 +5,7 @@
 import { DesignTokens } from '../types/tokens';
 import * as fs from 'fs';
 import * as path from 'path';
+import { logger } from './logger';
 
 export function loadTokens(tokenFile: string): DesignTokens {
   // Reject anything that isn't a plain basename with a .json extension
@@ -33,7 +34,7 @@ export function getAllTokens(): DesignTokens {
       const tokens = loadTokens(file);
       Object.assign(allTokens, tokens);
     } catch (error) {
-      console.warn(`Failed to load ${file}:`, error);
+      logger.warn(`Failed to load ${file}:`, error);
     }
   });
   

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -251,6 +251,63 @@ but current tests are primarily explicit fixture tests.
 - Add design-system tests inside `design-system/src/__tests__/` and run the
   design-system Jest command from inside that package.
 
+## Logging Convention
+
+All new code must use the typed logger instead of calling `console.*` directly.
+This gives a single place to control log levels, suppress output in production,
+and forward to an observability service in the future.
+
+**Frontend app** (`src/`):
+
+```ts
+import { logger } from '../utils/logger';
+
+logger.debug('Loading tokens');          // dev-only
+logger.info('Wallet connected', { address }); // dev-only
+logger.warn('No trustline found');       // dev-only
+logger.error('Connection failed', err);  // always – errors are never suppressed
+```
+
+The frontend logger reads `import.meta.env.PROD` (set by Vite) and no-ops
+`debug`, `info`, and `warn` when building for production. `error` always
+propagates.
+
+**Design system** (`design-system/`):
+
+```ts
+import { logger } from './logger';
+
+logger.warn(`Failed to load ${file}:`, error);
+```
+
+The design-system logger reads `process.env.NODE_ENV` (Node) and applies the
+same suppression rules.
+
+### Mocking the logger in tests
+
+Spy on the underlying `console` method rather than importing the logger:
+
+```ts
+const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+// …trigger the code path that logs…
+
+expect(warnSpy).toHaveBeenCalledWith('Failed to load colors.json:', expect.any(Error));
+vi.restoreAllMocks();
+```
+
+To test production-mode suppression, override `import.meta.env.PROD` before
+re-importing the module:
+
+```ts
+Object.defineProperty(import.meta.env, 'PROD', { value: true, configurable: true });
+vi.resetModules();
+const { logger } = await import('../logger');
+// now logger.warn is a no-op
+```
+
+See `src/utils/__tests__/logger.test.ts` for the full pattern.
+
 ## Troubleshooting
 
 - `matchMedia is not a function`: add the `window.matchMedia` stub before the

--- a/src/components/Wallet/WalletDropdown.tsx
+++ b/src/components/Wallet/WalletDropdown.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useWallet } from '../../context/WalletContext';
 import { Copy, Plus, LogOut, Check, ExternalLink } from 'lucide-react';
 import './wallet.css';
+import { logger } from '../../utils/logger';
 
 interface WalletDropdownProps {
     onClose: () => void;
@@ -24,7 +25,7 @@ export function WalletDropdown({ onClose, onSwitch }: WalletDropdownProps) {
             setCopied(true);
             setTimeout(() => setCopied(false), 2000);
         } catch (err) {
-            console.error('Failed to copy', err);
+            logger.error('Failed to copy', err);
         }
     };
 

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { isAllowed, setAllowed, requestAccess, getAddress, getNetworkDetails } from '@stellar/freighter-api';
 import { fetchUsdcBalance } from '../utils/horizon';
+import { logger } from '../utils/logger';
 
 export type WalletNetwork = 'TESTNET' | 'PUBLIC';
 export type BalanceStatus = 'idle' | 'loading' | 'success' | 'no_trustline' | 'error';
@@ -46,7 +47,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
             setBalance(usdcBalance.balance);
             setBalanceStatus(usdcBalance.hasTrustline ? 'success' : 'no_trustline');
         } catch (err) {
-            console.error('Failed to get network details', err);
+            logger.error('Failed to get network details', err);
             const message = err instanceof Error ? err.message : 'Unable to load USDC balance.';
             setBalance(null);
             setBalanceStatus('error');
@@ -64,7 +65,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
                 }
             }
         } catch (err) {
-            console.error('Check connection error', err);
+            logger.error('Check connection error', err);
         }
     };
 
@@ -91,7 +92,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
                 setError('Wallet access denied.');
             }
         } catch (err: unknown) {
-            console.error('Connection error', err);
+            logger.error('Connection error', err);
             const message = err instanceof Error ? err.message : undefined;
             setError(message || 'Failed to connect wallet. Make sure Freighter is installed and unlocked.');
         } finally {

--- a/src/pages/CreateVault.tsx
+++ b/src/pages/CreateVault.tsx
@@ -9,6 +9,7 @@ import {
 import { EvidenceUpload } from "../components/EvidenceUpload";
 import { CreateVaultReview } from "../components/CreateVaultReview";
 import { formatUsdcInput, parseUsdcInput } from "../utils/usdcInput";
+import { logger } from "../utils/logger";
 
 export default function CreateVault() {
   const [amount, setAmount] = useState("");
@@ -35,7 +36,7 @@ export default function CreateVault() {
 
   const handleConfirm = () => {
     // Placeholder: will call backend / contract
-    console.log({
+    logger.debug('CreateVault confirm', {
       amount,
       deadline,
       successAddress,

--- a/src/pages/__tests__/CreateVault.test.tsx
+++ b/src/pages/__tests__/CreateVault.test.tsx
@@ -15,8 +15,8 @@ describe("CreateVault", () => {
   });
 
   it("renders accessible inline errors and blocks invalid submissions", () => {
-    const consoleLog = vi
-      .spyOn(console, "log")
+    const consoleDebug = vi
+      .spyOn(console, "debug")
       .mockImplementation(() => undefined);
     render(<CreateVault />);
 
@@ -38,7 +38,7 @@ describe("CreateVault", () => {
       "aria-describedby",
       "field-amount-(usdc)-error",
     );
-    expect(consoleLog).not.toHaveBeenCalled();
+    expect(consoleDebug).not.toHaveBeenCalled();
   });
 
   it("rejects identical destination addresses", () => {
@@ -62,8 +62,8 @@ describe("CreateVault", () => {
   });
 
   it("shows the review step for valid values and confirms once", () => {
-    const consoleLog = vi
-      .spyOn(console, "log")
+    const consoleDebug = vi
+      .spyOn(console, "debug")
       .mockImplementation(() => undefined);
     render(<CreateVault />);
 
@@ -82,13 +82,14 @@ describe("CreateVault", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /confirm vault/i }));
 
-    expect(consoleLog).toHaveBeenCalledWith({
+    expect(consoleDebug).toHaveBeenCalledWith('CreateVault confirm', {
       amount: "100.1234567",
       deadline: "2030-01-01T00:00",
       successAddress,
       failureAddress,
+      evidenceUrl: undefined,
     });
-    expect(consoleLog).toHaveBeenCalledTimes(1);
+    expect(consoleDebug).toHaveBeenCalledTimes(1);
   });
 
   it("returns to edit mode without losing entered values", () => {
@@ -162,8 +163,8 @@ describe("CreateVault", () => {
   });
 
   it("keeps underlying raw value compatible with isValidUsdcAmount", () => {
-    const consoleLog = vi
-      .spyOn(console, "log")
+    const consoleDebug = vi
+      .spyOn(console, "debug")
       .mockImplementation(() => undefined);
     render(<CreateVault />);
 
@@ -186,7 +187,8 @@ describe("CreateVault", () => {
 
     // The raw amount passed to the confirm handler should not have commas
     // and should be compatible with isValidUsdcAmount
-    expect(consoleLog).toHaveBeenCalledWith(
+    expect(consoleDebug).toHaveBeenCalledWith(
+      'CreateVault confirm',
       expect.objectContaining({ amount: "1234.5678" }),
     );
   });

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Re-import logger fresh each time so MODE change takes effect.
+async function freshLogger() {
+  vi.resetModules();
+  const mod = await import('../logger');
+  return mod.logger;
+}
+
+describe('logger – development mode', () => {
+  beforeEach(() => {
+    vi.stubEnv('MODE', 'development');
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('forwards debug in dev', async () => {
+    const log = await freshLogger();
+    log.debug('dbg msg', 42);
+    expect(console.debug).toHaveBeenCalledWith('dbg msg', 42);
+  });
+
+  it('forwards info in dev', async () => {
+    const log = await freshLogger();
+    log.info('info msg');
+    expect(console.info).toHaveBeenCalledWith('info msg');
+  });
+
+  it('forwards warn in dev', async () => {
+    const log = await freshLogger();
+    log.warn('warn msg');
+    expect(console.warn).toHaveBeenCalledWith('warn msg');
+  });
+
+  it('forwards error in dev', async () => {
+    const log = await freshLogger();
+    log.error('err msg', new Error('boom'));
+    expect(console.error).toHaveBeenCalledWith('err msg', new Error('boom'));
+  });
+});
+
+describe('logger – production mode', () => {
+  beforeEach(() => {
+    vi.stubEnv('MODE', 'production');
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('suppresses debug in prod', async () => {
+    const log = await freshLogger();
+    log.debug('should not appear');
+    expect(console.debug).not.toHaveBeenCalled();
+  });
+
+  it('suppresses info in prod', async () => {
+    const log = await freshLogger();
+    log.info('should not appear');
+    expect(console.info).not.toHaveBeenCalled();
+  });
+
+  it('suppresses warn in prod', async () => {
+    const log = await freshLogger();
+    log.warn('should not appear');
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('still forwards error in prod', async () => {
+    const log = await freshLogger();
+    log.error('critical', new Error('fatal'));
+    expect(console.error).toHaveBeenCalledWith('critical', new Error('fatal'));
+  });
+});
+
+describe('logger – argument types', () => {
+  beforeEach(() => {
+    vi.stubEnv('MODE', 'development');
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('passes Error instance through to console.error', async () => {
+    const log = await freshLogger();
+    const err = new Error('test error');
+    log.error('context label', err);
+    expect(console.error).toHaveBeenCalledWith('context label', err);
+  });
+
+  it('passes plain string through to console.warn', async () => {
+    const log = await freshLogger();
+    log.warn('string warning');
+    expect(console.warn).toHaveBeenCalledWith('string warning');
+  });
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,32 @@
+/**
+ * Thin logger that no-ops non-error levels in production.
+ * Replace `console.*` calls with these so log level, suppression,
+ * and future forwarding to an observability service can be controlled
+ * from one place.
+ *
+ * Usage:
+ *   import { logger } from '../utils/logger';
+ *   logger.debug('Loading tokens');
+ *   logger.info('Wallet connected', { address });
+ *   logger.warn('No trustline found');
+ *   logger.error('Connection failed', err);
+ */
+
+const isProd = () => import.meta.env.MODE === 'production';
+
+/* eslint-disable no-console */
+export const logger = {
+  debug: (...args: unknown[]): void => {
+    if (!isProd()) console.debug(...args);
+  },
+  info: (...args: unknown[]): void => {
+    if (!isProd()) console.info(...args);
+  },
+  warn: (...args: unknown[]): void => {
+    if (!isProd()) console.warn(...args);
+  },
+  error: (...args: unknown[]): void => {
+    console.error(...args);
+  },
+};
+/* eslint-enable no-console */


### PR DESCRIPTION

  Summary
  
  Replaces scattered console.* calls with a thin typed logger so log levels can be controlled,
  suppressed in production, and mocked consistently in tests.
  
  Changes
  
  - Added src/utils/logger.ts — debug/info/warn/error interface; non-error levels no-op when
  import.meta.env.MODE === 'production'
  - Added design-system/src/utils/logger.ts — same contract for the Node package, keyed off
  process.env.NODE_ENV
  - Replaced console.* calls in:
    - WalletContext.tsx — 3× console.error → logger.error
    - WalletDropdown.tsx — 1× console.error → logger.error
    - CreateVault.tsx — console.log → logger.debug (placeholder handler)
    - design-system/src/utils/token-loader.ts — console.warn → logger.warn
  
  - Added src/utils/__tests__/logger.test.ts — 10 tests covering dev forwarding, prod
  suppression, and argument types
  - Updated docs/TESTING.md with logging convention and mock patterns
  
  Testing
  
  - All 10 logger tests pass
  - No regressions introduced; pre-existing failures are unrelated to this change
  - CreateVault tests updated to assert on console.debug after the call site change
  
  Behaviour in dev vs prod
  
  ┌─────────────────────┬─────────────┬────────────┐
  │ Level               │ Development │ Production │
  ├─────────────────────┼─────────────┼────────────┤
  │ debug / info / warn │ forwarded   │ suppressed │
  ├─────────────────────┼─────────────┼────────────┤
  │ error               │ forwarded   │ forwarded  │
  └─────────────────────┴─────────────┴────────────┘
closes #354