### PR TITLE
test: add coverage for design-system logger

### DIFF
--- a/design-system/src/__tests__/logger.test.ts
+++ b/design-system/src/__tests__/logger.test.ts
@@ -1,0 +1,83 @@
+import { logger } from '../utils/logger';
+
+describe('design-system logger', () => {
+  const originalEnv = process.env.NODE_ENV;
+  let debugSpy: jest.SpyInstance;
+  let infoSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  describe('non-production routing', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development';
+    });
+
+    it('routes debug to console.debug', () => {
+      logger.debug('hello');
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+      expect(debugSpy).toHaveBeenCalledWith('hello');
+    });
+
+    it('routes info to console.info', () => {
+      logger.info('hi');
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      expect(infoSpy).toHaveBeenCalledWith('hi');
+    });
+
+    it('routes warn to console.warn', () => {
+      logger.warn('careful');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith('careful');
+    });
+
+    it('routes error to console.error', () => {
+      logger.error('boom');
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledWith('boom');
+    });
+
+    it('forwards metadata/object arguments unchanged', () => {
+      const meta = { file: 'colors.json', count: 3 };
+      logger.warn('Failed to load:', meta);
+      expect(warnSpy).toHaveBeenCalledWith('Failed to load:', meta);
+    });
+
+    it('supports a no-argument call without throwing', () => {
+      expect(() => logger.info()).not.toThrow();
+      expect(infoSpy).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('production level gating', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+    });
+
+    it('suppresses debug, info, and warn', () => {
+      logger.debug('d');
+      logger.info('i');
+      logger.warn('w');
+      expect(debugSpy).not.toHaveBeenCalled();
+      expect(infoSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('still emits error in production', () => {
+      logger.error('critical', { code: 500 });
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledWith('critical', { code: 500 });
+    });
+  });
+});


### PR DESCRIPTION
Closes #486.

Adds `design-system/src/__tests__/logger.test.ts` mocking the console methods to assert debug/info/warn/error each route to the matching console method, that object/metadata arguments are forwarded unchanged, and that a no-arg call does not throw. Also verifies production level gating: debug/info/warn are suppressed while error still emits. All tests pass via jest.