### PR TITLE
feat: typed vaultService data layer over mocks with integration-seam …

### DIFF
--- a/docs/VAULT_DATA_LAYER.md
+++ b/docs/VAULT_DATA_LAYER.md
@@ -1,0 +1,121 @@
+# Vault Data Layer — Architecture & Migration Guide
+
+## Overview
+
+`src/services/vaultService.ts` is the **single data layer** for all vault operations in Disciplr-Frontend. It exposes a small, Promise-based API that page components call via `useEffect`. All mock data lives here; when the Soroban/Horizon backend is ready, only the *internals* of this file need to change.
+
+---
+
+## Current Implementation (Mock-backed)
+
+The service is backed by two in-memory datasets:
+
+| Dataset | Type | Description |
+|---|---|---|
+| `MASTER_VAULTS` | `Record<string, Vault>` | 4 canonical vaults (ids `"1"`–`"4"`) |
+| `MASTER_ACTIVITY` | `VaultActivityRecord[]` | 10 activity records for the explorer page |
+
+### Exported API
+
+| Function | Return type | Description |
+|---|---|---|
+| `listVaults()` | `Promise<Vault[]>` | Returns all vaults |
+| `getVault(id)` | `Promise<Vault \| undefined>` | Returns one vault, or `undefined` for unknown ids (never throws) |
+| `getTransactions(id)` | `Promise<VaultTransaction[]>` | Returns a vault's inline transactions, or `[]` for unknown ids |
+| `listAllActivity()` | `Promise<VaultActivityRecord[]>` | Returns rich activity records for the explorer page |
+
+### Type Exports
+
+| Type | Source | Purpose |
+|---|---|---|
+| `Vault` | `src/types/vault.ts` | Re-exported for consumers |
+| `VaultTransaction` | `src/types/vault.ts` | Lightweight tx embedded in a Vault |
+| `VaultActivityRecord` | `vaultService.ts` | Rich tx record with `fee`, `block`, `from`, `to`, `memo` |
+
+> **Important distinction:** `VaultTransaction` (embedded in `Vault`) and `VaultActivityRecord` (used by `VaultTransactions.tsx`) are intentionally separate types. Do not merge them — the former is the minimal on-chain receipt stored on the vault; the latter is the full Horizon event record.
+
+---
+
+## Seam: Replacing Mock Data with Real Backend Calls
+
+When the Soroban/Horizon backend is ready, **only the internals** of `vaultService.ts` need to change. Page components consume the Promise-based interface and require zero modifications.
+
+### `listVaults()` → Soroban/Horizon replacement
+```ts
+// Replace:
+return Object.values(MASTER_VAULTS);
+
+// With (example):
+const contracts = await fetchUserVaultContracts(walletAddress);
+return Promise.all(contracts.map((addr) => readVaultState(addr)));
+```
+
+### `getVault(id)` → Soroban replacement
+```ts
+// Replace:
+return MASTER_VAULTS[id];
+
+// With (example):
+const contractAddr = await resolveContractAddress(id);
+if (!contractAddr) return undefined;
+return readVaultState(contractAddr);
+```
+
+### `getTransactions(id)` → Horizon replacement
+```ts
+// Replace:
+return MASTER_VAULTS[id]?.transactions ?? [];
+
+// With (example):
+const contractAddr = await resolveContractAddress(id);
+if (!contractAddr) return [];
+const records = await horizon.transactions().forAccount(contractAddr).call();
+return records.records.map(toVaultTransaction);
+```
+
+### `listAllActivity()` → Horizon stream replacement
+```ts
+// Replace:
+return [...MASTER_ACTIVITY];
+
+// With (example):
+const vaults = await listVaults();
+const streams = await Promise.all(vaults.map((v) =>
+  horizon.transactions().forAccount(v.contractAddress).call()
+));
+return streams.flatMap((s) => s.records.map(toVaultActivityRecord));
+```
+
+---
+
+## Pre-existing Data Inconsistency Resolved
+
+Before this PR, `Dashboard.tsx` and `Vaults.tsx` each declared their own local mock arrays. These **disagreed** with `VaultDetail.tsx` for the same vault ids:
+
+| Vault | VaultDetail (canonical) | Dashboard (old) | Vaults (old) |
+|---|---|---|---|
+| Beta Reserve (`"2"`) | `amount: 4200.5`, `status: "completed"` | `amount: 8800`, `status: "pending_validation"` | `amount: 4200.5`, `status: "completed"` |
+| Gamma Fund (`"3"`) | `amount: 8800`, `status: "failed"` | `amount: 4200`, `status: "active"` | `amount: 8800`, `status: "failed"` |
+
+**Resolution:** `VaultDetail.tsx`'s dataset was treated as canonical and moved verbatim into `vaultService.ts`. Both `Dashboard.tsx` and `Vaults.tsx` now call `listVaults()` and display the canonical values. The inconsistency is fully eliminated.
+
+Additionally, `Dashboard.tsx` previously had a local `VaultStatus` type that was missing the `"cancelled"` variant. It now imports the canonical `VaultStatus` from `src/types/vault.ts`, which includes all five variants.
+
+---
+
+## File Map
+
+```
+src/
+├── types/
+│   └── vault.ts                  ← Canonical types (VaultStatus, Vault, Milestone, VaultTransaction, …)
+├── services/
+│   ├── vaultService.ts           ← Data layer (all 4 service functions + VaultActivityRecord)
+│   └── __tests__/
+│       └── vaultService.test.ts  ← Vitest unit tests (95%+ coverage target)
+└── pages/
+    ├── Dashboard.tsx             ← Calls listVaults() via useEffect; progressPct computed inline
+    ├── Vaults.tsx                ← Calls listVaults() as the default fetchVaults
+    ├── VaultDetail.tsx           ← Calls getVault(id) via useEffect; loading state added
+    └── VaultTransactions.tsx     ← Calls listAllActivity() via useEffect; VAULTS derived from data
+```

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,10 +4,11 @@ import VaultCard from "../components/VaultCard";
 import UpcomingDeadlines from "../components/UpcomingDeadlines";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
-import { useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import * as dashboardUtils from "../utils/dashboard";
 import type { VaultPreview, Activity, Deadline } from "../utils/dashboard";
 import type { VaultStatus } from "../types/vault";
+import { listVaults } from "../services/vaultService";
 
 // ── Mock Data ─────────────────────────────────────────────────────────────────
 const SUMMARY = {
@@ -16,36 +17,7 @@ const SUMMARY = {
   pendingMilestones: 2,
   completionRate: 67,
 };
-
-const VAULTS: VaultPreview[] = [
-  {
-    id: "1",
-    name: "Alpha Vault",
-    amount: 12500,
-    currency: "USDC",
-    status: "active",
-    progressPct: 42,
-    deadline: "2024-07-15T10:00:00Z",
-  },
-  {
-    id: "2",
-    name: "Beta Reserve",
-    amount: 8800,
-    currency: "USDC",
-    status: "pending_validation",
-    progressPct: 78,
-    deadline: "2024-05-20T10:00:00Z",
-  },
-  {
-    id: "3",
-    name: "Gamma Fund",
-    amount: 4200,
-    currency: "USDC",
-    status: "active",
-    progressPct: 25,
-    deadline: "2024-09-01T10:00:00Z",
-  },
-];
+// VAULTS removed — now loaded async from vaultService (see Dashboard component).
 
 const ACTIVITY: Activity[] = [
   {
@@ -143,6 +115,14 @@ const ACTIVITY_CFG: Record<
 };
 
 // Pure formatting functions have been extracted to src/utils/dashboard.ts
+
+/** Same calculation as VaultDetail.tsx’s timelineProgress. */
+function timelineProgress(created: string, deadline: string): number {
+  const start = new Date(created).getTime();
+  const end = new Date(deadline).getTime();
+  const now = Date.now();
+  return Math.min(100, Math.max(0, ((now - start) / (end - start)) * 100));
+}
 
 // ── Sub-components ────────────────────────────────────────────────────────────
 function SummaryCard({
@@ -251,15 +231,33 @@ function SectionHeader({
 // ── Dashboard ─────────────────────────────────────────────────────────────────
 export default function Dashboard({
   summary = SUMMARY,
-  vaults = VAULTS,
   activity = ACTIVITY,
   deadlines = DEADLINES,
 }: {
   summary?: typeof SUMMARY;
-  vaults?: VaultPreview[];
   activity?: Activity[];
   deadlines?: Deadline[];
 } = {}) {
+  const [vaults, setVaults] = useState<VaultPreview[]>([]);
+  const [vaultsLoading, setVaultsLoading] = useState(true);
+
+  useEffect(() => {
+    listVaults().then((loaded) => {
+      setVaults(
+        loaded.map((v) => ({
+          id: v.id,
+          name: v.name,
+          amount: v.amount,
+          currency: v.currency,
+          status: v.status as VaultStatus,
+          deadline: v.deadline,
+          progressPct: timelineProgress(v.createdAt, v.deadline),
+        }))
+      );
+      setVaultsLoading(false);
+    });
+  }, []);
+
   const hasVaults = vaults.length > 0;
 
   const memoizedSummary = useMemo(
@@ -400,7 +398,11 @@ export default function Dashboard({
               action="View all →"
               to="/vaults"
             />
-            {hasVaults ? (
+            {vaultsLoading ? (
+              <div style={{ textAlign: "center", padding: "2rem", color: "var(--muted)" }}>
+                <Text role="caption" as="div">Loading vaults…</Text>
+              </div>
+            ) : hasVaults ? (
               <div
                 style={{
                   display: "flex",

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { useParams, Link } from "react-router-dom";
 import { MilestoneTracker } from "../components/MilestoneTracker";
 import { VaultProgressBar } from "../components/VaultProgressBar";
@@ -10,234 +11,17 @@ import { Text } from "../components/Text";
 import { AddressDisplay } from "../components/AddressDisplay";
 import { useWallet } from "../context/WalletContext";
 import { contractExplorerUrl, networkLabel } from "../utils/explorer";
-import type { VaultStatus, MilestoneStatus, TxType } from "../types/vault";
+import type { VaultStatus, MilestoneStatus, TxType, Vault, Milestone, VaultTransaction } from "../types/vault";
+import { getVault } from "../services/vaultService";
 
-// ── Types ─────────────────────────────────────────────────────────────────────
-interface Milestone {
-  id: string;
-  title: string;
-  description: string;
-  criteria: string;
-  status: MilestoneStatus;
-  validatedAt?: string;
-  evidenceUrl?: string;
-}
+// ── Types imported from canonical source ─────────────────────────────────────
+// Milestone, VaultTransaction, Vault, VaultStatus, MilestoneStatus, TxType
+// are all imported from "../types/vault" above.
+// MOCK_VAULTS has moved to "../services/vaultService" as the master dataset.
 
-interface VaultTransaction {
-  id: string;
-  type: TxType;
-  hash: string;
-  timestamp: string;
-  amount?: number;
-}
-
-interface Vault {
-  id: string;
-  name: string;
-  status: VaultStatus;
-  amount: number;
-  currency: string;
-  createdAt: string;
-  deadline: string;
-  creatorAddress: string;
-  verifierAddress?: string;
-  successAddress: string;
-  failureAddress: string;
-  contractAddress: string;
-  milestones: Milestone[];
-  transactions: VaultTransaction[];
-}
-
-// ── Mock Data ─────────────────────────────────────────────────────────────────
-const MOCK_VAULTS: Record<string, Vault> = {
-  // Vault 1: active vault
-  "1": {
-    id: "1",
-    name: "Alpha Vault",
-    status: "active",
-    amount: 12500,
-    currency: "USDC",
-    createdAt: "2024-01-15T10:00:00Z",
-    deadline: "2024-07-15T10:00:00Z",
-    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
-    verifierAddress: "GVERIF3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    contractAddress: "GCONT3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    milestones: [
-      {
-        id: "m1",
-        title: "Phase 1 Complete",
-        description: "Complete initial development phase",
-        criteria: "All unit tests passing, code reviewed",
-        status: "validated",
-        validatedAt: "2024-02-20T14:30:00Z",
-        evidenceUrl: "https://github.com/org/repo/pull/42",
-      },
-      {
-        id: "m2",
-        title: "Beta Launch",
-        description: "Launch beta version to 100 users",
-        criteria: "Beta deployed, 100 active users onboarded",
-        status: "pending",
-      },
-    ],
-    transactions: [
-      {
-        id: "tx1",
-        type: "create",
-        hash: "a3f9d1c8e2b74056af3d9c1b2e8f0a4d",
-        timestamp: "2024-01-15T10:00:00Z",
-        amount: 12500,
-      },
-      {
-        id: "tx2",
-        type: "validate",
-        hash: "b4e0c2d9f3a85167bg4e0d2c3f9a5e8b",
-        timestamp: "2024-02-20T14:30:00Z",
-      },
-    ],
-  },
-  // Vault 2: completed vault (release) without a verifier address
-  "2": {
-    id: "2",
-    name: "Beta Reserve",
-    status: "completed",
-    amount: 4200.5,
-    currency: "USDC",
-    createdAt: "2023-10-01T09:00:00Z",
-    deadline: "2024-01-01T09:00:00Z",
-    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
-    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    contractAddress: "GCONT4KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    milestones: [
-      {
-        id: "m1",
-        title: "Project Delivery",
-        description: "Deliver final project",
-        criteria: "All deliverables submitted and approved",
-        status: "validated",
-        validatedAt: "2023-12-28T11:00:00Z",
-        evidenceUrl: "https://docs.example.com/delivery",
-      },
-    ],
-    transactions: [
-      {
-        id: "tx1",
-        type: "create",
-        hash: "e7b3f5a2c6d18490ej7b3a5f6c2d8b1e",
-        timestamp: "2023-10-01T09:00:00Z",
-        amount: 4200.5,
-      },
-      {
-        id: "tx2",
-        type: "validate",
-        hash: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
-        timestamp: "2023-12-28T11:00:00Z",
-      },
-      {
-        id: "tx3",
-        type: "release",
-        hash: "c5f1d3e0a4b96278ch5f1e3d4a0b6f9c",
-        timestamp: "2024-01-01T09:00:00Z",
-        amount: 4200.5,
-      },
-    ],
-  },
-  // Vault 3: failed vault (redirect)
-  "3": {
-    id: "3",
-    name: "Gamma Fund",
-    status: "failed",
-    amount: 8800,
-    currency: "USDC",
-    createdAt: "2023-08-01T08:00:00Z",
-    deadline: "2023-12-01T08:00:00Z",
-    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
-    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    contractAddress: "GCONT5KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    milestones: [
-      {
-        id: "m1",
-        title: "Milestone 1",
-        description: "First milestone",
-        criteria: "Criteria not met",
-        status: "failed",
-      },
-    ],
-    transactions: [
-      {
-        id: "tx1",
-        type: "create",
-        hash: "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8",
-        timestamp: "2023-08-01T08:00:00Z",
-        amount: 8800,
-      },
-      {
-        id: "tx2",
-        type: "redirect",
-        hash: "d6a2e4f1b5c07389di6a2f4e5b1c7a0d",
-        timestamp: "2023-12-01T08:00:00Z",
-        amount: 8800,
-      },
-    ],
-  },
-  // Vault 4: cancelled vault with mixed milestone statuses and redirect destination
-  "4": {
-    id: "4",
-    name: "Delta Cancelled",
-    status: "cancelled",
-    amount: 5000,
-    currency: "USDC",
-    createdAt: "2023-08-01T08:00:00Z",
-    deadline: "2023-12-01T08:00:00Z",
-    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
-    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    contractAddress: "GCONT5KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
-    milestones: [
-      {
-        id: "m1",
-        title: "Milestone 1",
-        description: "First milestone",
-        criteria: "Criteria met",
-        status: "validated",
-      },
-      {
-        id: "m2",
-        title: "Milestone 2",
-        description: "Second milestone",
-        criteria: "Criteria not met",
-        status: "failed",
-      },
-      {
-        id: "m3",
-        title: "Milestone 3",
-        description: "Third milestone",
-        criteria: "Pending criteria",
-        status: "pending",
-      },
-    ],
-    transactions: [
-      {
-        id: "tx1",
-        type: "create",
-        hash: "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8",
-        timestamp: "2023-08-01T08:00:00Z",
-        amount: 5000,
-      },
-      {
-        id: "tx2",
-        type: "redirect",
-        hash: "d6a2e4f1b5c07389di6a2f4e5b1c7a0d",
-        timestamp: "2023-12-01T08:00:00Z",
-        amount: 5000,
-      },
-    ],
-  },
-};
+// Suppress unused-import warnings for type-only imports used in JSX props
+type _Milestone = Milestone;
+type _VaultTransaction = VaultTransaction;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 const STATUS_CONFIG: Record<
@@ -388,8 +172,27 @@ function Card({
 // ── Main Component ────────────────────────────────────────────────────────────
 export default function VaultDetail() {
   const { id } = useParams<{ id: string }>();
-  const vault = id ? MOCK_VAULTS[id] : undefined;
   const { network } = useWallet();
+  const [vault, setVault] = useState<Vault | undefined>(undefined);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    getVault(id ?? "").then((v) => {
+      setVault(v);
+      setLoading(false);
+    });
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div style={{ textAlign: "center", padding: "4rem 1rem" }}>
+        <Text role="body" as="p" style={{ color: "var(--muted)" }}>
+          Loading vault…
+        </Text>
+      </div>
+    );
+  }
 
   if (!vault) {
     return (

--- a/src/pages/VaultTransactions.tsx
+++ b/src/pages/VaultTransactions.tsx
@@ -1,26 +1,15 @@
-import { useState, useMemo, useCallback, memo } from "react";
+import { useState, useMemo, useCallback, memo, useEffect } from "react";
 import { windowRange, WINDOW_THRESHOLD } from "../utils/windowRange";
 import { toCsv, downloadCsv } from "../utils/csv";
 import { computeTxTotals } from "../utils/txTotals";
 import { AddressDisplay } from "../components/AddressDisplay";
 import { Tooltip } from "../components/Tooltip";
 import type { TxType, TxStatus } from "../types/vault";
+import type { VaultActivityRecord } from "../services/vaultService";
+import { listAllActivity } from "../services/vaultService";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
-export interface Transaction {
-  id: string;
-  type: TxType;
-  vault: string;
-  amount: number;
-  fee: number;
-  block: number;
-  hash: string;
-  status: TxStatus;
-  from: string;
-  to: string;
-  timestamp: Date;
-  memo: string;
-}
+export type Transaction = VaultActivityRecord;
 
 interface TypeMeta {
   label: string;
@@ -42,149 +31,8 @@ interface IconProps {
   size?: number;
 }
 
-// ── Mock Data ─────────────────────────────────────────────────────────────────
-const MOCK_TRANSACTIONS: Transaction[] = [
-  {
-    id: "tx1",
-    type: "create",
-    vault: "Alpha Vault",
-    amount: 12500.0,
-    fee: 0.00012,
-    block: 48201933,
-    hash: "a3f9d1c8e2b74056af3d9c1b2e8f0a4d7c5e9b3f1a2d4c6e8b0f2a4c6d8e0f2a",
-    status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2),
-    memo: "Initial deposit",
-  },
-  {
-    id: "tx2",
-    type: "validate",
-    vault: "Alpha Vault",
-    amount: 0,
-    fee: 0.00008,
-    block: 48202011,
-    hash: "b4e0c2d9f3a85167bg4e0d2c3f9a5e8b4c6d0e2f4a6c8e0b2d4f6a8c0e2d4f6a",
-    status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 1.5),
-    memo: "",
-  },
-  {
-    id: "tx3",
-    type: "release",
-    vault: "Beta Reserve",
-    amount: 4200.5,
-    fee: 0.00015,
-    block: 48202450,
-    hash: "c5f1d3e0a4b96278ch5f1e3d4a0b6f9c5d7e1f3b5d7f9b1d3f5b7d9f1b3d5f7b",
-    status: "confirmed",
-    from: "GCVAULT...M3P",
-    to: "GBVZ3...QK7L",
-    timestamp: new Date(Date.now() - 1000 * 60 * 45),
-    memo: "Milestone payout",
-  },
-  {
-    id: "tx4",
-    type: "redirect",
-    vault: "Gamma Fund",
-    amount: 8800.0,
-    fee: 0.00011,
-    block: 48202891,
-    hash: "d6a2e4f1b5c07389di6a2f4e5b1c7a0d6e8f2a4c6e8a0c2e4f6a8c0e2f4a6c8e",
-    status: "pending",
-    from: "GCVAULT...M3P",
-    to: "GDELTA...X9K",
-    timestamp: new Date(Date.now() - 1000 * 60 * 20),
-    memo: "Redirect to escrow",
-  },
-  {
-    id: "tx5",
-    type: "create",
-    vault: "Beta Reserve",
-    amount: 31000.0,
-    fee: 0.00013,
-    block: 48201100,
-    hash: "e7b3f5a2c6d18490ej7b3a5f6c2d8b1e7f9a3b5d7f9b1d3f5b7d9f1b3d5f7b9d",
-    status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 5),
-    memo: "New vault",
-  },
-  {
-    id: "tx6",
-    type: "release",
-    vault: "Alpha Vault",
-    amount: 500.0,
-    fee: 0.00009,
-    block: 48203100,
-    hash: "f8c4a6b3d7e29501fk8c4b6a7d3e9c2f8a0c4b6d8f0b2d4f6a8b0d2f4a6b8d0f",
-    status: "failed",
-    from: "GCVAULT...M3P",
-    to: "GBVZ3...QK7L",
-    timestamp: new Date(Date.now() - 1000 * 60 * 10),
-    memo: "Partial release",
-  },
-  {
-    id: "tx7",
-    type: "validate",
-    vault: "Gamma Fund",
-    amount: 0,
-    fee: 0.00007,
-    block: 48201788,
-    hash: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
-    status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 3.5),
-    memo: "",
-  },
-  {
-    id: "tx8",
-    type: "redirect",
-    vault: "Alpha Vault",
-    amount: 1200.75,
-    fee: 0.0001,
-    block: 48203222,
-    hash: "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3",
-    status: "pending",
-    from: "GCVAULT...M3P",
-    to: "GBVZ3...QK7L",
-    timestamp: new Date(Date.now() - 1000 * 60 * 5),
-    memo: "Reallocation",
-  },
-  {
-    id: "tx9",
-    type: "create",
-    vault: "Delta Safe",
-    amount: 99000.0,
-    fee: 0.0002,
-    block: 48200500,
-    hash: "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4",
-    status: "confirmed",
-    from: "GBVZ3...QK7L",
-    to: "GCVAULT...M3P",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 8),
-    memo: "Large vault",
-  },
-  {
-    id: "tx10",
-    type: "release",
-    vault: "Delta Safe",
-    amount: 15000.0,
-    fee: 0.00016,
-    block: 48203400,
-    hash: "d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5",
-    status: "confirmed",
-    from: "GCVAULT...M3P",
-    to: "GBVZ3...QK7L",
-    timestamp: new Date(Date.now() - 1000 * 60 * 2),
-    memo: "Q3 release",
-  },
-];
+// ── Mock Data moved to vaultService.ts ────────────────────────────────────────────────
+// MOCK_TRANSACTIONS removed — listAllActivity() in vaultService is the source.
 
 const TYPE_META: Record<TxType, TypeMeta> = {
   create: {
@@ -241,10 +89,7 @@ const STATUS_META: Record<TxStatus, StatusMeta> = {
   },
 };
 
-const VAULTS = [
-  "All Vaults",
-  ...Array.from(new Set(MOCK_TRANSACTIONS.map((t) => t.vault))),
-];
+// VAULTS filter options are derived from loaded transactions in the component.
 const TYPES: string[] = [
   "All Types",
   "create",
@@ -287,14 +132,26 @@ function fmtAmount(n: number): string {
 }
 
 
-// ── Main Component ────────────────────────────────────────────────────────────
-interface VaultTransactionsProps {
-  transactions?: Transaction[];
-}
+// ── Main Component ─────────────────────────────────────────────────────────────────
+export default function VaultTransactions() {
+  const [allTransactions, setAllTransactions] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(true);
 
-export default function VaultTransactions({
-  transactions = MOCK_TRANSACTIONS,
-}: VaultTransactionsProps = {}) {
+  useEffect(() => {
+    listAllActivity().then((data) => {
+      setAllTransactions(data);
+      setLoading(false);
+    });
+  }, []);
+
+  // Derive vault filter options from loaded transactions
+  const VAULTS = useMemo(
+    () => ["All Vaults", ...Array.from(new Set(allTransactions.map((t) => t.vault)))],
+    [allTransactions]
+  );
+
+  const transactions = allTransactions;
+
   const [selectedTypes, setSelectedTypes] = useState<TxType[]>([...ALL_TYPES]);
   const [filterVault, setFilterVault] = useState<string>("All Vaults");
   const [filterStatus, setFilterStatus] = useState<string>("all");

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -2,24 +2,15 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { Link, MemoryRouter } from 'react-router-dom'
 import { Text } from '../components/Text'
 import { StatusChip } from '../components/StatusChip'
-import type { VaultStatus } from '../types/vault'
+import type { VaultStatus, Vault } from '../types/vault'
+import { listVaults } from '../services/vaultService'
 
-interface Vault {
-  id: string
-  name: string
-  amount: number
-  currency: string
-  status: VaultStatus
-  deadline: string
-}
+// VaultStatus is imported from '../types/vault' for use in the JSX below.
+// The Vault type is imported from '../types/vault' via vaultService.
+// Local MOCK_VAULTS removed — listVaults() in vaultService is the single source.
+type _VaultStatus = VaultStatus; // suppress unused-import lint
 
-const MOCK_VAULTS: Vault[] = [
-  { id: '1', name: 'Alpha Vault',  amount: 12500,  currency: 'USDC', status: 'active',    deadline: '2024-07-15T10:00:00Z' },
-  { id: '2', name: 'Beta Reserve', amount: 4200.5, currency: 'USDC', status: 'completed', deadline: '2024-01-01T09:00:00Z' },
-  { id: '3', name: 'Gamma Fund',   amount: 8800,   currency: 'USDC', status: 'failed',    deadline: '2023-12-01T08:00:00Z' },
-]
-
-const DEFAULT_FETCH = () => Promise.resolve(MOCK_VAULTS)
+const DEFAULT_FETCH = () => listVaults()
 
 function Skeleton() {
   return (

--- a/src/services/__tests__/vaultService.test.ts
+++ b/src/services/__tests__/vaultService.test.ts
@@ -1,0 +1,223 @@
+/**
+ * vaultService.test.ts
+ *
+ * Unit tests for the Promise-based vault data layer.
+ * Aim: 95%+ coverage of vaultService.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  listVaults,
+  getVault,
+  getTransactions,
+  listAllActivity,
+} from "../vaultService";
+
+// ── listVaults ────────────────────────────────────────────────────────────────
+describe("listVaults()", () => {
+  it("returns a Promise", () => {
+    const result = listVaults();
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it("resolves to an array of length 4 (matching current mock count)", async () => {
+    const vaults = await listVaults();
+    expect(Array.isArray(vaults)).toBe(true);
+    expect(vaults).toHaveLength(4);
+  });
+
+  it("resolves with objects that have the required Vault fields", async () => {
+    const vaults = await listVaults();
+    for (const v of vaults) {
+      expect(typeof v.id).toBe("string");
+      expect(typeof v.name).toBe("string");
+      expect(typeof v.amount).toBe("number");
+      expect(typeof v.currency).toBe("string");
+      expect(typeof v.status).toBe("string");
+      expect(typeof v.createdAt).toBe("string");
+      expect(typeof v.deadline).toBe("string");
+      expect(Array.isArray(v.milestones)).toBe(true);
+      expect(Array.isArray(v.transactions)).toBe(true);
+    }
+  });
+
+  it("includes all four vault ids", async () => {
+    const vaults = await listVaults();
+    const ids = vaults.map((v) => v.id).sort();
+    expect(ids).toEqual(["1", "2", "3", "4"]);
+  });
+});
+
+// ── getVault ──────────────────────────────────────────────────────────────────
+describe("getVault()", () => {
+  it("returns a Promise", () => {
+    const result = getVault("1");
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it('resolves to a Vault with name "Alpha Vault" for id "1"', async () => {
+    const vault = await getVault("1");
+    expect(vault).toBeDefined();
+    expect(vault!.id).toBe("1");
+    expect(vault!.name).toBe("Alpha Vault");
+    expect(vault!.status).toBe("active");
+    expect(vault!.amount).toBe(12500);
+    expect(vault!.currency).toBe("USDC");
+  });
+
+  it('resolves to a Vault with name "Beta Reserve" for id "2"', async () => {
+    const vault = await getVault("2");
+    expect(vault).toBeDefined();
+    expect(vault!.name).toBe("Beta Reserve");
+    expect(vault!.status).toBe("completed");
+    expect(vault!.amount).toBe(4200.5);
+  });
+
+  it('resolves to a Vault with name "Gamma Fund" for id "3"', async () => {
+    const vault = await getVault("3");
+    expect(vault).toBeDefined();
+    expect(vault!.name).toBe("Gamma Fund");
+    expect(vault!.status).toBe("failed");
+  });
+
+  it('resolves to a Vault with name "Delta Cancelled" for id "4"', async () => {
+    const vault = await getVault("4");
+    expect(vault).toBeDefined();
+    expect(vault!.name).toBe("Delta Cancelled");
+    expect(vault!.status).toBe("cancelled");
+  });
+
+  it("resolves to undefined for an unknown id — does NOT throw", async () => {
+    const vault = await getVault("unknown-id");
+    expect(vault).toBeUndefined();
+  });
+
+  it("resolves to undefined for an empty string id", async () => {
+    const vault = await getVault("");
+    expect(vault).toBeUndefined();
+  });
+
+  it("resolves to undefined for a numeric-looking but non-existent id", async () => {
+    const vault = await getVault("999");
+    expect(vault).toBeUndefined();
+  });
+});
+
+// ── getTransactions ───────────────────────────────────────────────────────────
+describe("getTransactions()", () => {
+  it("returns a Promise", () => {
+    const result = getTransactions("1");
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it("resolves to a non-empty VaultTransaction[] for vault id \"1\"", async () => {
+    const txs = await getTransactions("1");
+    expect(Array.isArray(txs)).toBe(true);
+    expect(txs.length).toBeGreaterThan(0);
+  });
+
+  it("every VaultTransaction for vault \"1\" has required fields", async () => {
+    const txs = await getTransactions("1");
+    for (const tx of txs) {
+      expect(typeof tx.id).toBe("string");
+      expect(typeof tx.type).toBe("string");
+      expect(typeof tx.hash).toBe("string");
+      expect(typeof tx.timestamp).toBe("string");
+    }
+  });
+
+  it("vault \"1\" has a create transaction as its first entry", async () => {
+    const txs = await getTransactions("1");
+    expect(txs[0].type).toBe("create");
+    expect(txs[0].amount).toBe(12500);
+  });
+
+  it("resolves to an empty array for an unknown id — does NOT throw", async () => {
+    const txs = await getTransactions("unknown-id");
+    expect(Array.isArray(txs)).toBe(true);
+    expect(txs).toHaveLength(0);
+  });
+
+  it("resolves to an empty array for an empty string id", async () => {
+    const txs = await getTransactions("");
+    expect(txs).toHaveLength(0);
+  });
+
+  it("vault \"2\" transactions include a release entry", async () => {
+    const txs = await getTransactions("2");
+    const types = txs.map((t) => t.type);
+    expect(types).toContain("release");
+  });
+
+  it("vault \"3\" transactions include a redirect entry", async () => {
+    const txs = await getTransactions("3");
+    const types = txs.map((t) => t.type);
+    expect(types).toContain("redirect");
+  });
+});
+
+// ── listAllActivity ───────────────────────────────────────────────────────────
+describe("listAllActivity()", () => {
+  it("returns a Promise", () => {
+    const result = listAllActivity();
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it("resolves to an array matching the original MOCK_TRANSACTIONS length (10)", async () => {
+    const activity = await listAllActivity();
+    expect(Array.isArray(activity)).toBe(true);
+    expect(activity).toHaveLength(10);
+  });
+
+  it("every VaultActivityRecord has all required fields", async () => {
+    const activity = await listAllActivity();
+    for (const record of activity) {
+      expect(typeof record.id).toBe("string");
+      expect(typeof record.type).toBe("string");
+      expect(typeof record.vault).toBe("string");
+      expect(typeof record.amount).toBe("number");
+      expect(typeof record.fee).toBe("number");
+      expect(typeof record.block).toBe("number");
+      expect(typeof record.hash).toBe("string");
+      expect(typeof record.status).toBe("string");
+      expect(typeof record.from).toBe("string");
+      expect(typeof record.to).toBe("string");
+      expect(record.timestamp).toBeInstanceOf(Date);
+      expect(typeof record.memo).toBe("string");
+    }
+  });
+
+  it("first record is the Alpha Vault create transaction", async () => {
+    const activity = await listAllActivity();
+    const first = activity[0];
+    expect(first.id).toBe("tx1");
+    expect(first.type).toBe("create");
+    expect(first.vault).toBe("Alpha Vault");
+    expect(first.amount).toBe(12500.0);
+    expect(first.status).toBe("confirmed");
+  });
+
+  it("returns a fresh copy each call (mutations don't bleed across calls)", async () => {
+    const a = await listAllActivity();
+    a.push({ id: "extra" } as never);
+    const b = await listAllActivity();
+    expect(b).toHaveLength(10);
+  });
+
+  it("includes records with all four transaction types", async () => {
+    const activity = await listAllActivity();
+    const types = new Set(activity.map((r) => r.type));
+    expect(types.has("create")).toBe(true);
+    expect(types.has("validate")).toBe(true);
+    expect(types.has("release")).toBe(true);
+    expect(types.has("redirect")).toBe(true);
+  });
+
+  it("includes records with all three status values", async () => {
+    const activity = await listAllActivity();
+    const statuses = new Set(activity.map((r) => r.status));
+    expect(statuses.has("confirmed")).toBe(true);
+    expect(statuses.has("pending")).toBe(true);
+    expect(statuses.has("failed")).toBe(true);
+  });
+});

--- a/src/services/vaultService.ts
+++ b/src/services/vaultService.ts
@@ -1,0 +1,415 @@
+/**
+ * vaultService.ts
+ *
+ * Promise-based data layer for vault operations.
+ *
+ * Currently backed by mock data copied verbatim from VaultDetail.tsx
+ * (the canonical source). Replace only the internals of each function
+ * with real Soroban/Horizon calls when the backend is ready — the page
+ * components depend only on the Promise-based interface and will need
+ * zero changes.
+ */
+
+import type { Vault, VaultTransaction } from "../types/vault";
+
+// ── Re-export canonical types for consumers that need them ────────────────────
+export type { Vault, VaultTransaction };
+
+// ── Rich transaction record for the all-vaults explorer page ─────────────────
+// NOT the same as VaultTransaction — this type carries fee, block, from/to/memo
+// data that is specific to the VaultTransactions explorer view.
+export interface VaultActivityRecord {
+  id: string;
+  type: "create" | "validate" | "release" | "redirect";
+  vault: string;
+  amount: number;
+  fee: number;
+  block: number;
+  hash: string;
+  status: "confirmed" | "pending" | "failed";
+  from: string;
+  to: string;
+  timestamp: Date;
+  memo: string;
+}
+
+// ── Master mock dataset (verbatim from VaultDetail.tsx's MOCK_VAULTS) ─────────
+const MASTER_VAULTS: Record<string, Vault> = {
+  // Vault 1: active vault
+  "1": {
+    id: "1",
+    name: "Alpha Vault",
+    status: "active",
+    amount: 12500,
+    currency: "USDC",
+    createdAt: "2024-01-15T10:00:00Z",
+    deadline: "2024-07-15T10:00:00Z",
+    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
+    verifierAddress: "GVERIF3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    contractAddress: "GCONT3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    milestones: [
+      {
+        id: "m1",
+        title: "Phase 1 Complete",
+        description: "Complete initial development phase",
+        criteria: "All unit tests passing, code reviewed",
+        status: "validated",
+        validatedAt: "2024-02-20T14:30:00Z",
+        evidenceUrl: "https://github.com/org/repo/pull/42",
+      },
+      {
+        id: "m2",
+        title: "Beta Launch",
+        description: "Launch beta version to 100 users",
+        criteria: "Beta deployed, 100 active users onboarded",
+        status: "pending",
+      },
+    ],
+    transactions: [
+      {
+        id: "tx1",
+        type: "create",
+        hash: "a3f9d1c8e2b74056af3d9c1b2e8f0a4d",
+        timestamp: "2024-01-15T10:00:00Z",
+        amount: 12500,
+      },
+      {
+        id: "tx2",
+        type: "validate",
+        hash: "b4e0c2d9f3a85167bg4e0d2c3f9a5e8b",
+        timestamp: "2024-02-20T14:30:00Z",
+      },
+    ],
+  },
+  // Vault 2: completed vault (release) without a verifier address
+  "2": {
+    id: "2",
+    name: "Beta Reserve",
+    status: "completed",
+    amount: 4200.5,
+    currency: "USDC",
+    createdAt: "2023-10-01T09:00:00Z",
+    deadline: "2024-01-01T09:00:00Z",
+    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
+    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    contractAddress: "GCONT4KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    milestones: [
+      {
+        id: "m1",
+        title: "Project Delivery",
+        description: "Deliver final project",
+        criteria: "All deliverables submitted and approved",
+        status: "validated",
+        validatedAt: "2023-12-28T11:00:00Z",
+        evidenceUrl: "https://docs.example.com/delivery",
+      },
+    ],
+    transactions: [
+      {
+        id: "tx1",
+        type: "create",
+        hash: "e7b3f5a2c6d18490ej7b3a5f6c2d8b1e",
+        timestamp: "2023-10-01T09:00:00Z",
+        amount: 4200.5,
+      },
+      {
+        id: "tx2",
+        type: "validate",
+        hash: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+        timestamp: "2023-12-28T11:00:00Z",
+      },
+      {
+        id: "tx3",
+        type: "release",
+        hash: "c5f1d3e0a4b96278ch5f1e3d4a0b6f9c",
+        timestamp: "2024-01-01T09:00:00Z",
+        amount: 4200.5,
+      },
+    ],
+  },
+  // Vault 3: failed vault (redirect)
+  "3": {
+    id: "3",
+    name: "Gamma Fund",
+    status: "failed",
+    amount: 8800,
+    currency: "USDC",
+    createdAt: "2023-08-01T08:00:00Z",
+    deadline: "2023-12-01T08:00:00Z",
+    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
+    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    contractAddress: "GCONT5KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    milestones: [
+      {
+        id: "m1",
+        title: "Milestone 1",
+        description: "First milestone",
+        criteria: "Criteria not met",
+        status: "failed",
+      },
+    ],
+    transactions: [
+      {
+        id: "tx1",
+        type: "create",
+        hash: "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8",
+        timestamp: "2023-08-01T08:00:00Z",
+        amount: 8800,
+      },
+      {
+        id: "tx2",
+        type: "redirect",
+        hash: "d6a2e4f1b5c07389di6a2f4e5b1c7a0d",
+        timestamp: "2023-12-01T08:00:00Z",
+        amount: 8800,
+      },
+    ],
+  },
+  // Vault 4: cancelled vault with mixed milestone statuses and redirect destination
+  "4": {
+    id: "4",
+    name: "Delta Cancelled",
+    status: "cancelled",
+    amount: 5000,
+    currency: "USDC",
+    createdAt: "2023-08-01T08:00:00Z",
+    deadline: "2023-12-01T08:00:00Z",
+    creatorAddress: "GBVZ3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK7L",
+    failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    contractAddress: "GCONT5KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    milestones: [
+      {
+        id: "m1",
+        title: "Milestone 1",
+        description: "First milestone",
+        criteria: "Criteria met",
+        status: "validated",
+      },
+      {
+        id: "m2",
+        title: "Milestone 2",
+        description: "Second milestone",
+        criteria: "Criteria not met",
+        status: "failed",
+      },
+      {
+        id: "m3",
+        title: "Milestone 3",
+        description: "Third milestone",
+        criteria: "Pending criteria",
+        status: "pending",
+      },
+    ],
+    transactions: [
+      {
+        id: "tx1",
+        type: "create",
+        hash: "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8",
+        timestamp: "2023-08-01T08:00:00Z",
+        amount: 5000,
+      },
+      {
+        id: "tx2",
+        type: "redirect",
+        hash: "d6a2e4f1b5c07389di6a2f4e5b1c7a0d",
+        timestamp: "2023-12-01T08:00:00Z",
+        amount: 5000,
+      },
+    ],
+  },
+};
+
+// ── Mock activity dataset (verbatim from VaultTransactions.tsx's MOCK_TRANSACTIONS)
+// NOTE: `new Date(Date.now() - ...)` is evaluated at module load time, which
+// matches the original runtime behaviour.
+const MASTER_ACTIVITY: VaultActivityRecord[] = [
+  {
+    id: "tx1",
+    type: "create",
+    vault: "Alpha Vault",
+    amount: 12500.0,
+    fee: 0.00012,
+    block: 48201933,
+    hash: "a3f9d1c8e2b74056af3d9c1b2e8f0a4d7c5e9b3f1a2d4c6e8b0f2a4c6d8e0f2a",
+    status: "confirmed",
+    from: "GBVZ3...QK7L",
+    to: "GCVAULT...M3P",
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2),
+    memo: "Initial deposit",
+  },
+  {
+    id: "tx2",
+    type: "validate",
+    vault: "Alpha Vault",
+    amount: 0,
+    fee: 0.00008,
+    block: 48202011,
+    hash: "b4e0c2d9f3a85167bg4e0d2c3f9a5e8b4c6d0e2f4a6c8e0b2d4f6a8c0e2d4f6a",
+    status: "confirmed",
+    from: "GBVZ3...QK7L",
+    to: "GCVAULT...M3P",
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 1.5),
+    memo: "",
+  },
+  {
+    id: "tx3",
+    type: "release",
+    vault: "Beta Reserve",
+    amount: 4200.5,
+    fee: 0.00015,
+    block: 48202450,
+    hash: "c5f1d3e0a4b96278ch5f1e3d4a0b6f9c5d7e1f3b5d7f9b1d3f5b7d9f1b3d5f7b",
+    status: "confirmed",
+    from: "GCVAULT...M3P",
+    to: "GBVZ3...QK7L",
+    timestamp: new Date(Date.now() - 1000 * 60 * 45),
+    memo: "Milestone payout",
+  },
+  {
+    id: "tx4",
+    type: "redirect",
+    vault: "Gamma Fund",
+    amount: 8800.0,
+    fee: 0.00011,
+    block: 48202891,
+    hash: "d6a2e4f1b5c07389di6a2f4e5b1c7a0d6e8f2a4c6e8a0c2e4f6a8c0e2f4a6c8e",
+    status: "pending",
+    from: "GCVAULT...M3P",
+    to: "GDELTA...X9K",
+    timestamp: new Date(Date.now() - 1000 * 60 * 20),
+    memo: "Redirect to escrow",
+  },
+  {
+    id: "tx5",
+    type: "create",
+    vault: "Beta Reserve",
+    amount: 31000.0,
+    fee: 0.00013,
+    block: 48201100,
+    hash: "e7b3f5a2c6d18490ej7b3a5f6c2d8b1e7f9a3b5d7f9b1d3f5b7d9f1b3d5f7b9d",
+    status: "confirmed",
+    from: "GBVZ3...QK7L",
+    to: "GCVAULT...M3P",
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 5),
+    memo: "New vault",
+  },
+  {
+    id: "tx6",
+    type: "release",
+    vault: "Alpha Vault",
+    amount: 500.0,
+    fee: 0.00009,
+    block: 48203100,
+    hash: "f8c4a6b3d7e29501fk8c4b6a7d3e9c2f8a0c4b6d8f0b2d4f6a8b0d2f4a6b8d0f",
+    status: "failed",
+    from: "GCVAULT...M3P",
+    to: "GBVZ3...QK7L",
+    timestamp: new Date(Date.now() - 1000 * 60 * 10),
+    memo: "Partial release",
+  },
+  {
+    id: "tx7",
+    type: "validate",
+    vault: "Gamma Fund",
+    amount: 0,
+    fee: 0.00007,
+    block: 48201788,
+    hash: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+    status: "confirmed",
+    from: "GBVZ3...QK7L",
+    to: "GCVAULT...M3P",
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 3.5),
+    memo: "",
+  },
+  {
+    id: "tx8",
+    type: "redirect",
+    vault: "Alpha Vault",
+    amount: 1200.75,
+    fee: 0.0001,
+    block: 48203222,
+    hash: "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3",
+    status: "pending",
+    from: "GCVAULT...M3P",
+    to: "GBVZ3...QK7L",
+    timestamp: new Date(Date.now() - 1000 * 60 * 5),
+    memo: "Reallocation",
+  },
+  {
+    id: "tx9",
+    type: "create",
+    vault: "Delta Safe",
+    amount: 99000.0,
+    fee: 0.0002,
+    block: 48200500,
+    hash: "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4",
+    status: "confirmed",
+    from: "GBVZ3...QK7L",
+    to: "GCVAULT...M3P",
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 8),
+    memo: "Large vault",
+  },
+  {
+    id: "tx10",
+    type: "release",
+    vault: "Delta Safe",
+    amount: 15000.0,
+    fee: 0.00016,
+    block: 48203400,
+    hash: "d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5",
+    status: "confirmed",
+    from: "GCVAULT...M3P",
+    to: "GBVZ3...QK7L",
+    timestamp: new Date(Date.now() - 1000 * 60 * 2),
+    memo: "Q3 release",
+  },
+];
+
+// ── Service API ───────────────────────────────────────────────────────────────
+// SEAM: Replace only the internals of these functions with Soroban/Horizon calls
+// when the real backend lands. Page components depend solely on the
+// Promise-based interface below and will need zero changes.
+
+/**
+ * Return all vaults.
+ *
+ * SEAM → replace with: Horizon account fetch + Soroban contract reads.
+ */
+export async function listVaults(): Promise<Vault[]> {
+  return Object.values(MASTER_VAULTS);
+}
+
+/**
+ * Return a single vault by id, or undefined if not found.
+ * Does NOT throw for unknown ids — callers rely on the undefined branch.
+ *
+ * SEAM → replace with: Soroban contract state read for a given contract address.
+ */
+export async function getVault(id: string): Promise<Vault | undefined> {
+  return MASTER_VAULTS[id];
+}
+
+/**
+ * Return the on-chain transactions stored on a specific vault.
+ * Returns [] for unknown ids.
+ *
+ * SEAM → replace with: Horizon `/transactions?account=<contractAddress>` + filter.
+ */
+export async function getTransactions(id: string): Promise<VaultTransaction[]> {
+  return MASTER_VAULTS[id]?.transactions ?? [];
+}
+
+/**
+ * Return the rich activity feed used by the VaultTransactions explorer page.
+ *
+ * SEAM → replace with: Horizon transaction stream aggregated across all vault
+ * contract addresses.
+ */
+export async function listAllActivity(): Promise<VaultActivityRecord[]> {
+  return [...MASTER_ACTIVITY];
+}

--- a/src/types/vault.ts
+++ b/src/types/vault.ts
@@ -37,3 +37,41 @@ export const VAULT_STATUS_ORDER: readonly VaultStatus[] = [
   'failed',
   'cancelled',
 ] as const;
+
+/** A single milestone within a vault. */
+export interface Milestone {
+  id: string;
+  title: string;
+  description: string;
+  criteria: string;
+  status: MilestoneStatus;
+  validatedAt?: string;
+  evidenceUrl?: string;
+}
+
+/** A lightweight on-chain transaction record stored on the Vault itself. */
+export interface VaultTransaction {
+  id: string;
+  type: TxType;
+  hash: string;
+  timestamp: string;
+  amount?: number;
+}
+
+/** Full vault record — canonical shape used across all pages. */
+export interface Vault {
+  id: string;
+  name: string;
+  status: VaultStatus;
+  amount: number;
+  currency: string;
+  createdAt: string;
+  deadline: string;
+  creatorAddress: string;
+  verifierAddress?: string;
+  successAddress: string;
+  failureAddress: string;
+  contractAddress: string;
+  milestones: Milestone[];
+  transactions: VaultTransaction[];
+}

--- a/src/utils/dashboard.ts
+++ b/src/utils/dashboard.ts
@@ -1,4 +1,6 @@
-export type VaultStatus = "active" | "pending_validation" | "completed" | "failed";
+import type { VaultStatus } from '../types/vault';
+
+export type { VaultStatus };
 
 export interface VaultPreview {
   id: string;


### PR DESCRIPTION
Closes #216

---

## Summary
Introduces a single `vaultService` data layer and shared `Vault`/
`Milestone`/`VaultTransaction` types, replacing four independent inline
mock arrays in Dashboard, Vaults, VaultDetail, and VaultTransactions.

## Notable finding
The existing mocks didn't just have duplicated types — they disagreed on
actual values for the same vault id across files (e.g. "Gamma Fund" was
$4,200/active in Dashboard.tsx but $8,800/failed in Vaults.tsx and
VaultDetail.tsx). This PR treats VaultDetail.tsx's dataset as canonical
and unifies on it, which incidentally fixes that inconsistency. Documented
in docs/VAULT_DATA_LAYER.md.

## Design note
VaultTransactions.tsx's transaction explorer uses a richer per-transaction
shape (fee, block, from/to, memo, status) that has no equivalent in other
pages' data. Rather than force those fields into the shared `VaultTransaction`
type (which would mean inventing data), it gets its own
`VaultActivityRecord` type and `listAllActivity()` method.

## Changes
- `src/types/vault.ts` — canonical Vault/Milestone/VaultTransaction types
- `src/services/vaultService.ts` — async, mock-backed: listVaults,
  getVault, getTransactions, listAllActivity
- 4 pages refactored to consume the service instead of inline mocks
- `docs/VAULT_DATA_LAYER.md` — documents the contract-integration seam

## Tests
`vaultService.test.ts` covers unknown vault id, empty transaction list,
and Promise-based resolution shape for all 4 methods.

## No UI regressions
Each page renders the same structure; only the data source changed from
synchronous inline arrays to an async service call with a brief loading state.