### PR TITLE
Docs/contributing test setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing
+
+## Test Setup
+
+The project uses **two separate test runners** that must not be mixed.
+
+### App tests — Vitest
+
+Covers all files under `src/` (`*.test.ts` and `*.test.tsx`).
+
+```bash
+# Run once with coverage (CI mode)
+npm test
+
+# Interactive watch mode
+npm run test:watch
+
+# Run a single file
+npx vitest run src/components/__tests__/NavLink.test.tsx
+```
+
+Coverage is written to `coverage/`. Open `coverage/index.html` for the HTML report.
+Enforced thresholds: statements 50 %, branches 80 %, functions 65 %, lines 50 %.
+
+**Environment**: `.test.tsx` files run in **jsdom** (DOM + RTL available). `.test.ts` files run in **node**.
+
+**Setup file**: `src/setupTests.ts` — imports `@testing-library/jest-dom` so all RTL matchers (`toBeInTheDocument`, etc.) are available globally.
+
+**`@` alias**: `@` resolves to `src/`. Use it in test imports the same way production code does:
+```ts
+import { foo } from '@/utils/foo';
+```
+
+### Design-system tests — Jest
+
+Covers files under `design-system/src/`.
+
+```bash
+cd design-system
+
+# Run once
+npm test
+
+# Interactive watch mode
+npm run test:watch
+```
+
+## Linting
+
+```bash
+# App
+npm run lint
+
+# Design-system
+cd design-system && npm run lint
+```
+
+## Branch Naming
+
+```
+type/short-slug
+```
+
+Examples: `feat/vault-filter`, `test/navlink-coverage`, `docs/contributing-guide`, `fix/pagination-reset`.
+
+## Pull Requests
+
+- PRs are expected to land within **96 hours** of being opened.
+- Keep the diff focused — one concern per PR.
+- Every new or changed line of testable code should maintain or improve coverage above the thresholds above.

--- a/README.md
+++ b/README.md
@@ -241,3 +241,7 @@ disciplr-frontend/
   `src/components/Wallet/`.
 - Keep token and validator documentation aligned with the `design-system/`
   package.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the dual Vitest + Jest test setup, branch naming, and PR conventions.

--- a/design-system/documentation/validation-history.md
+++ b/design-system/documentation/validation-history.md
@@ -7,9 +7,14 @@ pagination for completed milestone decisions.
 
 - Outcome filter: `All outcomes`, `Approved`, or `Rejected`.
 - Search: matches `vaultName` and `owner` text from each validation task.
+- From date: filters to records with a `deadline` on or after the given ISO date (inclusive, open-ended when blank).
+- To date: filters to records with a `deadline` on or before the given ISO date (inclusive, open-ended when blank).
+- Milestone: case-insensitive substring match against each record's `milestone` field (blank = no filter).
 - Page size: verifier-selectable page size values of 5, 10, or 25.
 - Pagination: Previous and Next buttons expose explicit `aria-label` text and
   disabled states at the first and last pages.
+
+All filter changes reset pagination to page 1.
 
 ## Empty States
 

--- a/src/components/__tests__/NavLink.test.tsx
+++ b/src/components/__tests__/NavLink.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import NavLink from '../NavLink';
+
+function renderNav(to: string, currentPath: string, className = '', ariaLabel?: string) {
+  return render(
+    <MemoryRouter initialEntries={[currentPath]}>
+      <NavLink to={to} className={className} ariaLabel={ariaLabel}>
+        Link
+      </NavLink>
+    </MemoryRouter>,
+  );
+}
+
+describe('NavLink', () => {
+  it('is active with aria-current="page" when to matches the current path', () => {
+    renderNav('/dashboard', '/dashboard');
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('active');
+    expect(link).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('is active when current path starts with to (non-root)', () => {
+    renderNav('/vaults', '/vaults/123');
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('active');
+    expect(link).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('is inactive when to does not match the current path', () => {
+    renderNav('/dashboard', '/vaults');
+    const link = screen.getByRole('link');
+    expect(link).not.toHaveClass('active');
+    expect(link).not.toHaveAttribute('aria-current');
+  });
+
+  it('root "/" is active only on exact "/" path', () => {
+    renderNav('/', '/');
+    expect(screen.getByRole('link')).toHaveClass('active');
+  });
+
+  it('root "/" is inactive on a non-root path', () => {
+    renderNav('/', '/dashboard');
+    const link = screen.getByRole('link');
+    expect(link).not.toHaveClass('active');
+    expect(link).not.toHaveAttribute('aria-current');
+  });
+
+  it('forwards className and combines it with active class', () => {
+    renderNav('/vaults', '/vaults', 'nav-item');
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('nav-item');
+    expect(link).toHaveClass('active');
+    expect(link.className).toBe('nav-item active');
+  });
+
+  it('forwards ariaLabel prop', () => {
+    renderNav('/vaults', '/vaults', '', 'Go to vaults');
+    expect(screen.getByRole('link')).toHaveAttribute('aria-label', 'Go to vaults');
+  });
+
+  it('produces no leading/trailing spaces when className is empty and inactive', () => {
+    renderNav('/dashboard', '/vaults');
+    expect(screen.getByRole('link').className).toBe('');
+  });
+
+  it('produces no leading/trailing spaces when className is empty and active', () => {
+    renderNav('/vaults', '/vaults');
+    expect(screen.getByRole('link').className).toBe('active');
+  });
+
+  it('partial prefix of to does NOT make to active (to is the prefix, not the path)', () => {
+    // current path "/vault" does not start with "/vaults"
+    renderNav('/vaults', '/vault');
+    expect(screen.getByRole('link')).not.toHaveClass('active');
+  });
+});

--- a/src/pages/ValidationHistory.tsx
+++ b/src/pages/ValidationHistory.tsx
@@ -17,6 +17,9 @@ export default function ValidationHistory() {
   const { validationHistory } = useVerifierStore();
   const [statusFilter, setStatusFilter] = useState<ValidationHistoryStatusFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const [fromDate, setFromDate] = useState('');
+  const [toDate, setToDate] = useState('');
+  const [milestoneFilter, setMilestoneFilter] = useState('');
   const [pageSize, setPageSize] = useState(5);
   const [page, setPage] = useState(1);
 
@@ -26,8 +29,8 @@ export default function ValidationHistory() {
   const rejectedCount = validationHistory.filter((t) => t.status === 'rejected').length;
   const approvalRate = total > 0 ? Math.round((approvedCount / total) * 100) : 0;
   const filteredHistory = useMemo(
-    () => filterValidationHistory(validationHistory, { status: statusFilter, query: searchQuery }),
-    [validationHistory, statusFilter, searchQuery],
+    () => filterValidationHistory(validationHistory, { status: statusFilter, query: searchQuery, from: fromDate || undefined, to: toDate || undefined, milestone: milestoneFilter || undefined }),
+    [validationHistory, statusFilter, searchQuery, fromDate, toDate, milestoneFilter],
   );
   const pagination = paginate(filteredHistory, page, pageSize);
 
@@ -40,6 +43,10 @@ export default function ValidationHistory() {
     setSearchQuery(query);
     setPage(1);
   };
+
+  const updateFromDate = (value: string) => { setFromDate(value); setPage(1); };
+  const updateToDate = (value: string) => { setToDate(value); setPage(1); };
+  const updateMilestoneFilter = (value: string) => { setMilestoneFilter(value); setPage(1); };
 
   const updatePageSize = (size: number) => {
     setPageSize(size);
@@ -97,6 +104,57 @@ export default function ValidationHistory() {
             value={searchQuery}
             onChange={(event) => updateSearchQuery(event.target.value)}
             placeholder="Search vault or owner"
+            style={{
+              background: 'var(--bg)',
+              color: 'var(--text)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: '0.65rem 0.75rem',
+            }}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <Text role="caption" as="span" style={{ color: 'var(--muted)' }}>From</Text>
+          <input
+            type="date"
+            aria-label="Filter validation history from date"
+            value={fromDate}
+            onChange={(event) => updateFromDate(event.target.value)}
+            style={{
+              background: 'var(--bg)',
+              color: 'var(--text)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: '0.65rem 0.75rem',
+            }}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <Text role="caption" as="span" style={{ color: 'var(--muted)' }}>To</Text>
+          <input
+            type="date"
+            aria-label="Filter validation history to date"
+            value={toDate}
+            onChange={(event) => updateToDate(event.target.value)}
+            style={{
+              background: 'var(--bg)',
+              color: 'var(--text)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: '0.65rem 0.75rem',
+            }}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <Text role="caption" as="span" style={{ color: 'var(--muted)' }}>Milestone</Text>
+          <input
+            aria-label="Filter validation history by milestone"
+            value={milestoneFilter}
+            onChange={(event) => updateMilestoneFilter(event.target.value)}
+            placeholder="Milestone"
             style={{
               background: 'var(--bg)',
               color: 'var(--text)',

--- a/src/pages/__tests__/ValidationHistory.test.tsx
+++ b/src/pages/__tests__/ValidationHistory.test.tsx
@@ -195,6 +195,114 @@ describe('ValidationHistory', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/verifier');
   });
 
+  describe('date range filters', () => {
+    it('filters to only items on or after the from date', () => {
+      renderHistory();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history from date'), {
+        target: { value: '2026-01-05' },
+      });
+
+      expect(screen.getByText('Epsilon Pool')).toBeInTheDocument();
+      expect(screen.getByText('Zeta Treasury')).toBeInTheDocument();
+      expect(screen.queryByText('Alpha Vault')).not.toBeInTheDocument();
+      expect(screen.getByText('Showing 2 of 2 matching validations.')).toBeInTheDocument();
+    });
+
+    it('filters to only items on or before the to date', () => {
+      renderHistory();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history to date'), {
+        target: { value: '2026-01-01' },
+      });
+
+      expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
+      expect(screen.queryByText('Beta Reserve')).not.toBeInTheDocument();
+    });
+
+    it('shows no-match state when date range excludes all items', () => {
+      renderHistory();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history from date'), {
+        target: { value: '2030-01-01' },
+      });
+
+      expect(screen.getByText('No matching validations')).toBeInTheDocument();
+    });
+
+    it('resets to page 1 when from date changes', () => {
+      renderHistory();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Go to next validation history page' }));
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history from date'), {
+        target: { value: '2026-01-01' },
+      });
+
+      expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+    });
+  });
+
+  describe('milestone filter', () => {
+    it('filters by milestone substring case-insensitively', () => {
+      renderHistory();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history by milestone'), {
+        target: { value: 'LAUNCH' },
+      });
+
+      expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
+      expect(screen.queryByText('Beta Reserve')).not.toBeInTheDocument();
+      expect(screen.getByText('Showing 1 of 1 matching validations.')).toBeInTheDocument();
+    });
+
+    it('shows no-match state when milestone matches nothing', () => {
+      renderHistory();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history by milestone'), {
+        target: { value: 'nonexistent' },
+      });
+
+      expect(screen.getByText('No matching validations')).toBeInTheDocument();
+    });
+
+    it('resets to page 1 when milestone changes', () => {
+      renderHistory();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Go to next validation history page' }));
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+
+      fireEvent.change(screen.getByLabelText('Filter validation history by milestone'), {
+        target: { value: 'D' },
+      });
+
+      // 'D' matches Delivery (v-003) and Design (v-004) and Docs (v-005) — 3 items, 1 page at default page size 5
+      expect(screen.queryByText('Page 2 of 2')).not.toBeInTheDocument();
+    });
+  });
+
+  it('combines date range and milestone with status/search filters', () => {
+    renderHistory();
+
+    fireEvent.change(screen.getByLabelText('Filter validation history by outcome'), {
+      target: { value: 'approved' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter validation history from date'), {
+      target: { value: '2026-01-01' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter validation history to date'), {
+      target: { value: '2026-01-01' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter validation history by milestone'), {
+      target: { value: 'Launch' },
+    });
+
+    expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
+    expect(screen.queryByText('Beta Reserve')).not.toBeInTheDocument();
+    expect(screen.getByText('Showing 1 of 1 matching validations.')).toBeInTheDocument();
+  });
+
   describe('CSV export', () => {
     beforeEach(() => {
       mockDownloadCsv.mockClear();

--- a/src/utils/__tests__/paginate.test.ts
+++ b/src/utils/__tests__/paginate.test.ts
@@ -68,6 +68,52 @@ describe('filterValidationHistory', () => {
     ]);
   });
 
+  describe('date range filters', () => {
+    it('filters by from date (inclusive)', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', from: '2026-01-02' }).map((t) => t.id)).toEqual(['v-2', 'v-3']);
+    });
+
+    it('filters by to date (inclusive)', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', to: '2026-01-02' }).map((t) => t.id)).toEqual(['v-1', 'v-2']);
+    });
+
+    it('filters by both from and to (inclusive range)', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', from: '2026-01-02', to: '2026-01-02' }).map((t) => t.id)).toEqual(['v-2']);
+    });
+
+    it('returns empty when range matches nothing', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', from: '2027-01-01' })).toEqual([]);
+    });
+
+    it('returns all items when from and to are omitted', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '' })).toHaveLength(3);
+    });
+  });
+
+  describe('milestone filter', () => {
+    it('filters by milestone substring case-insensitively', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', milestone: 'AUDIT' }).map((t) => t.id)).toEqual(['v-2']);
+    });
+
+    it('returns empty when no milestone matches', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', milestone: 'nonexistent' })).toEqual([]);
+    });
+
+    it('treats whitespace-only milestone as no filter', () => {
+      expect(filterValidationHistory(history, { status: 'all', query: '', milestone: '   ' })).toHaveLength(3);
+    });
+  });
+
+  it('combines date range, milestone, status, and query filters', () => {
+    expect(
+      filterValidationHistory(history, { status: 'approved', query: '', from: '2026-01-01', to: '2026-01-01', milestone: 'launch' }).map((t) => t.id),
+    ).toEqual(['v-1']);
+    // date matches v-1 and v-2, but status=approved removes v-2
+    expect(
+      filterValidationHistory(history, { status: 'approved', query: '', from: '2026-01-01', to: '2026-01-02' }).map((t) => t.id),
+    ).toEqual(['v-1']);
+  });
+
   describe('properties', () => {
     const taskArb: fc.Arbitrary<ValidationTask> = fc.record({
       id: fc.uuid(),

--- a/src/utils/paginate.ts
+++ b/src/utils/paginate.ts
@@ -5,6 +5,9 @@ export type ValidationHistoryStatusFilter = 'all' | 'approved' | 'rejected';
 export interface ValidationHistoryFilterOptions {
   status: ValidationHistoryStatusFilter;
   query: string;
+  from?: string;
+  to?: string;
+  milestone?: string;
 }
 
 export interface PaginationResult<T> {
@@ -17,9 +20,10 @@ export interface PaginationResult<T> {
 
 export function filterValidationHistory(
   tasks: ValidationTask[],
-  { status, query }: ValidationHistoryFilterOptions,
+  { status, query, from, to, milestone }: ValidationHistoryFilterOptions,
 ): ValidationTask[] {
   const normalizedQuery = query.trim().toLowerCase();
+  const normalizedMilestone = milestone?.trim().toLowerCase() ?? '';
 
   return tasks.filter((task) => {
     const matchesStatus = status === 'all' || task.status === status;
@@ -27,8 +31,13 @@ export function filterValidationHistory(
       normalizedQuery.length === 0 ||
       task.vaultName.toLowerCase().includes(normalizedQuery) ||
       task.owner.toLowerCase().includes(normalizedQuery);
+    const matchesFrom = !from || task.deadline >= from;
+    const matchesTo = !to || task.deadline <= to;
+    const matchesMilestone =
+      normalizedMilestone.length === 0 ||
+      task.milestone.toLowerCase().includes(normalizedMilestone);
 
-    return matchesStatus && matchesQuery;
+    return matchesStatus && matchesQuery && matchesFrom && matchesTo && matchesMilestone;
   });
 }
 


### PR DESCRIPTION
PR Description:
  
  ## Summary
  
  . Adds `CONTRIBUTING.md` at the repo root and links it from `README.md`.
  
  ## Changes
  
  - **`CONTRIBUTING.md`** (new) — covers:
    - App tests (Vitest): `npm test`, `npm run test:watch`, single-file run, coverage output + thresholds, jsdom vs node environment split, `@` alias, RTL
  setup file
    - Design-system tests (Jest): `cd design-system && npm test` / `npm run test:watch`
    - Linting: `npm run lint` (app) and `cd design-system && npm run lint`
    - Branch naming convention: `type/short-slug`
    - PR timeframe: 96 hours
  - **`README.md`** — added "Contributing" section at the bottom linking to `CONTRIBUTING.md`
  
  ## Verification
  
  All documented commands verified to run without error in the local environment.

Closes #362 