### PR TITLE
test: cover NavLink trailing-slash active-state edge cases

### DIFF
--- a/src/components/__tests__/NavLink.test.tsx
+++ b/src/components/__tests__/NavLink.test.tsx
@@ -75,4 +75,20 @@ describe('NavLink', () => {
     renderNav('/vaults', '/vault');
     expect(screen.getByRole('link')).not.toHaveClass('active');
   });
+
+  it('is inactive when to has a trailing slash the current path lacks', () => {
+    // path "/vaults" does not start with "/vaults/"
+    renderNav('/vaults/', '/vaults');
+    const link = screen.getByRole('link');
+    expect(link).not.toHaveClass('active');
+    expect(link).not.toHaveAttribute('aria-current');
+  });
+
+  it('is active when the current path adds a trailing slash to to', () => {
+    // path "/vaults/" starts with "/vaults"
+    renderNav('/vaults', '/vaults/');
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('active');
+    expect(link).toHaveAttribute('aria-current', 'page');
+  });
 });


### PR DESCRIPTION

closes #321 

  adds RTL coverage for `NavLink`'s active-state and `aria-current` behaviour.

  `src/components/NavLink.tsx` computes an `active` class and sets `aria-current="page"` from `useLocation().pathname`. This is the primary
  navigation affordance, and its active/current logic is exactly the kind of thing that silently breaks on a router upgrade. This PR adds
  focused tests for that logic under `MemoryRouter`, including the trailing-slash edge cases called out in the issue.

  ## What's covered

  All tests render `NavLink` inside a `MemoryRouter` with controllable `initialEntries`:

  - **Active match** — when `to` matches the current path, the link has the `active` class and `aria-current="page"`.
  - **Non-match** — on a non-matching path, the `active` class is absent and `aria-current` is undefined.
  - **Prop forwarding** — `className` and `ariaLabel` are forwarded to the rendered link.
  - **Trimmed class string** — no leading/trailing spaces (verified for empty-className + active, and empty-className + inactive).
  - **Root vs non-root matching** — `/` is active only on the exact `/` path; non-root links use prefix matching.
  - **Exact vs partial path match** — a nested path (`/vaults/123`) activates `/vaults`, while `/vault` does not activate `/vaults`.
  - **Trailing-slash differences** — `to="/vaults/"` with path `/vaults` stays inactive; path `/vaults/` activates `to="/vaults"`.

  ## Testing

  npm run test -- src/components/tests/NavLink.test.tsx

  ✅ 12/12 tests pass. No source changes — test-only, no regressions to navigation highlighting.
