### PR TITLE
perf: split recharts/jsPDF into named vendor chunks with budget

### DIFF
--- a/docs/BUNDLE_BUDGET.md
+++ b/docs/BUNDLE_BUDGET.md
@@ -1,0 +1,13 @@
+# Bundle Size Budget
+
+Chunks are split via `build.rollupOptions.output.manualChunks` in `vite.config.ts`.
+Sizes are gzip-compressed targets. Regressions should be visible in `npm run build` output.
+
+| Chunk                  | Target (gzip) |
+| ---------------------- | ------------- |
+| `index` (initial)      | < 200 kB      |
+| `vendor-recharts`      | < 150 kB      |
+| `vendor-jspdf`         | < 120 kB      |
+| `vendor-framer-motion` | < 30 kB       |
+| `Analytics` (lazy)     | < 50 kB       |
+| `Notification` (lazy)  | < 20 kB       |

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,30 +8,34 @@ import { configDefaults } from 'vitest/config';
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   test: {
-    environment: 'jsdom',
     globals: true,
-    setupFiles: './src/setupTests.ts',
-    include: ['src/**/*.test.{ts,tsx}'],
+    environment: "happy-dom",
+    setupFiles: "./src/setupTests.ts",
+    css: true,
+    include: ["src/**/*.test.{tsx,ts}"],
     coverage: {
       reporter: ['text', 'html'],
     },
-    exclude: [...configDefaults.exclude, 'node_modules', 'dist']
+    exclude: [...configDefaults.exclude, 'node_modules', 'dist'],
   },
   resolve: {
     alias: { "@": path.resolve(__dirname, "./src") },
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('recharts')) return 'vendor-recharts';
+          if (id.includes('jspdf')) return 'vendor-jspdf';
+          if (id.includes('framer-motion')) return 'vendor-framer-motion';
+        },
+      },
+    },
   },
   server: {
     port: 5173,
     proxy: {
       "/api": { target: "http://localhost:3000", changeOrigin: true },
     },
-  },
-  // Vitest configuration
-  test: {
-    globals: true,
-    environment: "happy-dom",
-    setupFiles: "./src/setupTests.ts",
-    css: true,
-    include: ["src/**/*.test.{tsx,ts}"]
   },
 });


### PR DESCRIPTION
 Description:
  
  ## Summary
  
  Configures Vite `manualChunks` to isolate heavy vendor libraries into
  named chunks, and documents a gzip size budget for CI visibility.
  
  ## Changes
  
  **`vite.config.ts`**
  - Added `build.rollupOptions.output.manualChunks` routing:
    - `recharts` → `vendor-recharts`
    - `jspdf` → `vendor-jspdf`
    - `framer-motion` → `vendor-framer-motion`
  - Fixed pre-existing duplicate `test` block (merged into one).
  
  **`docs/BUNDLE_BUDGET.md`** (new)
  - Documents target gzip sizes for initial bundle, each vendor chunk,
    and the lazy Analytics/Notification chunks.
  
  ## Result
  
  The Analytics lazy route already uses `React.lazy` in `App.tsx`.
  With `manualChunks`, recharts and jspdf will no longer be bundled
  into the initial `index` chunk.
  
  ## Checklist
  
  - [x] No regressions in tests
 Closes #352 