### PR TITLE
test: schema and ordering tests for z-index tokens

### DIFF
--- a/design-system/package-lock.json
+++ b/design-system/package-lock.json
@@ -52,6 +52,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1393,6 +1394,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1562,6 +1564,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1871,6 +1874,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2283,6 +2287,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3180,6 +3185,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5006,6 +5012,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/design-system/src/__tests__/z-index.test.ts
+++ b/design-system/src/__tests__/z-index.test.ts
@@ -1,0 +1,74 @@
+import { loadTokens } from '../utils/token-loader';
+
+// Documented stacking order: base < header < drawer < modal < toast.
+const LAYER_ORDER = ['base', 'header', 'drawer', 'modal', 'toast'] as const;
+
+interface NumberToken {
+  $type: string;
+  $value: unknown;
+  $description?: string;
+}
+
+function getLayers(): Record<string, NumberToken> {
+  const tokens = loadTokens('z-index.json');
+  const zIndex = tokens.zIndex as Record<string, NumberToken> | undefined;
+  expect(zIndex).toBeDefined();
+  return zIndex as Record<string, NumberToken>;
+}
+
+describe('z-index.json schema', () => {
+  let layers: Record<string, NumberToken>;
+
+  beforeAll(() => {
+    layers = getLayers();
+  });
+
+  it('defines exactly the documented layers', () => {
+    expect(Object.keys(layers).sort()).toEqual([...LAYER_ORDER].sort());
+  });
+
+  it('every layer is a DTCG number token with a numeric $value', () => {
+    LAYER_ORDER.forEach((name) => {
+      const layer = layers[name];
+      expect(layer.$type).toBe('number');
+      expect(typeof layer.$value).toBe('number');
+      expect(Number.isFinite(layer.$value as number)).toBe(true);
+    });
+  });
+
+  it('values are strictly increasing in the documented order', () => {
+    const values = LAYER_ORDER.map((name) => layers[name].$value as number);
+    for (let i = 1; i < values.length; i += 1) {
+      expect(values[i]).toBeGreaterThan(values[i - 1]);
+    }
+  });
+
+  it('no two layers share a value (uniqueness)', () => {
+    const values = LAYER_ORDER.map((name) => layers[name].$value as number);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});
+
+describe('z-index schema assertions catch malformed tokens', () => {
+  // Guard helpers mirroring the assertions above, exercised against fixtures
+  // so a type mismatch or collision is provably detected.
+  function isNumberToken(token: NumberToken): boolean {
+    return token.$type === 'number' && typeof token.$value === 'number';
+  }
+
+  function isStrictlyIncreasing(values: number[]): boolean {
+    return values.every((v, i) => i === 0 || v > values[i - 1]);
+  }
+
+  it('flags a $type mismatch', () => {
+    expect(isNumberToken({ $type: 'dimension', $value: 100 })).toBe(false);
+    expect(isNumberToken({ $type: 'number', $value: '100' })).toBe(false);
+    expect(isNumberToken({ $type: 'number', $value: 100 })).toBe(true);
+  });
+
+  it('flags out-of-order or duplicate values', () => {
+    expect(isStrictlyIncreasing([0, 100, 200, 300, 400])).toBe(true);
+    expect(isStrictlyIncreasing([0, 100, 100, 300])).toBe(false); // duplicate
+    expect(isStrictlyIncreasing([0, 300, 200])).toBe(false); // out of order
+  });
+});


### PR DESCRIPTION
Closes #487.

Adds `design-system/src/__tests__/z-index.test.ts` asserting each z-index layer is a DTCG `number` token with a numeric `$value`, that values are strictly increasing in the documented order (base < header < drawer < modal < toast), and that no two layers share a value. Also includes guard-helper fixtures proving a $type mismatch, duplicate, or out-of-order value is detected. All tests pass via jest.