### PR TITLE
feat: add USDC trustline banner driven by wallet balanceStatus

### DIFF
--- a/design-system/documentation/wallet-balance.md
+++ b/design-system/documentation/wallet-balance.md
@@ -1,10 +1,62 @@
-# Wallet USDC Balance
+# Wallet Balance
 
-Connected wallets display the Circle USDC trustline balance for the active Stellar network.
+## Overview
 
-- `TESTNET` accounts query `https://horizon-testnet.stellar.org`.
-- `PUBLIC` accounts query `https://horizon.stellar.org`.
-- The balance helper only accepts the configured Circle USDC issuer for the active network.
-- Accounts without that USDC trustline show `0.00 USDC` with a no-trustline note.
-- Horizon request failures and missing accounts show a balance-unavailable state instead of a stale or mocked value.
-- The dropdown renders a loading state while the Horizon request is in flight.
+`WalletContext` exposes `balance`, `balanceStatus`, and `balanceError` derived
+from a live Horizon account query. Components read these values through
+`useWallet()` to surface balance-related UI.
+
+## balanceStatus values
+
+| Value | Meaning |
+|---|---|
+| `idle` | Wallet not connected; no query issued. |
+| `loading` | Balance fetch in progress. |
+| `success` | USDC trustline found; `balance` holds the current amount. |
+| `no_trustline` | Account exists but has no USDC trustline. |
+| `error` | Horizon request failed; `balanceError` contains the message. |
+
+## TrustlineBanner
+
+`src/components/TrustlineBanner.tsx` renders a dismissible warning banner when
+`balanceStatus === 'no_trustline'` and the wallet is connected. It displays the
+network-specific USDC issuer address from `USDC_ISSUERS[network]` in
+`src/utils/horizon.ts` so the user knows exactly which asset to trust.
+
+- Uses `var(--warning)` and `var(--surface)` design tokens — no hardcoded colors.
+- Dismissible per session via local React state (re-appears on page reload).
+- Mounted globally in `Layout.tsx` so every page benefits.
+
+### Usage
+
+The banner mounts automatically via `Layout`. No extra wiring is needed in
+individual pages.
+
+```tsx
+// Layout.tsx (already wired)
+import { TrustlineBanner } from './TrustlineBanner';
+// ...
+<TrustlineBanner />
+```
+
+## Balance-aware CreateVault
+
+`src/pages/CreateVault.tsx` reads `balance` and `balanceStatus` from
+`useWallet()` and shows a non-blocking inline warning when the entered amount
+exceeds the available balance.
+
+- Warning is soft: the submit button is **not** disabled by an insufficient
+  balance.
+- Only shown when `balanceStatus === 'success'` (known, positive balance).
+- Powered by `exceedsBalance(amount, balance)` in
+  `src/utils/vaultValidation.ts`.
+
+### exceedsBalance helper
+
+```ts
+exceedsBalance(amount: string, balance: string | null): boolean
+```
+
+Returns `true` only when both values parse as finite numbers and `amount > balance`.
+Returns `false` for `null` balance, unparseable strings, or equal values, making
+it safe to call when the balance has not yet loaded.

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import { WalletConnectButton } from "./Wallet/WalletConnectButton";
 import MobileDrawer from "./MobileDrawer";
 import NavLink from "./NavLink";
 import { Text } from "./Text";
+import { TrustlineBanner } from "./TrustlineBanner";
 import "./Layout.css";
 
 interface LayoutProps {
@@ -99,6 +100,7 @@ export default function Layout({ children }: LayoutProps) {
         </button>
         <MobileDrawer isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)} />
       </header>
+      <TrustlineBanner />
 
       <main
         {...backgroundA11yProps}

--- a/src/components/TrustlineBanner.tsx
+++ b/src/components/TrustlineBanner.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { useWallet } from '../context/WalletContext';
+import { USDC_ISSUERS } from '../utils/horizon';
+
+export function TrustlineBanner() {
+  const { address, network, balanceStatus } = useWallet();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!address || balanceStatus !== 'no_trustline' || dismissed) return null;
+
+  const issuer = network ? USDC_ISSUERS[network] : '';
+
+  return (
+    <div
+      role="alert"
+      style={{
+        background: 'var(--warning)',
+        color: 'var(--surface)',
+        padding: '0.75rem 1rem',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: '1rem',
+        flexWrap: 'wrap',
+      }}
+    >
+      <span>
+        Your wallet has no USDC trustline. To receive USDC, add a trustline to{' '}
+        <strong>{issuer}</strong> using Stellar Laboratory or your wallet app.
+      </span>
+      <button
+        type="button"
+        aria-label="Dismiss trustline banner"
+        onClick={() => setDismissed(true)}
+        style={{
+          background: 'transparent',
+          border: 'none',
+          color: 'var(--surface)',
+          cursor: 'pointer',
+          fontWeight: 600,
+          fontSize: '1rem',
+          lineHeight: 1,
+        }}
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -7,6 +7,10 @@ vi.mock('../Wallet/WalletConnectButton', () => ({
   WalletConnectButton: () => <button type="button">Connect wallet</button>,
 }));
 
+vi.mock('../TrustlineBanner', () => ({
+  TrustlineBanner: () => null,
+}));
+
 // MobileDrawer uses FocusTrap only when open; mock it so any accidental open
 // in these tests doesn't break due to missing DOM focus targets.
 vi.mock('focus-trap-react', () => ({

--- a/src/components/__tests__/MobileDrawer.test.tsx
+++ b/src/components/__tests__/MobileDrawer.test.tsx
@@ -20,6 +20,10 @@ vi.mock('../Wallet/WalletConnectButton', () => ({
   WalletConnectButton: () => <button type="button">Connect wallet</button>,
 }));
 
+vi.mock('../TrustlineBanner', () => ({
+  TrustlineBanner: () => null,
+}));
+
 function renderOpenDrawer(onClose = vi.fn()) {
   render(
     <MemoryRouter>

--- a/src/components/__tests__/TrustlineBanner.test.tsx
+++ b/src/components/__tests__/TrustlineBanner.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TrustlineBanner } from '../TrustlineBanner';
+
+vi.mock('../../context/WalletContext', () => ({
+  useWallet: vi.fn(),
+}));
+
+import { useWallet } from '../../context/WalletContext';
+const mockUseWallet = vi.mocked(useWallet);
+
+const TESTNET_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+const PUBLIC_ISSUER = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+
+describe('TrustlineBanner', () => {
+  it('shows the banner when connected and balanceStatus is no_trustline', () => {
+    mockUseWallet.mockReturnValue({
+      address: 'GABC',
+      network: 'TESTNET',
+      balanceStatus: 'no_trustline',
+    } as ReturnType<typeof useWallet>);
+
+    render(<TrustlineBanner />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(TESTNET_ISSUER)).toBeInTheDocument();
+  });
+
+  it('shows the PUBLIC network issuer when on PUBLIC', () => {
+    mockUseWallet.mockReturnValue({
+      address: 'GABC',
+      network: 'PUBLIC',
+      balanceStatus: 'no_trustline',
+    } as ReturnType<typeof useWallet>);
+
+    render(<TrustlineBanner />);
+
+    expect(screen.getByText(PUBLIC_ISSUER)).toBeInTheDocument();
+  });
+
+  it('hides the banner when balanceStatus is success', () => {
+    mockUseWallet.mockReturnValue({
+      address: 'GABC',
+      network: 'TESTNET',
+      balanceStatus: 'success',
+    } as ReturnType<typeof useWallet>);
+
+    render(<TrustlineBanner />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('hides the banner when wallet is disconnected (no address)', () => {
+    mockUseWallet.mockReturnValue({
+      address: null,
+      network: null,
+      balanceStatus: 'no_trustline',
+    } as ReturnType<typeof useWallet>);
+
+    render(<TrustlineBanner />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('dismisses the banner for the session when the dismiss button is clicked', () => {
+    mockUseWallet.mockReturnValue({
+      address: 'GABC',
+      network: 'TESTNET',
+      balanceStatus: 'no_trustline',
+    } as ReturnType<typeof useWallet>);
+
+    render(<TrustlineBanner />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss trustline banner/i }));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('does not show the banner when balanceStatus is idle', () => {
+    mockUseWallet.mockReturnValue({
+      address: 'GABC',
+      network: 'TESTNET',
+      balanceStatus: 'idle',
+    } as ReturnType<typeof useWallet>);
+
+    render(<TrustlineBanner />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('does not show the banner when balanceStatus is error', () => {
+    mockUseWallet.mockReturnValue({
+      address: 'GABC',
+      network: 'TESTNET',
+      balanceStatus: 'error',
+    } as ReturnType<typeof useWallet>);
+
+    render(<TrustlineBanner />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #273

- Add TrustlineBanner component that renders when balanceStatus === 'no_trustline'
- Shows network-specific USDC issuer address from USDC_ISSUERS[network]
- Uses var(--warning)/var(--surface) design tokens; dismissible per session
- Mount in Layout.tsx so it is globally visible
- Add TrustlineBanner.test.tsx covering all edge cases
- Mock TrustlineBanner in Layout and MobileDrawer tests to avoid WalletProvider dependency
- Document in design-system/documentation/wallet-balance.md
closes #293