### PR TITLE
perf: trim react-icons imports in notification data module

### DIFF
--- a/src/components/Notification/exampleNotification/example.ts
+++ b/src/components/Notification/exampleNotification/example.ts
@@ -261,5 +261,5 @@ export const notificationTypeColors: { [key: string]: string } = {
   funds_released: "green",
   funds_redirected: "amber",
   verification_requested: "blue",
-  system_announcements: "grey",
+  system_announcement: "grey",
 };

--- a/src/components/__tests__/NotificationTypeMaps.test.ts
+++ b/src/components/__tests__/NotificationTypeMaps.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import {
+  notificationTypeIcons,
+  notificationTypeColors,
+  getNotifications,
+} from '../Notification/exampleNotification/example';
+
+const TYPES = [
+  'vault_created_successfully',
+  'milestone_validated',
+  'vault_deadline_approaching',
+  'funds_released',
+  'funds_redirected',
+  'verification_requested',
+  'system_announcement',
+];
+
+describe('notificationTypeIcons', () => {
+  it.each(TYPES)('%s resolves to a non-null icon', (type) => {
+    expect(notificationTypeIcons[type]).toBeTruthy();
+  });
+
+  it('unknown type returns undefined without throwing', () => {
+    expect(() => notificationTypeIcons['unknown_type']).not.toThrow();
+    expect(notificationTypeIcons['unknown_type']).toBeUndefined();
+  });
+});
+
+describe('notificationTypeColors', () => {
+  it.each(TYPES)('%s resolves to a non-empty color string', (type) => {
+    expect(typeof notificationTypeColors[type]).toBe('string');
+    expect(notificationTypeColors[type].length).toBeGreaterThan(0);
+  });
+
+  it('unknown type returns undefined without throwing', () => {
+    expect(() => notificationTypeColors['unknown_type']).not.toThrow();
+    expect(notificationTypeColors['unknown_type']).toBeUndefined();
+  });
+});
+
+describe('getNotifications', () => {
+  it('every notification type has a matching icon and color', () => {
+    const notifications = getNotifications();
+    for (const n of notifications) {
+      expect(notificationTypeIcons[n.type]).toBeTruthy();
+      expect(notificationTypeColors[n.type]).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
 Description:
  
  ## Summary
  
  Audited `example.ts` icon imports — they were already individual named
  imports (no wildcard/namespace imports), so no tree-shaking was being
  lost. The actual gap was:
  
  1. A typo in `notificationTypeColors`: `system_announcements` instead
     of `system_announcement`, causing every `system_announcement`
     notification to return `undefined` for its color.
  2. No tests asserting that each notification type resolves to a valid
     icon and color.
  
  ## Changes
  
  **`example.ts`**
  - Fixed typo: `system_announcements` → `system_announcement` in
    `notificationTypeColors`.
  
  **`src/components/__tests__/NotificationTypeMaps.test.ts`** (new)
  - Asserts every documented type resolves to a non-null icon and
    non-empty color string.
  - Asserts unknown types return `undefined` without throwing.
  - Asserts every notification object from `getNotifications()` has a
    matching icon and color (catches future typos like the one fixed here).
  
  ## Test results
  
  Tests: 17 passed, 17 total
  
  ## Checklist
  
  - [x] No regressions in existing tests
   Closes #353 