### PR TITLE
feat: warn on insufficient USDC balance in CreateVault

### DIFF
--- a/src/pages/CreateVault.tsx
+++ b/src/pages/CreateVault.tsx
@@ -3,14 +3,17 @@ import { Text } from "../components/Text";
 import { Field } from "../components/Field";
 import type { CreateVaultErrors } from "../utils/vaultValidation";
 import {
+  exceedsBalance,
   hasCreateVaultErrors,
   validateCreateVault,
 } from "../utils/vaultValidation";
 import { EvidenceUpload } from "../components/EvidenceUpload";
 import { CreateVaultReview } from "../components/CreateVaultReview";
 import { formatUsdcInput, parseUsdcInput } from "../utils/usdcInput";
+import { useWallet } from "../context/WalletContext";
 
 export default function CreateVault() {
+  const { balance, balanceStatus } = useWallet();
   const [amount, setAmount] = useState("");
   const [deadline, setDeadline] = useState("");
   const [successAddress, setSuccessAddress] = useState("");
@@ -94,6 +97,14 @@ export default function CreateVault() {
             error={errors.amount}
             required
           />
+          {balanceStatus === 'success' && exceedsBalance(amount, balance) && (
+            <p
+              role="status"
+              style={{ color: 'var(--warning)', margin: 0, fontSize: '0.875rem' }}
+            >
+              Amount exceeds your available USDC balance ({balance}).
+            </p>
+          )}
           <Field
             label="Deadline (ISO date)"
             type="datetime-local"

--- a/src/pages/__tests__/CreateVault.test.tsx
+++ b/src/pages/__tests__/CreateVault.test.tsx
@@ -2,6 +2,13 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import CreateVault from "../CreateVault";
 
+vi.mock("../../context/WalletContext", () => ({
+  useWallet: vi.fn(() => ({ balance: null, balanceStatus: 'idle' })),
+}));
+
+import { useWallet } from "../../context/WalletContext";
+const mockUseWallet = vi.mocked(useWallet);
+
 const successAddress = `G${"A".repeat(55)}`;
 const failureAddress = `G${"B".repeat(55)}`;
 
@@ -12,6 +19,7 @@ function fillField(label: RegExp, value: string) {
 describe("CreateVault", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    mockUseWallet.mockReturnValue({ balance: null, balanceStatus: 'idle' } as ReturnType<typeof useWallet>);
   });
 
   it("renders accessible inline errors and blocks invalid submissions", () => {
@@ -189,5 +197,62 @@ describe("CreateVault", () => {
     expect(consoleLog).toHaveBeenCalledWith(
       expect.objectContaining({ amount: "1234.5678" }),
     );
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  Balance warning                                                    */
+  /* ------------------------------------------------------------------ */
+  it("shows insufficient balance warning when amount exceeds balance", () => {
+    mockUseWallet.mockReturnValue({ balance: '50', balanceStatus: 'success' } as ReturnType<typeof useWallet>);
+    render(<CreateVault />);
+
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: "100" } });
+
+    expect(screen.getByRole('status')).toHaveTextContent(/exceeds your available usdc balance/i);
+  });
+
+  it("does not show warning when amount equals balance", () => {
+    mockUseWallet.mockReturnValue({ balance: '100', balanceStatus: 'success' } as ReturnType<typeof useWallet>);
+    render(<CreateVault />);
+
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: "100" } });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it("does not show warning when amount is within balance", () => {
+    mockUseWallet.mockReturnValue({ balance: '200', balanceStatus: 'success' } as ReturnType<typeof useWallet>);
+    render(<CreateVault />);
+
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: "100" } });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it("does not show warning when balance is null (not loaded)", () => {
+    mockUseWallet.mockReturnValue({ balance: null, balanceStatus: 'loading' } as ReturnType<typeof useWallet>);
+    render(<CreateVault />);
+
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: "100" } });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it("does not show warning when wallet is disconnected", () => {
+    mockUseWallet.mockReturnValue({ balance: null, balanceStatus: 'idle' } as ReturnType<typeof useWallet>);
+    render(<CreateVault />);
+
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: "100" } });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it("does not show warning when balanceStatus is no_trustline", () => {
+    mockUseWallet.mockReturnValue({ balance: null, balanceStatus: 'no_trustline' } as ReturnType<typeof useWallet>);
+    render(<CreateVault />);
+
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: "100" } });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 });

--- a/src/utils/__tests__/vaultValidation.test.ts
+++ b/src/utils/__tests__/vaultValidation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  exceedsBalance,
   isFutureDeadline,
   isValidStellarAddress,
   isValidUsdcAmount,
@@ -81,5 +82,36 @@ describe('vaultValidation', () => {
         now,
       ),
     ).toEqual({});
+  });
+});
+
+describe('exceedsBalance', () => {
+  it('returns true when amount is greater than balance', () => {
+    expect(exceedsBalance('200', '100')).toBe(true);
+  });
+
+  it('returns false when amount equals balance', () => {
+    expect(exceedsBalance('100', '100')).toBe(false);
+  });
+
+  it('returns false when amount is less than balance', () => {
+    expect(exceedsBalance('50', '100')).toBe(false);
+  });
+
+  it('returns false when balance is null (unknown)', () => {
+    expect(exceedsBalance('100', null)).toBe(false);
+  });
+
+  it('returns false when amount is not a finite number', () => {
+    expect(exceedsBalance('abc', '100')).toBe(false);
+  });
+
+  it('returns false when balance is not a finite number', () => {
+    expect(exceedsBalance('100', 'abc')).toBe(false);
+  });
+
+  it('handles decimal amounts correctly', () => {
+    expect(exceedsBalance('100.01', '100')).toBe(true);
+    expect(exceedsBalance('99.99', '100')).toBe(false);
   });
 });

--- a/src/utils/vaultValidation.ts
+++ b/src/utils/vaultValidation.ts
@@ -57,3 +57,16 @@ export function validateCreateVault(
 export function hasCreateVaultErrors(errors: CreateVaultErrors): boolean {
   return Object.keys(errors).length > 0;
 }
+
+/**
+ * Returns true when amount is a valid positive number that strictly exceeds the
+ * available balance. Returns false when either value is not a finite number so
+ * the caller can treat an unknown balance as non-blocking.
+ */
+export function exceedsBalance(amount: string, balance: string | null): boolean {
+  if (balance === null) return false;
+  const a = Number(amount);
+  const b = Number(balance);
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
+  return a > b;
+}


### PR DESCRIPTION
Closes #290

- Add exceedsBalance(amount, balance) helper to vaultValidation.ts
- Read balance/balanceStatus from useWallet() in CreateVault.tsx
- Show inline soft warning when amount > balance and balanceStatus === 'success'
- Submit button not disabled; balance check is advisory only
- Update vaultValidation.test.ts with exceedsBalance edge cases
- Update CreateVault.test.tsx with useWallet mock and balance warning tests
- Document in design-system/documentation/wallet-balance.md
closes #273