### PR TITLE
feat: date-range and milestone filters for validation history (#282)

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,6 +2,20 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import React from 'react';
 
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  window.matchMedia = (query: string): MediaQueryList =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as MediaQueryList;
+}
+
 vi.mock('focus-trap-react', () => ({
   default: ({
     children,


### PR DESCRIPTION
Closes #282 

date-range and milestone filtering for the verifier `ValidationHistory` page.

The filter logic, UI controls, tests, and docs for this feature were in place, but the `ValidationHistory` test suite could not run: the page renders `StatusChip` → `Tooltip`, which calls `window.matchMedia`. jsdom does not implement `matchMedia` and the shared test setup never mocked it, so every test threw before asserting.

This PR adds a `window.matchMedia` stub to `src/setupTests.ts` so the suite runs.

## Behavior (per issue requirements)

- `filterValidationHistory` accepts optional `{ from, to, milestone }`.
- Date-range inputs and milestone filter in `ValidationHistory.tsx`.
- Pagination resets to page 1 on any filter change.
- Status/search filters unchanged.

## Testing

- `paginate.test.ts` — 21/21 pass (open-ended ranges, inclusive bounds, no-match, combined filters).
- `ValidationHistory.test.tsx` — 17/17 pass (date range, milestone, page-1 reset, combined with status/search).
- No regressions: the `matchMedia` stub strictly reduces pre-existing failures across other Tooltip/Theme-dependent suites.