### PR TITLE
Test/safelink inert rendering coverage

### DIFF
--- a/src/components/SafeLink.tsx
+++ b/src/components/SafeLink.tsx
@@ -16,12 +16,14 @@ export const SafeLink: React.FC<SafeLinkProps> = ({ href, children, ...props }) 
     return <span title={`Rejected URL: ${href}`}>[Invalid Link]</span>;
   }
 
+  // Spread caller props first so the enforced safety attributes below cannot
+  // be overridden (e.g. a caller passing rel="" or target="_self").
   return (
     <a
+      {...props}
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      {...props}
     >
       {children}
     </a>

--- a/src/components/__tests__/NavLink.test.tsx
+++ b/src/components/__tests__/NavLink.test.tsx
@@ -75,4 +75,20 @@ describe('NavLink', () => {
     renderNav('/vaults', '/vault');
     expect(screen.getByRole('link')).not.toHaveClass('active');
   });
+
+  it('is inactive when to has a trailing slash the current path lacks', () => {
+    // path "/vaults" does not start with "/vaults/"
+    renderNav('/vaults/', '/vaults');
+    const link = screen.getByRole('link');
+    expect(link).not.toHaveClass('active');
+    expect(link).not.toHaveAttribute('aria-current');
+  });
+
+  it('is active when the current path adds a trailing slash to to', () => {
+    // path "/vaults/" starts with "/vaults"
+    renderNav('/vaults', '/vaults/');
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('active');
+    expect(link).toHaveAttribute('aria-current', 'page');
+  });
 });

--- a/src/components/__tests__/SafeLink.test.tsx
+++ b/src/components/__tests__/SafeLink.test.tsx
@@ -1,25 +1,90 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
 import { SafeLink } from '../SafeLink';
 
 describe('SafeLink component', () => {
-  test('renders as anchor tag for safe URLs', () => {
-    const url = 'https://example.com';
-    render(<SafeLink href={url}>Link</SafeLink>);
-    const link = screen.getByRole('link', { name: /link/i });
-    expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute('href', url);
-    expect(link).toHaveAttribute('target', '_blank');
-    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  describe('safe URLs', () => {
+    test('renders an anchor with enforced target/rel for https URLs', () => {
+      const url = 'https://example.com';
+      render(<SafeLink href={url}>Link</SafeLink>);
+      const link = screen.getByRole('link', { name: /link/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', url);
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    test('renders an anchor for http URLs', () => {
+      const url = 'http://example.com';
+      render(<SafeLink href={url}>Link</SafeLink>);
+      expect(screen.getByRole('link', { name: /link/i })).toHaveAttribute('href', url);
+    });
+
+    test('accepts a valid URL with a query string', () => {
+      const url = 'https://example.com/search?q=test&page=2';
+      render(<SafeLink href={url}>Query</SafeLink>);
+      expect(screen.getByRole('link', { name: /query/i })).toHaveAttribute('href', url);
+    });
+
+    test('enforces target/rel even when the caller passes conflicting props', () => {
+      render(
+        <SafeLink href="https://example.com" target="_self" rel="opener">
+          Link
+        </SafeLink>,
+      );
+      const link = screen.getByRole('link', { name: /link/i });
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    test('forwards non-conflicting props such as className', () => {
+      render(
+        <SafeLink href="https://example.com" className="evidence-link">
+          Link
+        </SafeLink>,
+      );
+      expect(screen.getByRole('link', { name: /link/i })).toHaveClass('evidence-link');
+    });
+
+    test('renders children in the safe branch', () => {
+      render(
+        <SafeLink href="https://example.com">
+          <span>Open evidence</span>
+        </SafeLink>,
+      );
+      expect(screen.getByText('Open evidence')).toBeInTheDocument();
+    });
   });
 
-  test('renders as span for unsafe URLs', () => {
-    const url = 'javascript:alert(1)';
-    render(<SafeLink href={url}>Link</SafeLink>);
-    const link = screen.queryByRole('link', { name: /link/i });
-    expect(link).not.toBeInTheDocument();
-    const span = screen.getByText('[Invalid Link]');
-    expect(span).toBeInTheDocument();
-    expect(span).toHaveAttribute('title', `Rejected URL: ${url}`);
+  describe('unsafe URLs render inert [Invalid Link]', () => {
+    const unsafeUrls: Array<[string, string]> = [
+      ['javascript: scheme', 'javascript:alert(1)'],
+      ['data: scheme', 'data:text/html,<script>alert(1)</script>'],
+      ['empty string', ''],
+      ['whitespace only', '   '],
+      ['userinfo-bearing', 'https://trusted.com@evil.com'],
+      ['userinfo with password', 'https://user:pass@example.com'],
+      ['missing scheme', 'example.com/evidence'],
+    ];
+
+    test.each(unsafeUrls)('rejects %s as an inert span with rejected-URL title', (_label, url) => {
+      render(<SafeLink href={url}>Link</SafeLink>);
+
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+      const span = screen.getByText('[Invalid Link]');
+      expect(span).toBeInTheDocument();
+      expect(span).toHaveAttribute('title', `Rejected URL: ${url}`);
+    });
+
+    test('does not render caller children in the unsafe branch', () => {
+      render(
+        <SafeLink href="javascript:alert(1)">
+          <span>Open evidence</span>
+        </SafeLink>,
+      );
+      expect(screen.queryByText('Open evidence')).not.toBeInTheDocument();
+      expect(screen.getByText('[Invalid Link]')).toBeInTheDocument();
+    });
   });
 });

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -12,7 +12,15 @@ export function normalizeEvidenceUrl(value: string): string | null {
 
   try {
     const parsed = new URL(trimmed)
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? trimmed : null
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return null
+    }
+    // Reject userinfo-bearing URLs (e.g. https://trusted.com@evil.com) — a
+    // common credential/phishing vector that hides the real host.
+    if (parsed.username || parsed.password) {
+      return null
+    }
+    return trimmed
   } catch {
     return null
   }


### PR DESCRIPTION
closes #365 
 

 tighten unit-test coverage for `SafeLink`'s inert rendering and `rel`/`target` attribute enforcement across the full
  unsafe-scheme matrix.

  While extending the tests, the issue's required assertions surfaced two real link-safety gaps that had to be fixed for the assertions to
  hold. Both are small, security-positive changes.

  ## Changes

  ### `src/components/SafeLink.tsx` — enforce safety attributes
  Previously `{...props}` was spread **after** `target`/`rel`, so a caller could override them (e.g. `rel=""` or `target="_self"`),
  silently defeating tab-nabbing protection. The spread now comes **before** the enforced attributes, so `target="_blank"` and
  `rel="noopener noreferrer"` always win while non-conflicting props (e.g. `className`) still pass through.

  ### `src/utils/url.ts` — reject userinfo-bearing URLs
  `normalizeEvidenceUrl` accepted URLs like `https://trusted.com@evil.com` because the protocol was `https:`. Userinfo
  (`username`/`password`) is now rejected — it's a common credential/phishing vector that hides the real host.

  ### `src/components/__tests__/SafeLink.test.tsx` — expanded coverage
  - **Unsafe-scheme matrix** (`test.each`): `javascript:`, `data:`, empty, whitespace-only, missing-scheme, and userinfo-bearing URLs all
  render the inert `[Invalid Link]` span with the `Rejected URL: …` title.
  - **Safe URLs**: `http`/`https` (incl. query strings) render an `<a>` with `target="_blank"` and `rel="noopener noreferrer"`.
  - **Conflicting-props case**: caller-supplied `target`/`rel` cannot override the enforced values.
  - **Prop forwarding**: non-conflicting props such as `className` are forwarded.
  - **Children**: rendered in the safe branch; not rendered in the unsafe branch.

  ## Testing

  npm run test -- src/components/tests/SafeLink.test.tsx src/utils/tests/url.test.ts

  - `SafeLink.test.tsx` — 14 passing
  - `url.test.ts` — 10 passing
  - Consumers (`ValidationDetail`, `ConfirmationModal`, `EvidenceUpload`) — 49 passing, no regressions in link safety.
