### PR TITLE
perf: memoize VaultTransactions filtering, windowing, and totals

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -97,3 +97,13 @@ The reporter has minimal performance impact:
 - Observers are passive and don't block rendering
 - Callback execution is asynchronous
 - No network calls unless explicitly added by the callback
+
+## Component Rendering Optimization
+
+### VaultTransactions
+The `VaultTransactions` component manages heavy data processing including filtering, sorting, pagination (windowing), and aggregate computations. To ensure fluid interaction and prevent unnecessary layout or computation cycles:
+- **Filter derivations** (`pending`, `failed`, `confirmed`) are memoized and only recompute when the underlying dataset or filter criteria changes.
+- **Window slices** (`windowRange`) are independently memoized per status section to avoid recalculating the slice for one section when another is modified.
+- **Totals and aggregations** (`computeTxTotals`, `stats`) are memoized to skip intensive reduction loops on unrelated state changes (e.g. copying a hash or opening a modal).
+
+Integration tests in `src/pages/__tests__/VaultTransactions.test.tsx` assert that these derivation pipelines do not fire during unrelated re-renders.

--- a/src/pages/VaultTransactions.tsx
+++ b/src/pages/VaultTransactions.tsx
@@ -345,16 +345,16 @@ export default function VaultTransactions({
     transactions,
   ]);
 
-  const pending = filtered.filter((t) => t.status === "pending");
-  const failed = filtered.filter((t) => t.status === "failed");
-  const rest = filtered.filter((t) => t.status === "confirmed");
+  const pending = useMemo(() => filtered.filter((t) => t.status === "pending"), [filtered]);
+  const failed = useMemo(() => filtered.filter((t) => t.status === "failed"), [filtered]);
+  const rest = useMemo(() => filtered.filter((t) => t.status === "confirmed"), [filtered]);
 
   // Reset window anchor when filters change so the user always sees the top.
   // windowRange is applied per-section; each section independently does not
   // exceed WINDOW_THRESHOLD in typical use, but large "confirmed" lists will.
-  const pendingWindow = windowRange(pending, anchorIndex);
-  const failedWindow = windowRange(failed, anchorIndex);
-  const restWindow = windowRange(rest, anchorIndex);
+  const pendingWindow = useMemo(() => windowRange(pending, anchorIndex), [pending, anchorIndex]);
+  const failedWindow = useMemo(() => windowRange(failed, anchorIndex), [failed, anchorIndex]);
+  const restWindow = useMemo(() => windowRange(rest, anchorIndex), [rest, anchorIndex]);
 
   const stats = useMemo(
     () => ({
@@ -752,6 +752,7 @@ const TxRow = memo(function TxRow({ tx, onSelect, onCopy, copiedId, children }: 
           <Tooltip content={tx.hash} position="top">
             <button
               className="vt-tx-hash"
+              title="Copy hash"
               onClick={(e) => {
                 e.stopPropagation();
                 onCopy(tx.hash, tx.id + "-hash");

--- a/src/pages/__tests__/VaultTransactions.test.tsx
+++ b/src/pages/__tests__/VaultTransactions.test.tsx
@@ -3,6 +3,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import VaultTransactions, { Transaction } from '../VaultTransactions';
 import { toCsv, downloadCsv } from '../../utils/csv';
 import { WINDOW_SIZE, WINDOW_THRESHOLD } from '../../utils/windowRange';
+import * as windowRangeMod from '../../utils/windowRange';
+import * as txTotalsMod from '../../utils/txTotals';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }),
+});
 
 vi.mock('../../utils/csv', () => ({
   toCsv: vi.fn((_data, _type) => 'mocked,csv,content'),
@@ -292,7 +308,8 @@ describe('VaultTransactions', () => {
       fireEvent.click(rows[0]);
       // tx8 full hash
       const fullHash = 'b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3';
-      expect(screen.getByText(fullHash)).toBeInTheDocument();
+      const modal = document.querySelector('.vt-modal') as HTMLElement;
+      expect(within(modal).getByText(fullHash)).toBeInTheDocument();
     });
   });
 
@@ -623,6 +640,38 @@ describe('VaultTransactions large fixture integration', () => {
     render(<VaultTransactions />);
     const rows = document.querySelectorAll('.vt-tx-row');
     expect(rows.length).toBe(10);
+  });
+
+  it('memoizes derivations so unrelated state changes do not re-run filter/total pipeline', () => {
+    const windowSpy = vi.spyOn(windowRangeMod, 'windowRange');
+    const totalsSpy = vi.spyOn(txTotalsMod, 'computeTxTotals');
+    
+    render(<VaultTransactions />);
+    
+    const initialWindowCalls = windowSpy.mock.calls.length;
+    const initialTotalsCalls = totalsSpy.mock.calls.length;
+    
+    expect(initialWindowCalls).toBeGreaterThan(0);
+    expect(initialTotalsCalls).toBeGreaterThan(0);
+    
+    // Click a row to set selectedTx (unrelated state)
+    const rows = document.querySelectorAll('.vt-tx-row');
+    fireEvent.click(rows[0]);
+    
+    expect(document.querySelector('.vt-modal')).toBeInTheDocument();
+    
+    expect(windowSpy.mock.calls.length).toBe(initialWindowCalls);
+    expect(totalsSpy.mock.calls.length).toBe(initialTotalsCalls);
+    
+    // Changing a filter should re-run derivations
+    const searchInput = screen.getByPlaceholderText(/search by transaction hash/i);
+    fireEvent.change(searchInput, { target: { value: 'a3f9' } });
+    
+    expect(windowSpy.mock.calls.length).toBeGreaterThan(initialWindowCalls);
+    expect(totalsSpy.mock.calls.length).toBeGreaterThan(initialTotalsCalls);
+    
+    windowSpy.mockRestore();
+    totalsSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
This pr closes #505

**Description**:
This PR addresses the performance issue in `src/pages/VaultTransactions.tsx` where derived state—specifically the filtered status arrays (`pending`, `failed`, `rest`), their respective window slices, and transaction totals—were recomputed on every render. This caused intensive array methods to run even when interacting with unrelated local state (like copying hashes, or opening the detail modal).

**Changes Included**:
1. **Memoization (`src/pages/VaultTransactions.tsx`)**:
   - Wrapped the filter operations for `pending`, `failed`, and `rest` arrays in `useMemo` so they only recalculate when the actively visible `filtered` list changes.
   - Wrapped the windowing slice calculations (`pendingWindow`, `failedWindow`, `restWindow`) in `useMemo` so they only recalculate when their respective status list or `anchorIndex` changes.
2. **Testing Updates (`src/pages/__tests__/VaultTransactions.test.tsx`)**:
   - Added an integration test using `vi.spyOn` against the `windowRange` and `computeTxTotals` modules to verify that derivations do NOT re-run during unrelated state changes (like opening the transaction detail modal) but DO re-run when filters are actively changed.
   - Fixed a query ambiguity in the tests where our added Tooltip `content` inadvertently appeared multiple times, and resolved a `window.matchMedia` rendering crash in the test suite setup. 
3. **Documentation Update (`docs/PERFORMANCE.md`)**:
   - Added a new `Component Rendering Optimization` section documenting the strategy implemented in the `VaultTransactions` component.

**Verification**:
- Verified that all lines, including our modifications, are covered by passing Vitest unit tests meeting the >95% threshold requirement.
- Visually, the data output and total derivations remain perfectly untouched.

The push to your remote repository was successful! Let me know if you need any additional changes to this implementation or if there is anything else I can help you with.