### PR TITLE
feat: add formatRelativeTime util and apply to activity and transactions

### DIFF
--- a/design-system/documentation/getting-started.md
+++ b/design-system/documentation/getting-started.md
@@ -7,14 +7,14 @@ tokens and where contributors should add or validate new tokens.
 
 Design tokens live in `design-system/tokens/`:
 
-| Token file | Runtime surface | Notes |
-| --- | --- | --- |
-| `colors.json` | CSS variables in `src/index.css` such as `--bg`, `--surface`, `--text`, `--muted`, `--accent`, `--success`, `--warning`, and chart variables used by analytics views. | Use semantic names in components instead of hard-coded colors. |
-| `typography.json` | Typography CSS variables and classes in `src/index.css`, plus `src/utils/typography.ts`. | Components should use the `Text` component or `classifyTypography()` roles where possible. |
-| `spacing.json` | Spacing, container, touch-target, and breakpoint CSS variables in `src/index.css`; breakpoint details are documented in `documentation/breakpoints.md`. | Prefer `--spacing-*`, `--container-*`, and breakpoint tokens over one-off values. |
-| `borders.json` | Radius, border-width, and semantic border CSS variables in `src/index.css`. | Use `--radius-*`, `--border-width-*`, and semantic border variables for cards, fields, buttons, and modals. |
-| `shadows.json` | Elevation language for raised surfaces and overlays. | Match existing component surfaces before adding a new shadow. |
-| `motion.json` | JS motion constants in `src/utils/motion.ts` and reduced-motion guidance in `documentation/breakpoints.md`. | Use the exported `duration`, `ease`, and standard transitions for Framer Motion flows. |
+| Token file        | Runtime surface                                                                                                                                                       | Notes                                                                                                       |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `colors.json`     | CSS variables in `src/index.css` such as `--bg`, `--surface`, `--text`, `--muted`, `--accent`, `--success`, `--warning`, and chart variables used by analytics views. | Use semantic names in components instead of hard-coded colors.                                              |
+| `typography.json` | Typography CSS variables and classes in `src/index.css`, plus `src/utils/typography.ts`.                                                                              | Components should use the `Text` component or `classifyTypography()` roles where possible.                  |
+| `spacing.json`    | Spacing, container, touch-target, and breakpoint CSS variables in `src/index.css`; breakpoint details are documented in `documentation/breakpoints.md`.               | Prefer `--spacing-*`, `--container-*`, and breakpoint tokens over one-off values.                           |
+| `borders.json`    | Radius, border-width, and semantic border CSS variables in `src/index.css`.                                                                                           | Use `--radius-*`, `--border-width-*`, and semantic border variables for cards, fields, buttons, and modals. |
+| `shadows.json`    | Elevation language for raised surfaces and overlays.                                                                                                                  | Match existing component surfaces before adding a new shadow.                                               |
+| `motion.json`     | JS motion constants in `src/utils/motion.ts` and reduced-motion guidance in `documentation/breakpoints.md`.                                                           | Use the exported `duration`, `ease`, and standard transitions for Framer Motion flows.                      |
 
 ## Consuming Tokens In Components
 
@@ -31,6 +31,7 @@ Design tokens live in `design-system/tokens/`:
 4. Use `src/utils/motion.ts` for Framer Motion transitions. This keeps
    dropdowns, pages, and tooltips aligned with `motion.json`.
 5. Use `src/utils/csv.ts` for standardized CSV exports. The `toCsv()` utility supports both `ValidationTask[]` (for verification history) and `Transaction[]` (for vault activity logs). Pair it with `downloadCsv()` to trigger browser file downloads with stable, human-readable headers and proper comma-escaping.
+6. Use `src/utils/relativeTime.ts` for consistent, localized relative time formatting. The `formatRelativeTime()` utility handles seconds, minutes, hours, days, and weeks for both past and future dates using `Intl.RelativeTimeFormat`.
 
 ## Adding A Token
 
@@ -97,12 +98,12 @@ import { AddressDisplay } from '../components/AddressDisplay';
 
 ### Props
 
-| Prop | Type | Default | Description |
-| --- | --- | --- | --- |
-| `address` | `string` | — | Full Stellar address to display. |
-| `network` | `'TESTNET' \| 'PUBLIC' \| null` | `undefined` | When provided, renders an explorer link to `stellar.expert`. Omit or pass `null` to hide. |
-| `chars` | `number` | `6` | Characters to keep at the start of the truncated display. |
-| `tailChars` | `number` | `4` | Characters to keep at the end of the truncated display. |
+| Prop        | Type                            | Default     | Description                                                                               |
+| ----------- | ------------------------------- | ----------- | ----------------------------------------------------------------------------------------- |
+| `address`   | `string`                        | —           | Full Stellar address to display.                                                          |
+| `network`   | `'TESTNET' \| 'PUBLIC' \| null` | `undefined` | When provided, renders an explorer link to `stellar.expert`. Omit or pass `null` to hide. |
+| `chars`     | `number`                        | `6`         | Characters to keep at the start of the truncated display.                                 |
+| `tailChars` | `number`                        | `4`         | Characters to keep at the end of the truncated display.                                   |
 
 ### Accessibility
 
@@ -121,3 +122,44 @@ import { AddressDisplay } from '../components/AddressDisplay';
   so the explorer link points to the correct network.
 - The component uses `var(--success)`, `var(--muted)`, and `var(--accent)` CSS
   variables; it inherits correctly in both light and dark themes.
+
+## formatRelativeTime Utility
+
+`src/utils/relativeTime.ts` provides a consistent, localized relative time formatting
+utility using `Intl.RelativeTimeFormat`. It handles seconds, minutes, hours, days,
+and weeks for both past and future dates.
+
+```ts
+import { formatRelativeTime } from '../utils/relativeTime';
+
+// Basic usage - defaults to current time
+formatRelativeTime(new Date(Date.now() - 3600000)); // "1 hour ago"
+
+// With custom reference time for testing
+const now = new Date('2024-04-28T12:00:00Z').getTime();
+formatRelativeTime('2024-04-28T10:00:00Z', now); // "2 hours ago"
+
+// Future dates
+formatRelativeTime(new Date(Date.now() + 86400000)); // "in 1 day"
+
+// Accepts Date objects, ISO strings, or timestamps
+formatRelativeTime(new Date('2024-04-28T10:00:00Z'));
+formatRelativeTime('2024-04-28T10:00:00Z');
+formatRelativeTime(1714305600000);
+```
+
+### Features
+
+- **Localized**: Uses `Intl.RelativeTimeFormat` for proper English locale formatting
+- **Deterministic testing**: Optional `now` parameter allows predictable test results
+- **Comprehensive coverage**: Handles seconds, minutes, hours, days, and weeks
+- **Future support**: Formats both past and future dates correctly
+- **Graceful fallback**: Returns absolute date for dates beyond a month
+- **Error handling**: Returns "Invalid date" for invalid inputs
+
+### Usage Guidelines
+
+- Use `formatRelativeTime()` everywhere timestamps are displayed to users (activity feeds, transaction lists, etc.)
+- Avoid ad-hoc time formatting helpers in components
+- The utility is already applied in `src/utils/dashboard.ts` for the Dashboard activity feed and in `src/pages/VaultTransactions.tsx` for transaction timestamps
+- For testing, pass a fixed `now` timestamp to ensure deterministic results

--- a/src/pages/VaultTransactions.tsx
+++ b/src/pages/VaultTransactions.tsx
@@ -1,12 +1,13 @@
-import { useState, useMemo, useCallback, memo, useEffect } from "react";
-import { windowRange, WINDOW_THRESHOLD } from "../utils/windowRange";
-import { toCsv, downloadCsv } from "../utils/csv";
-import { computeTxTotals } from "../utils/txTotals";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { AddressDisplay } from "../components/AddressDisplay";
 import { Tooltip } from "../components/Tooltip";
-import type { TxType, TxStatus } from "../types/vault";
 import type { VaultActivityRecord } from "../services/vaultService";
 import { listAllActivity } from "../services/vaultService";
+import type { TxStatus, TxType } from "../types/vault";
+import { downloadCsv, toCsv } from "../utils/csv";
+import { formatRelativeTime } from "../utils/relativeTime";
+import { computeTxTotals } from "../utils/txTotals";
+import { windowRange } from "../utils/windowRange";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 export type Transaction = VaultActivityRecord;
@@ -105,11 +106,7 @@ function truncHash(hash: string, head = 8, tail = 6): string {
 }
 
 function fmtTime(date: Date): string {
-  const diff = Date.now() - date.getTime();
-  if (diff < 60000) return "just now";
-  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
-  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
-  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return formatRelativeTime(date);
 }
 
 function fmtFullTime(date: Date): string {
@@ -131,7 +128,6 @@ function fmtAmount(n: number): string {
   });
 }
 
-
 // ── Main Component ─────────────────────────────────────────────────────────────────
 export default function VaultTransactions() {
   const [allTransactions, setAllTransactions] = useState<Transaction[]>([]);
@@ -146,8 +142,11 @@ export default function VaultTransactions() {
 
   // Derive vault filter options from loaded transactions
   const VAULTS = useMemo(
-    () => ["All Vaults", ...Array.from(new Set(allTransactions.map((t) => t.vault)))],
-    [allTransactions]
+    () => [
+      "All Vaults",
+      ...Array.from(new Set(allTransactions.map((t) => t.vault))),
+    ],
+    [allTransactions],
   );
 
   const transactions = allTransactions;
@@ -202,16 +201,34 @@ export default function VaultTransactions() {
     transactions,
   ]);
 
-  const pending = useMemo(() => filtered.filter((t) => t.status === "pending"), [filtered]);
-  const failed = useMemo(() => filtered.filter((t) => t.status === "failed"), [filtered]);
-  const rest = useMemo(() => filtered.filter((t) => t.status === "confirmed"), [filtered]);
+  const pending = useMemo(
+    () => filtered.filter((t) => t.status === "pending"),
+    [filtered],
+  );
+  const failed = useMemo(
+    () => filtered.filter((t) => t.status === "failed"),
+    [filtered],
+  );
+  const rest = useMemo(
+    () => filtered.filter((t) => t.status === "confirmed"),
+    [filtered],
+  );
 
   // Reset window anchor when filters change so the user always sees the top.
   // windowRange is applied per-section; each section independently does not
   // exceed WINDOW_THRESHOLD in typical use, but large "confirmed" lists will.
-  const pendingWindow = useMemo(() => windowRange(pending, anchorIndex), [pending, anchorIndex]);
-  const failedWindow = useMemo(() => windowRange(failed, anchorIndex), [failed, anchorIndex]);
-  const restWindow = useMemo(() => windowRange(rest, anchorIndex), [rest, anchorIndex]);
+  const pendingWindow = useMemo(
+    () => windowRange(pending, anchorIndex),
+    [pending, anchorIndex],
+  );
+  const failedWindow = useMemo(
+    () => windowRange(failed, anchorIndex),
+    [failed, anchorIndex],
+  );
+  const restWindow = useMemo(
+    () => windowRange(rest, anchorIndex),
+    [rest, anchorIndex],
+  );
 
   const stats = useMemo(
     () => ({
@@ -239,10 +256,7 @@ export default function VaultTransactions() {
     return counts;
   }, [filtered]);
 
-  const filteredTotals = useMemo(
-    () => computeTxTotals(filtered),
-    [filtered],
-  );
+  const filteredTotals = useMemo(() => computeTxTotals(filtered), [filtered]);
 
   const clearFilters = () => {
     setSelectedTypes([...ALL_TYPES]);
@@ -282,7 +296,12 @@ export default function VaultTransactions() {
             </div>
             <button
               className="vt-export-btn"
-              onClick={() => downloadCsv(toCsv(filtered, "transactions"), "vault-transactions.csv")}
+              onClick={() =>
+                downloadCsv(
+                  toCsv(filtered, "transactions"),
+                  "vault-transactions.csv",
+                )
+              }
               disabled={filtered.length === 0}
             >
               <ExportIcon />
@@ -318,12 +337,18 @@ export default function VaultTransactions() {
           </div>
 
           {/* Type Filter Toolbar */}
-          <div className="vt-type-toolbar" role="group" aria-label="Filter by transaction type">
+          <div
+            className="vt-type-toolbar"
+            role="group"
+            aria-label="Filter by transaction type"
+          >
             <button
               className={`vt-type-chip ${selectedTypes.length === ALL_TYPES.length ? "vt-type-chip--active-all" : ""}`}
               onClick={() =>
                 setSelectedTypes(
-                  selectedTypes.length === ALL_TYPES.length ? [] : [...ALL_TYPES],
+                  selectedTypes.length === ALL_TYPES.length
+                    ? []
+                    : [...ALL_TYPES],
                 )
               }
               aria-pressed={selectedTypes.length === ALL_TYPES.length}
@@ -356,9 +381,14 @@ export default function VaultTransactions() {
                   }
                   aria-pressed={active}
                 >
-                  <meta.icon size={13} color={active ? meta.color : undefined} />
+                  <meta.icon
+                    size={13}
+                    color={active ? meta.color : undefined}
+                  />
                   <span className="vt-type-chip-label">{meta.label}</span>
-                  <span className="vt-type-chip-count">{filteredTypeCounts[type] ?? 0}</span>
+                  <span className="vt-type-chip-count">
+                    {filteredTypeCounts[type] ?? 0}
+                  </span>
                 </button>
               );
             })}
@@ -460,7 +490,9 @@ export default function VaultTransactions() {
                   end={pendingWindow.endIndex}
                   total={pending.length}
                   onPrev={() => setAnchorIndex((a) => Math.max(0, a - 10))}
-                  onNext={() => setAnchorIndex((a) => Math.min(pending.length - 1, a + 10))}
+                  onNext={() =>
+                    setAnchorIndex((a) => Math.min(pending.length - 1, a + 10))
+                  }
                 />
               )}
             </Section>
@@ -486,7 +518,9 @@ export default function VaultTransactions() {
                   end={failedWindow.endIndex}
                   total={failed.length}
                   onPrev={() => setAnchorIndex((a) => Math.max(0, a - 10))}
-                  onNext={() => setAnchorIndex((a) => Math.min(failed.length - 1, a + 10))}
+                  onNext={() =>
+                    setAnchorIndex((a) => Math.min(failed.length - 1, a + 10))
+                  }
                 />
               )}
             </Section>
@@ -513,7 +547,9 @@ export default function VaultTransactions() {
                     end={restWindow.endIndex}
                     total={rest.length}
                     onPrev={() => setAnchorIndex((a) => Math.max(0, a - 10))}
-                    onNext={() => setAnchorIndex((a) => Math.min(rest.length - 1, a + 10))}
+                    onNext={() =>
+                      setAnchorIndex((a) => Math.min(rest.length - 1, a + 10))
+                    }
                   />
                 )}
               </>
@@ -547,7 +583,11 @@ function Section({ title, accent, count, children }: SectionProps) {
   return (
     <section className="vt-section">
       <div className="vt-section-header">
-        <span className="vt-section-dot" style={{ background: accent }} aria-hidden="true" />
+        <span
+          className="vt-section-dot"
+          style={{ background: accent }}
+          aria-hidden="true"
+        />
         <span className="vt-section-title">{title}</span>
         <span className="vt-section-count">{count}</span>
       </div>
@@ -566,9 +606,7 @@ function Section({ title, accent, count, children }: SectionProps) {
             </div>
           </div>
         )}
-        <div role={hasRows ? "rowgroup" : undefined}>
-          {children}
-        </div>
+        <div role={hasRows ? "rowgroup" : undefined}>{children}</div>
       </div>
     </section>
   );
@@ -582,7 +620,13 @@ interface TxRowProps {
   children?: React.ReactNode;
 }
 
-const TxRow = memo(function TxRow({ tx, onSelect, onCopy, copiedId, children }: TxRowProps) {
+const TxRow = memo(function TxRow({
+  tx,
+  onSelect,
+  onCopy,
+  copiedId,
+  children,
+}: TxRowProps) {
   const meta = TYPE_META[tx.type];
   const status = STATUS_META[tx.status];
   const Icon = meta.icon;
@@ -646,7 +690,11 @@ const TxRow = memo(function TxRow({ tx, onSelect, onCopy, copiedId, children }: 
           className="vt-tx-status"
           style={{ color: status.color, background: status.bg }}
         >
-          <span className="vt-status-dot" style={{ background: status.dot }} aria-hidden="true" />
+          <span
+            className="vt-status-dot"
+            style={{ background: status.dot }}
+            aria-hidden="true"
+          />
           {status.label}
         </span>
         <span className="vt-tx-time">{fmtTime(tx.timestamp)}</span>
@@ -877,17 +925,31 @@ interface WindowBannerProps {
   onNext: () => void;
 }
 
-function WindowBanner({ start, end, total, onPrev, onNext }: WindowBannerProps) {
+function WindowBanner({
+  start,
+  end,
+  total,
+  onPrev,
+  onNext,
+}: WindowBannerProps) {
   return (
     <div className="vt-window-banner">
       <span className="vt-window-info">
         Showing {start + 1}–{end} of {total}
       </span>
       <div className="vt-window-nav">
-        <button className="vt-window-btn" onClick={onPrev} disabled={start === 0}>
+        <button
+          className="vt-window-btn"
+          onClick={onPrev}
+          disabled={start === 0}
+        >
           ← Prev
         </button>
-        <button className="vt-window-btn" onClick={onNext} disabled={end >= total}>
+        <button
+          className="vt-window-btn"
+          onClick={onNext}
+          disabled={end >= total}
+        >
           Next →
         </button>
       </div>

--- a/src/utils/__tests__/relativeTime.test.ts
+++ b/src/utils/__tests__/relativeTime.test.ts
@@ -1,0 +1,148 @@
+import { formatRelativeTime } from "../relativeTime";
+
+describe("formatRelativeTime", () => {
+  const NOW = new Date("2024-04-28T12:00:00Z").getTime();
+
+  describe("past dates", () => {
+    it('should return "just now" for very recent timestamps', () => {
+      expect(formatRelativeTime(NOW - 5000, NOW)).toBe("just now");
+      expect(formatRelativeTime(NOW - 9000, NOW)).toBe("just now");
+    });
+
+    it("should format seconds correctly", () => {
+      expect(formatRelativeTime(NOW - 15000, NOW)).toBe("15 seconds ago");
+      expect(formatRelativeTime(NOW - 30000, NOW)).toBe("30 seconds ago");
+      expect(formatRelativeTime(NOW - 45000, NOW)).toBe("45 seconds ago");
+    });
+
+    it("should format minutes correctly", () => {
+      expect(formatRelativeTime(NOW - 60000, NOW)).toBe("1 minute ago");
+      expect(formatRelativeTime(NOW - 120000, NOW)).toBe("2 minutes ago");
+      expect(formatRelativeTime(NOW - 1800000, NOW)).toBe("30 minutes ago");
+      expect(formatRelativeTime(NOW - 3540000, NOW)).toBe("59 minutes ago");
+    });
+
+    it("should format hours correctly", () => {
+      expect(formatRelativeTime(NOW - 3600000, NOW)).toBe("1 hour ago");
+      expect(formatRelativeTime(NOW - 7200000, NOW)).toBe("2 hours ago");
+      expect(formatRelativeTime(NOW - 14400000, NOW)).toBe("4 hours ago");
+      expect(formatRelativeTime(NOW - 82800000, NOW)).toBe("23 hours ago");
+    });
+
+    it("should format days correctly", () => {
+      expect(formatRelativeTime(NOW - 86400000, NOW)).toBe("1 day ago");
+      expect(formatRelativeTime(NOW - 172800000, NOW)).toBe("2 days ago");
+      expect(formatRelativeTime(NOW - 432000000, NOW)).toBe("5 days ago");
+    });
+
+    it("should format weeks correctly", () => {
+      expect(formatRelativeTime(NOW - 604800000, NOW)).toBe("1 week ago");
+      expect(formatRelativeTime(NOW - 1209600000, NOW)).toBe("2 weeks ago");
+      expect(formatRelativeTime(NOW - 1814400000, NOW)).toBe("3 weeks ago");
+    });
+
+    it("should fall back to absolute date for dates beyond a month", () => {
+      const thirtyOneDaysAgo = NOW - 2678400000; // 31 days
+      const result = formatRelativeTime(thirtyOneDaysAgo, NOW);
+      expect(result).toMatch(/Mar/);
+    });
+  });
+
+  describe("future dates", () => {
+    it('should return "just now" for very near future timestamps', () => {
+      expect(formatRelativeTime(NOW + 5000, NOW)).toBe("just now");
+      expect(formatRelativeTime(NOW + 9000, NOW)).toBe("just now");
+    });
+
+    it("should format future seconds correctly", () => {
+      expect(formatRelativeTime(NOW + 15000, NOW)).toBe("in 15 seconds");
+      expect(formatRelativeTime(NOW + 30000, NOW)).toBe("in 30 seconds");
+    });
+
+    it("should format future minutes correctly", () => {
+      expect(formatRelativeTime(NOW + 60000, NOW)).toBe("in 1 minute");
+      expect(formatRelativeTime(NOW + 120000, NOW)).toBe("in 2 minutes");
+      expect(formatRelativeTime(NOW + 1800000, NOW)).toBe("in 30 minutes");
+    });
+
+    it("should format future hours correctly", () => {
+      expect(formatRelativeTime(NOW + 3600000, NOW)).toBe("in 1 hour");
+      expect(formatRelativeTime(NOW + 7200000, NOW)).toBe("in 2 hours");
+      expect(formatRelativeTime(NOW + 14400000, NOW)).toBe("in 4 hours");
+    });
+
+    it("should format future days correctly", () => {
+      expect(formatRelativeTime(NOW + 86400000, NOW)).toBe("in 1 day");
+      expect(formatRelativeTime(NOW + 172800000, NOW)).toBe("in 2 days");
+      expect(formatRelativeTime(NOW + 432000000, NOW)).toBe("in 5 days");
+    });
+
+    it("should format future weeks correctly", () => {
+      expect(formatRelativeTime(NOW + 604800000, NOW)).toBe("in 1 week");
+      expect(formatRelativeTime(NOW + 1209600000, NOW)).toBe("in 2 weeks");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle exactly 1 minute", () => {
+      expect(formatRelativeTime(NOW - 60000, NOW)).toBe("1 minute ago");
+      expect(formatRelativeTime(NOW + 60000, NOW)).toBe("in 1 minute");
+    });
+
+    it("should handle exactly 1 hour", () => {
+      expect(formatRelativeTime(NOW - 3600000, NOW)).toBe("1 hour ago");
+      expect(formatRelativeTime(NOW + 3600000, NOW)).toBe("in 1 hour");
+    });
+
+    it("should handle exactly 1 day", () => {
+      expect(formatRelativeTime(NOW - 86400000, NOW)).toBe("1 day ago");
+      expect(formatRelativeTime(NOW + 86400000, NOW)).toBe("in 1 day");
+    });
+
+    it("should handle exactly 1 week", () => {
+      expect(formatRelativeTime(NOW - 604800000, NOW)).toBe("1 week ago");
+      expect(formatRelativeTime(NOW + 604800000, NOW)).toBe("in 1 week");
+    });
+
+    it("should handle day boundaries", () => {
+      // Just under 24 hours
+      expect(formatRelativeTime(NOW - 82800000, NOW)).toBe("23 hours ago");
+      // Just over 24 hours
+      expect(formatRelativeTime(NOW - 86460000, NOW)).toBe("1 day ago");
+    });
+
+    it("should handle invalid dates", () => {
+      expect(formatRelativeTime("invalid date", NOW)).toBe("Invalid date");
+      expect(formatRelativeTime(NaN, NOW)).toBe("Invalid date");
+    });
+  });
+
+  describe("input formats", () => {
+    it("should accept Date objects", () => {
+      const date = new Date(NOW - 3600000);
+      expect(formatRelativeTime(date, NOW)).toBe("1 hour ago");
+    });
+
+    it("should accept ISO strings", () => {
+      const iso = new Date(NOW - 7200000).toISOString();
+      expect(formatRelativeTime(iso, NOW)).toBe("2 hours ago");
+    });
+
+    it("should accept timestamps", () => {
+      expect(formatRelativeTime(NOW - 1800000, NOW)).toBe("30 minutes ago");
+    });
+
+    it('should default to current time when "now" is not provided', () => {
+      const fiveMinutesAgo = Date.now() - 300000;
+      const result = formatRelativeTime(fiveMinutesAgo);
+      expect(result).toBe("5 minutes ago");
+    });
+  });
+
+  describe("localization", () => {
+    it("should use Intl.RelativeTimeFormat for English locale", () => {
+      expect(formatRelativeTime(NOW - 3600000, NOW)).toBe("1 hour ago");
+      expect(formatRelativeTime(NOW + 3600000, NOW)).toBe("in 1 hour");
+    });
+  });
+});

--- a/src/utils/dashboard.ts
+++ b/src/utils/dashboard.ts
@@ -1,4 +1,5 @@
-import type { VaultStatus } from '../types/vault';
+import type { VaultStatus } from "../types/vault";
+import { formatRelativeTime } from "./relativeTime";
 
 export type { VaultStatus };
 
@@ -47,10 +48,13 @@ export interface FormattedActivity extends Activity {
   relativeTime: string;
 }
 
-export function daysRemaining(deadline: string, now: number = Date.now()): number {
+export function daysRemaining(
+  deadline: string,
+  now: number = Date.now(),
+): number {
   return Math.max(
     0,
-    Math.ceil((new Date(deadline).getTime() - now) / 86400000)
+    Math.ceil((new Date(deadline).getTime() - now) / 86400000),
   );
 }
 
@@ -61,11 +65,7 @@ export function urgencyColor(days: number): string {
 }
 
 export function relativeTime(iso: string, now: number = Date.now()): string {
-  const diff = now - new Date(iso).getTime();
-  const h = Math.floor(diff / 3600000);
-  if (h < 1) return "just now";
-  if (h < 24) return `${h}h ago`;
-  return `${Math.floor(h / 24)}d ago`;
+  return formatRelativeTime(iso, now);
 }
 
 export function formatSummary(summary: DashboardSummary) {
@@ -77,9 +77,14 @@ export function formatSummary(summary: DashboardSummary) {
   };
 }
 
-export function processDeadlines(deadlines: Deadline[], now: number = Date.now()): FormattedDeadline[] {
+export function processDeadlines(
+  deadlines: Deadline[],
+  now: number = Date.now(),
+): FormattedDeadline[] {
   return [...deadlines]
-    .sort((a, b) => new Date(a.deadline).getTime() - new Date(b.deadline).getTime())
+    .sort(
+      (a, b) => new Date(a.deadline).getTime() - new Date(b.deadline).getTime(),
+    )
     .map((d) => {
       const days = daysRemaining(d.deadline, now);
       const color = urgencyColor(days);
@@ -97,13 +102,20 @@ export function processDeadlines(deadlines: Deadline[], now: number = Date.now()
     });
 }
 
-export function processActivity(activities: Activity[], now: number = Date.now()): FormattedActivity[] {
+export function processActivity(
+  activities: Activity[],
+  now: number = Date.now(),
+): FormattedActivity[] {
   return [...activities]
-    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+    .sort(
+      (a, b) =>
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    )
     .map((a) => {
       return {
         ...a,
-        formattedAmount: a.amount != null ? `${a.amount.toLocaleString()} USDC` : undefined,
+        formattedAmount:
+          a.amount != null ? `${a.amount.toLocaleString()} USDC` : undefined,
         relativeTime: relativeTime(a.timestamp, now),
       };
     });

--- a/src/utils/relativeTime.ts
+++ b/src/utils/relativeTime.ts
@@ -1,0 +1,76 @@
+/**
+ * formatRelativeTime - Format a date as a relative time string (e.g., "2 hours ago")
+ *
+ * Uses Intl.RelativeTimeFormat for localized, human-readable time differences.
+ * Handles seconds, minutes, hours, days, and weeks. Supports both past and future dates.
+ *
+ * @param date - The date to format (Date object, ISO string, or timestamp)
+ * @param now - Optional reference time for testing (defaults to current time)
+ * @returns A localized relative time string (e.g., "2 hours ago", "in 3 days")
+ *
+ * @example
+ * formatRelativeTime(new Date(Date.now() - 3600000)) // "1 hour ago"
+ * formatRelativeTime(new Date(Date.now() + 86400000)) // "in 1 day"
+ * formatRelativeTime("2024-04-28T14:30:00Z", new Date("2024-04-28T16:30:00Z").getTime()) // "2 hours ago"
+ */
+export function formatRelativeTime(
+  date: Date | string | number,
+  now: number = Date.now(),
+): string {
+  // Convert input to timestamp
+  const timestamp = typeof date === "number" ? date : new Date(date).getTime();
+
+  // Handle invalid dates
+  if (isNaN(timestamp)) {
+    return "Invalid date";
+  }
+
+  const diffInSeconds = (timestamp - now) / 1000;
+  const absDiff = Math.abs(diffInSeconds);
+
+  // Use Intl.RelativeTimeFormat for localized formatting
+  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "always" });
+
+  // Less than 1 minute
+  if (absDiff < 60) {
+    if (absDiff < 10) {
+      return diffInSeconds > 0 ? "just now" : "just now";
+    }
+    return rtf.format(Math.round(diffInSeconds), "second");
+  }
+
+  // Less than 1 hour
+  if (absDiff < 3600) {
+    const minutes = Math.round(diffInSeconds / 60);
+    return rtf.format(minutes, "minute");
+  }
+
+  // Less than 1 day
+  if (absDiff < 86400) {
+    const hours = Math.round(diffInSeconds / 3600);
+    return rtf.format(hours, "hour");
+  }
+
+  // Less than 1 week
+  if (absDiff < 604800) {
+    const days = Math.round(diffInSeconds / 86400);
+    return rtf.format(days, "day");
+  }
+
+  // Less than 1 month (approximately 30 days)
+  if (absDiff < 2592000) {
+    const weeks = Math.round(diffInSeconds / 604800);
+    return rtf.format(weeks, "week");
+  }
+
+  // For dates beyond a month, fall back to absolute date formatting
+  const dateObj = new Date(timestamp);
+  return dateObj.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year:
+      dateObj.getFullYear() !== new Date(now).getFullYear()
+        ? "numeric"
+        : undefined,
+  });
+}


### PR DESCRIPTION
Closes #271

- Add src/utils/relativeTime.ts with formatRelativeTime utility
- Uses Intl.RelativeTimeFormat for localized time formatting
- Handles seconds, minutes, hours, days, and weeks for past/future dates
- Pure function with injectable now parameter for deterministic tests
- Apply to Dashboard activity feed via src/utils/dashboard.ts
- Apply to VaultTransactions timestamps via fmtTime helper
- Add comprehensive test suite in src/utils/__tests__/relativeTime.test.ts
- Document utility in design-system/documentation/getting-started.md