### PR TITLE
security: confirmation-token and dual-control guard for destructive admin actions (#881)

### DIFF
--- a/docs/admin-overrides.md
+++ b/docs/admin-overrides.md
@@ -1,0 +1,176 @@
+# Admin Destructive-Action Guards
+
+This document describes the confirmation-token and dual-control system that
+protects the highest-impact admin endpoints from accidental or malicious
+single-session execution.
+
+---
+
+## Overview
+
+Three admin operations are classified as **destructive** because they are
+irreversible or have broad blast-radius:
+
+| Action | Description | Dual control required |
+|--------|-------------|----------------------|
+| `cursor:reset` | Resets the event-processing cursor to the beginning | No |
+| `jobs:purge` | Permanently deletes all queued jobs | **Yes** |
+| `sync:force` | Drops and rebuilds the sync state from scratch | **Yes** |
+
+A single compromised admin session cannot execute any of these actions
+unilaterally. Every execution requires:
+
+1. An active **step-up credential** (WebAuthn/MFA, valid for 15 minutes).
+2. A short-lived, action-scoped **confirmation token** obtained via a separate
+   `prepare` call.
+3. For dual-control actions: a **second admin approver** (a different admin
+   account) must approve the token before it is accepted.
+
+---
+
+## Two-phase execution flow
+
+### Phase 1 — Prepare (all destructive actions)
+
+```
+POST /admin/prepare
+Authorization: Bearer <admin-session>
+X-StepUp-Token: <webauthn-assertion>
+
+{ "action": "cursor:reset" }
+```
+
+Response:
+```json
+{
+  "token": "550e8400-e29b-41d4-a716-446655440000",
+  "actionScope": "cursor:reset",
+  "expiresAt": 1700000300000,
+  "requiresDualControl": false
+}
+```
+
+The token is valid for **5 minutes** and is scoped to exactly one action.
+It is stored server-side and consumed (deleted) on first successful execution.
+
+### Phase 2a — Approve (dual-control actions only)
+
+A **different** admin must call the approve endpoint with the token before it
+can be used:
+
+```
+POST /admin/approve
+Authorization: Bearer <second-admin-session>
+
+{ "token": "550e8400-e29b-41d4-a716-446655440000" }
+```
+
+The same admin who issued the token cannot approve it (`SELF_APPROVAL`).
+
+### Phase 2b — Execute
+
+```
+POST /admin/cursor/reset
+Authorization: Bearer <admin-session>
+X-Confirmation-Token: 550e8400-e29b-41d4-a716-446655440000
+```
+
+The guard:
+1. Looks up the token in the store.
+2. Verifies it has not expired.
+3. Verifies its scope matches the endpoint being called.
+4. For dual-control actions, verifies a second approver has confirmed.
+5. **Deletes the token** before calling the executor (replay-safe even on failure).
+6. Calls the executor.
+7. Writes `<action>.started` and `<action>.completed` audit events.
+
+---
+
+## Adding a new destructive action
+
+1. Add the action string to `DESTRUCTIVE_ACTIONS` in `src/routes/admin.ts`.
+2. If it also requires a second approver, add it to `DUAL_CONTROL_ACTIONS`.
+3. Call `executeDestructiveAction` in the new endpoint handler, passing the
+   executor function and the token from `X-Confirmation-Token`.
+4. Add tests in `src/tests/admin.dualControl.test.ts`.
+
+---
+
+## Error codes
+
+| Code | Meaning |
+|------|---------|
+| `MISSING` | Token not provided, unknown, or already consumed. |
+| `EXPIRED` | Token TTL (5 min) has elapsed; issue a new one. |
+| `WRONG_SCOPE` | Token was prepared for a different action. |
+| `SECOND_APPROVER_REQUIRED` | Dual-control action; a second admin must call `/admin/approve` first. |
+| `SELF_APPROVAL` | The approver is the same admin who prepared the token. |
+| `NOT_DUAL_CONTROL` | `/admin/approve` was called for a single-control action. |
+| `UNKNOWN_ACTION` | The action string passed to `/admin/prepare` is not in `DESTRUCTIVE_ACTIONS`. |
+
+---
+
+## Audit trail
+
+Every step produces an `AuditEvent`:
+
+```ts
+interface AuditEvent {
+  timestamp: number;   // Unix ms
+  actor: string;       // adminId
+  action: string;      // see table below
+  detail: Record<string, unknown>;
+}
+```
+
+| Event | When |
+|-------|------|
+| `confirmation_token.issued` | Token created by prepare call |
+| `confirmation_token.approved` | Second approver confirmed |
+| `<action>.started` | Just before executor runs (token already consumed) |
+| `<action>.completed` | Executor returned successfully |
+
+A full dual-control run for `sync:force` produces exactly:
+
+```
+confirmation_token.issued   actor=admin-1
+confirmation_token.approved actor=admin-2
+sync:force.started          actor=admin-1
+sync:force.completed        actor=admin-1
+```
+
+---
+
+## Step-up credential
+
+The step-up check is enforced in `prepareAction` via `requireStepUp`
+(`src/middleware/stepUp.ts`). A credential is valid for **15 minutes** from
+the time of WebAuthn verification (`session.stepUpVerifiedAt`). The TTL is
+injectable for testing.
+
+```ts
+requireStepUp(session);                  // uses 15-min default
+requireStepUp(session, 5 * 60 * 1000);  // custom TTL (ms)
+```
+
+---
+
+## Testing
+
+```
+npm test -- src/tests/admin.dualControl.test.ts
+```
+
+The test suite covers:
+
+- `prepareAction`: valid token shape, dual-control flag, unknown action, missing
+  step-up, expired step-up, distinct tokens per call.
+- `validateConfirmationToken`: valid token, missing token, unknown token, expired
+  token, wrong scope, unapproved dual-control token, approved dual-control token.
+- `approveAction`: second-approver recorded, audit event, unknown token, expired
+  token, non-dual-control rejection, self-approval rejection.
+- `executeDestructiveAction`: executor called, token consumed before run
+  (replay-safe on failure), audit event order, confirmedBy/approvedBy in events,
+  all rejection codes.
+- Full end-to-end audit trail for both single-control and dual-control flows.
+- Step-up TTL boundary conditions (exact boundary accepted, 1 ms over rejected).

--- a/src/middleware/stepUp.ts
+++ b/src/middleware/stepUp.ts
@@ -1,0 +1,33 @@
+/** Maximum age of a step-up credential before it must be refreshed (15 min). */
+export const STEP_UP_TTL_MS = 15 * 60 * 1000;
+
+export interface AdminSession {
+  adminId: string;
+  roles: string[];
+  /** Unix-ms timestamp set after a successful WebAuthn / MFA step-up. */
+  stepUpVerifiedAt?: number;
+}
+
+export class StepUpError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StepUpError';
+  }
+}
+
+/**
+ * Throws StepUpError when the session's step-up credential is absent or older
+ * than `requiredWithinMs`.  Pass `now` to make tests deterministic.
+ */
+export function requireStepUp(
+  session: AdminSession,
+  requiredWithinMs = STEP_UP_TTL_MS,
+  now = Date.now(),
+): void {
+  if (session.stepUpVerifiedAt === undefined) {
+    throw new StepUpError('Step-up authentication is required before this action.');
+  }
+  if (now - session.stepUpVerifiedAt > requiredWithinMs) {
+    throw new StepUpError('Step-up authentication has expired; please re-authenticate.');
+  }
+}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,0 +1,306 @@
+import { type AdminSession, requireStepUp } from '@/middleware/stepUp';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** How long a confirmation token is valid after issuance. */
+export const TOKEN_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Destructive actions that require a confirmation token before execution.
+ * Adding a new action here is the only change needed to protect it.
+ */
+export const DESTRUCTIVE_ACTIONS = new Set([
+  'cursor:reset',
+  'jobs:purge',
+  'sync:force',
+] as const);
+
+/**
+ * Subset of DESTRUCTIVE_ACTIONS that additionally require a second admin
+ * approver (dual-control) before the confirmation token is accepted.
+ */
+export const DUAL_CONTROL_ACTIONS = new Set([
+  'jobs:purge',
+  'sync:force',
+] as const);
+
+export type DestructiveAction = 'cursor:reset' | 'jobs:purge' | 'sync:force';
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export type ConfirmationTokenErrorCode =
+  | 'MISSING'
+  | 'EXPIRED'
+  | 'WRONG_SCOPE'
+  | 'SECOND_APPROVER_REQUIRED'
+  | 'SELF_APPROVAL'
+  | 'NOT_DUAL_CONTROL'
+  | 'UNKNOWN_ACTION';
+
+export class ConfirmationTokenError extends Error {
+  constructor(
+    message: string,
+    public readonly code: ConfirmationTokenErrorCode,
+  ) {
+    super(message);
+    this.name = 'ConfirmationTokenError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Token store
+// ---------------------------------------------------------------------------
+
+export interface ConfirmationToken {
+  token: string;
+  actionScope: DestructiveAction;
+  actorId: string;
+  issuedAt: number;
+  expiresAt: number;
+  requiresDualControl: boolean;
+  secondApproverId?: string;
+  approvedAt?: number;
+}
+
+export interface TokenStore {
+  set(token: string, entry: ConfirmationToken): void;
+  get(token: string): ConfirmationToken | undefined;
+  delete(token: string): void;
+}
+
+export class InMemoryTokenStore implements TokenStore {
+  private readonly store = new Map<string, ConfirmationToken>();
+  set(token: string, entry: ConfirmationToken): void { this.store.set(token, entry); }
+  get(token: string): ConfirmationToken | undefined { return this.store.get(token); }
+  delete(token: string): void { this.store.delete(token); }
+  /** Test helper: wipe all tokens. */
+  clear(): void { this.store.clear(); }
+}
+
+// ---------------------------------------------------------------------------
+// Audit logger
+// ---------------------------------------------------------------------------
+
+export interface AuditEvent {
+  timestamp: number;
+  actor: string;
+  action: string;
+  detail: Record<string, unknown>;
+}
+
+export interface AuditLogger {
+  log(event: AuditEvent): void;
+}
+
+// ---------------------------------------------------------------------------
+// Core guards
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates a confirmation token for the given action and actor.
+ * Returns the token entry on success; throws ConfirmationTokenError otherwise.
+ * Does NOT consume the token — call store.delete() after successful execution.
+ */
+export function validateConfirmationToken(
+  tokenValue: string | undefined,
+  requiredAction: DestructiveAction,
+  store: TokenStore,
+  now = Date.now(),
+): ConfirmationToken {
+  if (!tokenValue) {
+    throw new ConfirmationTokenError(
+      'A confirmation token is required for this action.',
+      'MISSING',
+    );
+  }
+
+  const entry = store.get(tokenValue);
+  if (!entry) {
+    throw new ConfirmationTokenError(
+      'Confirmation token is invalid or has already been used.',
+      'MISSING',
+    );
+  }
+
+  if (now > entry.expiresAt) {
+    store.delete(tokenValue);
+    throw new ConfirmationTokenError(
+      'Confirmation token has expired.',
+      'EXPIRED',
+    );
+  }
+
+  if (entry.actionScope !== requiredAction) {
+    throw new ConfirmationTokenError(
+      `Token scope mismatch: expected "${requiredAction}", got "${entry.actionScope}".`,
+      'WRONG_SCOPE',
+    );
+  }
+
+  if (entry.requiresDualControl && entry.approvedAt === undefined) {
+    throw new ConfirmationTokenError(
+      'A second admin approver must confirm this action before it can be executed.',
+      'SECOND_APPROVER_REQUIRED',
+    );
+  }
+
+  return entry;
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers
+// ---------------------------------------------------------------------------
+
+export interface AdminContext {
+  adminId: string;
+  session: AdminSession;
+}
+
+export interface PrepareResult {
+  token: string;
+  actionScope: DestructiveAction;
+  expiresAt: number;
+  requiresDualControl: boolean;
+}
+
+/**
+ * Issues a short-lived, action-scoped confirmation token.
+ * Requires the caller to have an active step-up credential.
+ */
+export function prepareAction(
+  ctx: AdminContext,
+  action: string,
+  store: TokenStore,
+  audit: AuditLogger,
+  now = Date.now(),
+): PrepareResult {
+  if (!DESTRUCTIVE_ACTIONS.has(action as DestructiveAction)) {
+    throw new ConfirmationTokenError(
+      `"${action}" is not a recognised destructive action.`,
+      'UNKNOWN_ACTION',
+    );
+  }
+
+  requireStepUp(ctx.session, undefined, now);
+
+  const token = globalThis.crypto.randomUUID();
+  const requiresDualControl = DUAL_CONTROL_ACTIONS.has(action as DestructiveAction);
+  const expiresAt = now + TOKEN_TTL_MS;
+
+  const entry: ConfirmationToken = {
+    token,
+    actionScope: action as DestructiveAction,
+    actorId: ctx.adminId,
+    issuedAt: now,
+    expiresAt,
+    requiresDualControl,
+  };
+
+  store.set(token, entry);
+
+  audit.log({
+    timestamp: now,
+    actor: ctx.adminId,
+    action: 'confirmation_token.issued',
+    detail: { actionScope: action, expiresAt, requiresDualControl },
+  });
+
+  return { token, actionScope: action as DestructiveAction, expiresAt, requiresDualControl };
+}
+
+/**
+ * Second-approver call for dual-control actions.
+ * The approver must be a different admin than the one who prepared the token.
+ */
+export function approveAction(
+  ctx: AdminContext,
+  tokenValue: string,
+  store: TokenStore,
+  audit: AuditLogger,
+  now = Date.now(),
+): void {
+  const entry = store.get(tokenValue);
+
+  if (!entry) {
+    throw new ConfirmationTokenError(
+      'Confirmation token is invalid or has already been used.',
+      'MISSING',
+    );
+  }
+
+  if (now > entry.expiresAt) {
+    store.delete(tokenValue);
+    throw new ConfirmationTokenError('Confirmation token has expired.', 'EXPIRED');
+  }
+
+  if (!entry.requiresDualControl) {
+    throw new ConfirmationTokenError(
+      'This action does not require dual-control approval.',
+      'NOT_DUAL_CONTROL',
+    );
+  }
+
+  if (entry.actorId === ctx.adminId) {
+    throw new ConfirmationTokenError(
+      'The same admin cannot both prepare and approve a dual-control action.',
+      'SELF_APPROVAL',
+    );
+  }
+
+  store.set(tokenValue, { ...entry, secondApproverId: ctx.adminId, approvedAt: now });
+
+  audit.log({
+    timestamp: now,
+    actor: ctx.adminId,
+    action: 'confirmation_token.approved',
+    detail: {
+      actionScope: entry.actionScope,
+      originalActor: entry.actorId,
+    },
+  });
+}
+
+/**
+ * Validates the token for the given action, consumes it (one-time use),
+ * runs the provided executor, and writes a completion audit event.
+ */
+export async function executeDestructiveAction(
+  ctx: AdminContext,
+  tokenValue: string | undefined,
+  action: DestructiveAction,
+  executor: () => Promise<void>,
+  store: TokenStore,
+  audit: AuditLogger,
+  now = Date.now(),
+): Promise<void> {
+  const entry = validateConfirmationToken(tokenValue, action, store, now);
+
+  // Consume token before execution to prevent replays even on executor failure.
+  store.delete(entry.token);
+
+  audit.log({
+    timestamp: now,
+    actor: ctx.adminId,
+    action: `${action}.started`,
+    detail: {
+      confirmedBy: entry.actorId,
+      approvedBy: entry.secondApproverId,
+    },
+  });
+
+  await executor();
+
+  audit.log({
+    timestamp: now,
+    actor: ctx.adminId,
+    action: `${action}.completed`,
+    detail: {
+      confirmedBy: entry.actorId,
+      approvedBy: entry.secondApproverId,
+    },
+  });
+}

--- a/src/tests/admin.dualControl.test.ts
+++ b/src/tests/admin.dualControl.test.ts
@@ -1,0 +1,564 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  prepareAction,
+  approveAction,
+  executeDestructiveAction,
+  validateConfirmationToken,
+  InMemoryTokenStore,
+  ConfirmationTokenError,
+  TOKEN_TTL_MS,
+  DESTRUCTIVE_ACTIONS,
+  DUAL_CONTROL_ACTIONS,
+  type AdminContext,
+  type AuditLogger,
+  type AuditEvent,
+} from '@/routes/admin';
+import { StepUpError } from '@/middleware/stepUp';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSession(stepUpAgeMs = 0) {
+  return { adminId: 'admin-1', roles: ['admin'], stepUpVerifiedAt: NOW - stepUpAgeMs };
+}
+
+function makeCtx(adminId = 'admin-1', stepUpAgeMs = 0): AdminContext {
+  return { adminId, session: makeSession(stepUpAgeMs) };
+}
+
+function makeAudit(): AuditLogger & { events: AuditEvent[] } {
+  const events: AuditEvent[] = [];
+  return { events, log: (e) => events.push(e) };
+}
+
+const NOW = 1_700_000_000_000;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+describe('configuration', () => {
+  it('DESTRUCTIVE_ACTIONS contains the three flagged actions', () => {
+    expect(DESTRUCTIVE_ACTIONS.has('cursor:reset')).toBe(true);
+    expect(DESTRUCTIVE_ACTIONS.has('jobs:purge')).toBe(true);
+    expect(DESTRUCTIVE_ACTIONS.has('sync:force')).toBe(true);
+  });
+
+  it('DUAL_CONTROL_ACTIONS is a strict subset of DESTRUCTIVE_ACTIONS', () => {
+    for (const a of DUAL_CONTROL_ACTIONS) {
+      expect(DESTRUCTIVE_ACTIONS.has(a)).toBe(true);
+    }
+  });
+
+  it('cursor:reset does not require dual control', () => {
+    expect(DUAL_CONTROL_ACTIONS.has('cursor:reset')).toBe(false);
+  });
+
+  it('jobs:purge requires dual control', () => {
+    expect(DUAL_CONTROL_ACTIONS.has('jobs:purge')).toBe(true);
+  });
+
+  it('sync:force requires dual control', () => {
+    expect(DUAL_CONTROL_ACTIONS.has('sync:force')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// InMemoryTokenStore
+// ---------------------------------------------------------------------------
+
+describe('InMemoryTokenStore', () => {
+  it('stores and retrieves entries', () => {
+    const store = new InMemoryTokenStore();
+    const entry = {
+      token: 'tok',
+      actionScope: 'cursor:reset' as const,
+      actorId: 'admin-1',
+      issuedAt: NOW,
+      expiresAt: NOW + TOKEN_TTL_MS,
+      requiresDualControl: false,
+    };
+    store.set('tok', entry);
+    expect(store.get('tok')).toEqual(entry);
+  });
+
+  it('returns undefined for unknown tokens', () => {
+    expect(new InMemoryTokenStore().get('nope')).toBeUndefined();
+  });
+
+  it('deletes entries', () => {
+    const store = new InMemoryTokenStore();
+    store.set('tok', {
+      token: 'tok',
+      actionScope: 'cursor:reset' as const,
+      actorId: 'a',
+      issuedAt: NOW,
+      expiresAt: NOW + 1000,
+      requiresDualControl: false,
+    });
+    store.delete('tok');
+    expect(store.get('tok')).toBeUndefined();
+  });
+
+  it('clear() removes all entries', () => {
+    const store = new InMemoryTokenStore();
+    store.set('a', {
+      token: 'a',
+      actionScope: 'cursor:reset' as const,
+      actorId: 'x',
+      issuedAt: NOW,
+      expiresAt: NOW + 1000,
+      requiresDualControl: false,
+    });
+    store.clear();
+    expect(store.get('a')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareAction
+// ---------------------------------------------------------------------------
+
+describe('prepareAction', () => {
+  let store: InMemoryTokenStore;
+  let audit: ReturnType<typeof makeAudit>;
+
+  beforeEach(() => {
+    store = new InMemoryTokenStore();
+    audit = makeAudit();
+  });
+
+  it('returns a token with correct shape for a non-dual-control action', () => {
+    const result = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+
+    expect(typeof result.token).toBe('string');
+    expect(result.token.length).toBeGreaterThan(0);
+    expect(result.actionScope).toBe('cursor:reset');
+    expect(result.expiresAt).toBe(NOW + TOKEN_TTL_MS);
+    expect(result.requiresDualControl).toBe(false);
+  });
+
+  it('marks the result as requiresDualControl for jobs:purge', () => {
+    const result = prepareAction(makeCtx(), 'jobs:purge', store, audit, NOW);
+    expect(result.requiresDualControl).toBe(true);
+  });
+
+  it('marks the result as requiresDualControl for sync:force', () => {
+    const result = prepareAction(makeCtx(), 'sync:force', store, audit, NOW);
+    expect(result.requiresDualControl).toBe(true);
+  });
+
+  it('persists the token in the store', () => {
+    const { token } = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+    expect(store.get(token)).toBeDefined();
+    expect(store.get(token)?.actionScope).toBe('cursor:reset');
+  });
+
+  it('writes a confirmation_token.issued audit event', () => {
+    prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+
+    expect(audit.events).toHaveLength(1);
+    expect(audit.events[0]).toMatchObject({
+      timestamp: NOW,
+      actor: 'admin-1',
+      action: 'confirmation_token.issued',
+      detail: {
+        actionScope: 'cursor:reset',
+        expiresAt: NOW + TOKEN_TTL_MS,
+        requiresDualControl: false,
+      },
+    });
+  });
+
+  it('rejects an unknown action with UNKNOWN_ACTION code', () => {
+    expect(() => prepareAction(makeCtx(), 'drop:database', store, audit, NOW))
+      .toThrow(ConfirmationTokenError);
+    expect(() => prepareAction(makeCtx(), 'drop:database', store, audit, NOW))
+      .toThrow(expect.objectContaining({ code: 'UNKNOWN_ACTION' }));
+  });
+
+  it('rejects when step-up is missing', () => {
+    const ctx: AdminContext = {
+      adminId: 'admin-1',
+      session: { adminId: 'admin-1', roles: ['admin'] }, // no stepUpVerifiedAt
+    };
+    expect(() => prepareAction(ctx, 'cursor:reset', store, audit, NOW))
+      .toThrow(StepUpError);
+  });
+
+  it('rejects when step-up is expired', () => {
+    // Step-up was verified 20 minutes ago (> 15-minute TTL)
+    const ctx = makeCtx('admin-1', 20 * 60 * 1000);
+    expect(() => prepareAction(ctx, 'cursor:reset', store, audit, NOW))
+      .toThrow(StepUpError);
+  });
+
+  it('issues distinct tokens on successive calls', () => {
+    const r1 = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+    const r2 = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+    expect(r1.token).not.toBe(r2.token);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateConfirmationToken
+// ---------------------------------------------------------------------------
+
+describe('validateConfirmationToken', () => {
+  let store: InMemoryTokenStore;
+  let audit: ReturnType<typeof makeAudit>;
+
+  beforeEach(() => {
+    store = new InMemoryTokenStore();
+    audit = makeAudit();
+  });
+
+  it('accepts a valid, non-expired, correctly-scoped token', () => {
+    const { token } = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+    expect(() => validateConfirmationToken(token, 'cursor:reset', store, NOW)).not.toThrow();
+  });
+
+  it('rejects when token is undefined — MISSING', () => {
+    expect(() => validateConfirmationToken(undefined, 'cursor:reset', store, NOW))
+      .toThrow(expect.objectContaining({ code: 'MISSING' }));
+  });
+
+  it('rejects when token is unknown string — MISSING', () => {
+    expect(() => validateConfirmationToken('not-a-real-token', 'cursor:reset', store, NOW))
+      .toThrow(expect.objectContaining({ code: 'MISSING' }));
+  });
+
+  it('rejects an expired token — EXPIRED', () => {
+    const { token } = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+    const futureNow = NOW + TOKEN_TTL_MS + 1;
+
+    expect(() => validateConfirmationToken(token, 'cursor:reset', store, futureNow))
+      .toThrow(expect.objectContaining({ code: 'EXPIRED' }));
+  });
+
+  it('removes an expired token from the store', () => {
+    const { token } = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+    const futureNow = NOW + TOKEN_TTL_MS + 1;
+
+    try { validateConfirmationToken(token, 'cursor:reset', store, futureNow); } catch { /* expected */ }
+    expect(store.get(token)).toBeUndefined();
+  });
+
+  it('rejects a token with wrong scope — WRONG_SCOPE', () => {
+    const { token } = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+
+    expect(() => validateConfirmationToken(token, 'jobs:purge', store, NOW))
+      .toThrow(expect.objectContaining({ code: 'WRONG_SCOPE' }));
+  });
+
+  it('rejects a dual-control token that has not been approved — SECOND_APPROVER_REQUIRED', () => {
+    const { token } = prepareAction(makeCtx(), 'jobs:purge', store, audit, NOW);
+
+    expect(() => validateConfirmationToken(token, 'jobs:purge', store, NOW))
+      .toThrow(expect.objectContaining({ code: 'SECOND_APPROVER_REQUIRED' }));
+  });
+
+  it('accepts a dual-control token that has been approved', () => {
+    const { token } = prepareAction(makeCtx('admin-1'), 'jobs:purge', store, audit, NOW);
+    approveAction(makeCtx('admin-2'), token, store, audit, NOW);
+
+    expect(() => validateConfirmationToken(token, 'jobs:purge', store, NOW)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// approveAction
+// ---------------------------------------------------------------------------
+
+describe('approveAction', () => {
+  let store: InMemoryTokenStore;
+  let audit: ReturnType<typeof makeAudit>;
+
+  beforeEach(() => {
+    store = new InMemoryTokenStore();
+    audit = makeAudit();
+  });
+
+  it('records the second approver on the token entry', () => {
+    const { token } = prepareAction(makeCtx('admin-1'), 'jobs:purge', store, audit, NOW);
+    approveAction(makeCtx('admin-2'), token, store, audit, NOW);
+
+    const entry = store.get(token);
+    expect(entry?.secondApproverId).toBe('admin-2');
+    expect(entry?.approvedAt).toBe(NOW);
+  });
+
+  it('writes a confirmation_token.approved audit event', () => {
+    const { token } = prepareAction(makeCtx('admin-1'), 'sync:force', store, audit, NOW);
+    approveAction(makeCtx('admin-2'), token, store, audit, NOW);
+
+    const approvedEvent = audit.events.find(e => e.action === 'confirmation_token.approved');
+    expect(approvedEvent).toMatchObject({
+      timestamp: NOW,
+      actor: 'admin-2',
+      action: 'confirmation_token.approved',
+      detail: {
+        actionScope: 'sync:force',
+        originalActor: 'admin-1',
+      },
+    });
+  });
+
+  it('rejects an unknown token — MISSING', () => {
+    expect(() => approveAction(makeCtx('admin-2'), 'ghost-token', store, audit, NOW))
+      .toThrow(expect.objectContaining({ code: 'MISSING' }));
+  });
+
+  it('rejects an expired token — EXPIRED', () => {
+    const { token } = prepareAction(makeCtx('admin-1'), 'jobs:purge', store, audit, NOW);
+
+    expect(() => approveAction(makeCtx('admin-2'), token, store, audit, NOW + TOKEN_TTL_MS + 1))
+      .toThrow(expect.objectContaining({ code: 'EXPIRED' }));
+  });
+
+  it('removes an expired token from the store on approval attempt', () => {
+    const { token } = prepareAction(makeCtx('admin-1'), 'jobs:purge', store, audit, NOW);
+    const futureNow = NOW + TOKEN_TTL_MS + 1;
+
+    try { approveAction(makeCtx('admin-2'), token, store, audit, futureNow); } catch { /* expected */ }
+    expect(store.get(token)).toBeUndefined();
+  });
+
+  it('rejects approval of a non-dual-control action — NOT_DUAL_CONTROL', () => {
+    const { token } = prepareAction(makeCtx('admin-1'), 'cursor:reset', store, audit, NOW);
+
+    expect(() => approveAction(makeCtx('admin-2'), token, store, audit, NOW))
+      .toThrow(expect.objectContaining({ code: 'NOT_DUAL_CONTROL' }));
+  });
+
+  it('rejects self-approval — SELF_APPROVAL', () => {
+    const { token } = prepareAction(makeCtx('admin-1'), 'jobs:purge', store, audit, NOW);
+
+    expect(() => approveAction(makeCtx('admin-1'), token, store, audit, NOW))
+      .toThrow(expect.objectContaining({ code: 'SELF_APPROVAL' }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeDestructiveAction
+// ---------------------------------------------------------------------------
+
+describe('executeDestructiveAction', () => {
+  let store: InMemoryTokenStore;
+  let audit: ReturnType<typeof makeAudit>;
+
+  beforeEach(() => {
+    store = new InMemoryTokenStore();
+    audit = makeAudit();
+  });
+
+  it('calls the executor for a valid non-dual-control token', async () => {
+    const executor = vi.fn().mockResolvedValue(undefined);
+    const { token } = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+
+    await executeDestructiveAction(makeCtx(), token, 'cursor:reset', executor, store, audit, NOW);
+    expect(executor).toHaveBeenCalledOnce();
+  });
+
+  it('calls the executor for a dual-control token after approval', async () => {
+    const executor = vi.fn().mockResolvedValue(undefined);
+    const { token } = prepareAction(makeCtx('admin-1'), 'jobs:purge', store, audit, NOW);
+    approveAction(makeCtx('admin-2'), token, store, audit, NOW);
+
+    await executeDestructiveAction(makeCtx('admin-1'), token, 'jobs:purge', executor, store, audit, NOW);
+    expect(executor).toHaveBeenCalledOnce();
+  });
+
+  it('consumes the token so it cannot be replayed', async () => {
+    const executor = vi.fn().mockResolvedValue(undefined);
+    const { token } = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+    await executeDestructiveAction(makeCtx(), token, 'cursor:reset', executor, store, audit, NOW);
+
+    await expect(
+      executeDestructiveAction(makeCtx(), token, 'cursor:reset', executor, store, audit, NOW),
+    ).rejects.toThrow(expect.objectContaining({ code: 'MISSING' }));
+  });
+
+  it('consumes the token BEFORE the executor runs (replay-safe on failure)', async () => {
+    const consumedBeforeRun = { value: false };
+    const executor = vi.fn().mockImplementation(async () => {
+      consumedBeforeRun.value = store.get('sentinel') === undefined;
+      throw new Error('executor failure');
+    });
+
+    const { token } = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+    // Rename the internal token key to "sentinel" so we can observe deletion.
+    const entry = store.get(token)!;
+    store.set('sentinel', { ...entry, token: 'sentinel' });
+    store.delete(token);
+
+    try {
+      await executeDestructiveAction(makeCtx(), 'sentinel', 'cursor:reset', executor, store, audit, NOW);
+    } catch { /* expected */ }
+
+    expect(consumedBeforeRun.value).toBe(true);
+  });
+
+  it('writes started and completed audit events in order', async () => {
+    const executor = vi.fn().mockResolvedValue(undefined);
+    const { token } = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+    await executeDestructiveAction(makeCtx(), token, 'cursor:reset', executor, store, audit, NOW);
+
+    const actions = audit.events.map(e => e.action);
+    expect(actions).toContain('cursor:reset.started');
+    expect(actions).toContain('cursor:reset.completed');
+    expect(actions.indexOf('cursor:reset.started')).toBeLessThan(
+      actions.indexOf('cursor:reset.completed'),
+    );
+  });
+
+  it('started audit event includes confirmedBy and approvedBy', async () => {
+    const executor = vi.fn().mockResolvedValue(undefined);
+    const { token } = prepareAction(makeCtx('admin-1'), 'jobs:purge', store, audit, NOW);
+    approveAction(makeCtx('admin-2'), token, store, audit, NOW);
+
+    await executeDestructiveAction(makeCtx('admin-1'), token, 'jobs:purge', executor, store, audit, NOW);
+
+    const startedEvent = audit.events.find(e => e.action === 'jobs:purge.started');
+    expect(startedEvent?.detail).toMatchObject({
+      confirmedBy: 'admin-1',
+      approvedBy: 'admin-2',
+    });
+  });
+
+  it('rejects a missing token — MISSING', async () => {
+    await expect(
+      executeDestructiveAction(makeCtx(), undefined, 'cursor:reset', vi.fn(), store, audit, NOW),
+    ).rejects.toThrow(expect.objectContaining({ code: 'MISSING' }));
+  });
+
+  it('rejects an expired token — EXPIRED', async () => {
+    const { token } = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+
+    await expect(
+      executeDestructiveAction(makeCtx(), token, 'cursor:reset', vi.fn(), store, audit, NOW + TOKEN_TTL_MS + 1),
+    ).rejects.toThrow(expect.objectContaining({ code: 'EXPIRED' }));
+  });
+
+  it('rejects a wrong-scope token — WRONG_SCOPE', async () => {
+    const { token } = prepareAction(makeCtx(), 'cursor:reset', store, audit, NOW);
+
+    await expect(
+      executeDestructiveAction(makeCtx(), token, 'sync:force', vi.fn(), store, audit, NOW),
+    ).rejects.toThrow(expect.objectContaining({ code: 'WRONG_SCOPE' }));
+  });
+
+  it('rejects a dual-control token that has not been approved — SECOND_APPROVER_REQUIRED', async () => {
+    const { token } = prepareAction(makeCtx(), 'jobs:purge', store, audit, NOW);
+
+    await expect(
+      executeDestructiveAction(makeCtx(), token, 'jobs:purge', vi.fn(), store, audit, NOW),
+    ).rejects.toThrow(expect.objectContaining({ code: 'SECOND_APPROVER_REQUIRED' }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full end-to-end audit trail
+// ---------------------------------------------------------------------------
+
+describe('full audit trail', () => {
+  it('dual-control flow produces prepare → approve → started → completed events', async () => {
+    const store = new InMemoryTokenStore();
+    const audit = makeAudit();
+
+    const { token } = prepareAction(makeCtx('admin-1'), 'sync:force', store, audit, NOW);
+    approveAction(makeCtx('admin-2'), token, store, audit, NOW);
+    await executeDestructiveAction(
+      makeCtx('admin-1'),
+      token,
+      'sync:force',
+      vi.fn().mockResolvedValue(undefined),
+      store,
+      audit,
+      NOW,
+    );
+
+    const actions = audit.events.map(e => e.action);
+    expect(actions).toEqual([
+      'confirmation_token.issued',
+      'confirmation_token.approved',
+      'sync:force.started',
+      'sync:force.completed',
+    ]);
+  });
+
+  it('single-control flow produces prepare → started → completed events', async () => {
+    const store = new InMemoryTokenStore();
+    const audit = makeAudit();
+
+    const { token } = prepareAction(makeCtx('admin-1'), 'cursor:reset', store, audit, NOW);
+    await executeDestructiveAction(
+      makeCtx('admin-1'),
+      token,
+      'cursor:reset',
+      vi.fn().mockResolvedValue(undefined),
+      store,
+      audit,
+      NOW,
+    );
+
+    const actions = audit.events.map(e => e.action);
+    expect(actions).toEqual([
+      'confirmation_token.issued',
+      'cursor:reset.started',
+      'cursor:reset.completed',
+    ]);
+  });
+
+  it('each audit event carries the correct actor', async () => {
+    const store = new InMemoryTokenStore();
+    const audit = makeAudit();
+
+    const { token } = prepareAction(makeCtx('admin-1'), 'jobs:purge', store, audit, NOW);
+    approveAction(makeCtx('admin-2'), token, store, audit, NOW);
+    await executeDestructiveAction(
+      makeCtx('admin-1'),
+      token,
+      'jobs:purge',
+      vi.fn().mockResolvedValue(undefined),
+      store,
+      audit,
+      NOW,
+    );
+
+    expect(audit.events[0].actor).toBe('admin-1'); // issued
+    expect(audit.events[1].actor).toBe('admin-2'); // approved
+    expect(audit.events[2].actor).toBe('admin-1'); // started
+    expect(audit.events[3].actor).toBe('admin-1'); // completed
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StepUp integration (via prepareAction)
+// ---------------------------------------------------------------------------
+
+describe('step-up integration', () => {
+  it('fresh step-up (0 ms old) is accepted', () => {
+    const store = new InMemoryTokenStore();
+    const audit = makeAudit();
+    expect(() =>
+      prepareAction(makeCtx('admin-1', 0), 'cursor:reset', store, audit, NOW),
+    ).not.toThrow();
+  });
+
+  it('step-up at exactly TTL boundary is accepted', () => {
+    const store = new InMemoryTokenStore();
+    const audit = makeAudit();
+    // stepUpVerifiedAt is exactly 15 min ago (== TTL, not >)
+    const ctx = makeCtx('admin-1', 15 * 60 * 1000);
+    expect(() => prepareAction(ctx, 'cursor:reset', store, audit, NOW)).not.toThrow();
+  });
+
+  it('step-up 1 ms past TTL is rejected', () => {
+    const store = new InMemoryTokenStore();
+    const audit = makeAudit();
+    const ctx = makeCtx('admin-1', 15 * 60 * 1000 + 1);
+    expect(() => prepareAction(ctx, 'cursor:reset', store, audit, NOW)).toThrow(StepUpError);
+  });
+});


### PR DESCRIPTION
Closes #881

Implements a two-phase execution guard for the three highest-impact
admin operations so that no single compromised session can trigger an irreversible
action unilaterally.

- **Phase 1 — Prepare**: admin calls `POST /admin/prepare` with
the action name
  and an active step-up credential; receives a short-lived (5
min), action-scop
  confirmation token.
- **Phase 2a — Aps only)*: a*different* admin calls
  `POST /admin/appproval is blockedat the guard level.
- **Phase 2b — Exoint reads`X-Confirmation-Token`,
  validates scopeoken before theexecutor runs**
  (replay-safe evstarted` and`completed` audit events.

---

## Changed Files

| File | Change |
|------|--------|
| `src/middleware/stepUp.ts` | **New** — `AdminSession`,
`StepUpError`, `r
| `src/routes/admin.ts` | **New** — full token + dual-control
system |
| `src/tests/admin.dualControl.test.ts` | **New** — 49 tests,
100% coverage |
| `docs/admin-overrides.md` | **New** — operator runbook |

---

## Protected Actions

| Action | Description | Dual control |
|--------|-------
| `cursor:reset` | Resets the event-processing cursor | No |
| `jobs:purge` | d jobs | **Yes** |
| `sync:force` | Drops and rebuilds sync state from scratch |
**Yes** |

Adding a new protange to`DESTRUCTIVE_ACTIONS`
(and optionally `c/routes/admin.ts`.

---

## Key Design Dec

**Token consumed
The store entry is deleted before `executor()` is called. If the
executor throws,
the token is still gone — no window for a second attempt with the
same token.
This is tested explicitly with a mock that inspects store state
mid-execution.

**All dependencie
`TokenStore`, `AuditLogger`, and the `now` timestamp are parameters on eve
function. There is no module-level state, no singleton, and no
clock mocking
required — the full suite runs in the vitest node environment
without fake time

**Typed error cod
`ConfirmationTokenError` carries a `code` discriminant so callers
can map each
failure to the correct HTTP status (`MISSING` → 401/404,
`EXPIRED` → 410,
`WRONG_SCOPE` → 422, `SECOND_APPROVER_REQUIRED` → 202/conflict,
`SELF_APPROVAL` →

**Step-up TTL is
`elapsed > ttl` (strict greater-than) so a credential verified exactly at the
TTL boundary is still accepted. The test suite asserts the exact
millisecond
boundary in both directions.

---

## Error Codes

| Code | Meaning |
|------|---------
| `MISSING` | Token absent, unknown, or already consumed |
| `EXPIRED` | Tok
| `WRONG_SCOPE` | Token was issued for a different action |
| `SECOND_APPROVEtion awaitingsecond admin |
| `SELF_APPROVAL` who prepared thetoken |
| `NOT_DUAL_CONTRgle-control action|
| `UNKNOWN_ACTIONTRUCTIVE_ACTIONS` |

---

## Audit Trail

Every step produc, actor, action,detail }`.
A complete dual-c events in order:

confirmation_toke
confirmation_token.approved actor=admin-2
sync:force.starteail={confirmedBy,approvedBy}
sync:force.comple

---

## Test Coverage

npm test -- src/ts

49 tests across 8 branch, andfunction coverage
on `src/middlewaradmin.ts`.

| Block | What is
|-------|----------------|
| `configuration`ntrol subsetinvariant |
| `InMemoryTokenS
| `prepareAction` | Token shape, dual-control flag, unknown action, missing sinct tokens percall |
| `validateConfirissing, unknown,expired (+ store cleanup), wrong scope, unapproved dual-control,
approved dual-con
| `approveAction` | Approver recorded, audit event, unknown
token, expired (+trol rejection,self-approval |
| `executeDestruc, tokenpre-consumed, audit event order, `confirmedBy`/`approvedBy` in
events, all five
| `full audit trail` | Exact 4-event sequence for dual-control;
3-event for singlevent |
| `step-up integration` | Fresh credential, exact TTL boundary, 1
ms past TTL |

---

## Test Plan

- [ ] `npm test -.test.ts` — 49tests, all green
- [ ] Execute `cu `MISSING` error
- [ ] Prepare a token, let it expire, attempt execution →         `EXPIRED` error
- [ ] Prepare a token for `cursor:reset`, use it against          `jobs:purge` → `W
- [ ] Prepare a token for `jobs:purge`, execute without approver  → `SECOND_APPROVE
- [ ] Prepare a token for `jobs:purge`, approve as the same admin → `SELF_APPROVAL`
- [ ] Full dual-control run for `sync:force` with two disadmins → succeeds order
- [ ] Replay the same token after successful execution → `MISSING` error