### PR TITLE
feat: add breakpoint tokens and hook

### DIFF
--- a/design-system/documentation/breakpoints.md
+++ b/design-system/documentation/breakpoints.md
@@ -1,7 +1,7 @@
 # Responsive Breakpoints
 
 Canonical breakpoint reference for Disciplr. All values are sourced from
-[`design-system/tokens/spacing.json`](../tokens/spacing.json) under `spacing.breakpoint.*`.
+[`design-system/tokens/breakpoints.json`](../tokens/breakpoints.json) under `breakpoint.*`.
 
 These breakpoints align 1:1 with Tailwind v4 defaults (used via `@tailwindcss/vite` in
 [`vite.config.ts`](../../vite.config.ts)) so a Tailwind class like `md:flex` and a CSS
@@ -21,17 +21,17 @@ These breakpoints align 1:1 with Tailwind v4 defaults (used via `@tailwindcss/vi
 | `2xl`    | 1536 px   | `2xl:`          | Large screens           | No additional layout reflow; content remains centered at `xl` max-width.        |
 
 The `sm` / `md` / `lg` triple is the canonical set referenced by this issue;
-`xl` and `2xl` are documented for completeness and exist in the same token file.
+`xl` is documented for completeness and exists in the same token file.
 
 ### Source of truth
 
 ```jsonc
-// design-system/tokens/spacing.json → spacing.breakpoint
+// design-system/tokens/breakpoints.json → breakpoint
 "sm":  "640px",
 "md":  "768px",
 "lg":  "1024px",
 "xl":  "1280px",
-"2xl": "1536px"
+"xl":  "1280px"
 ```
 
 ### Grid coupling
@@ -235,7 +235,7 @@ occurs — only generous side margins.
 ```
 
 The Tailwind prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`) resolve to the
-identical pixel values listed in the token table above.
+identical pixel values listed in the token table above. Runtime code can import `useBreakpoint` from `src/utils/useBreakpoint` when it needs the same min-width checks in React.
 
 ### Reading tokens from JS / TS
 

--- a/design-system/src/__tests__/token-loader.test.ts
+++ b/design-system/src/__tests__/token-loader.test.ts
@@ -25,140 +25,141 @@ describe('token-loader', () => {
     });
 
     it('should throw if JSON is malformed', () => {
-        mockedFs.readFileSync.mockReturnValue('{"invalid": }');
-        expect(() => loadTokens('invalid.json')).toThrow();
+      mockedFs.readFileSync.mockReturnValue('{"invalid": }');
+      expect(() => loadTokens('invalid.json')).toThrow();
     });
   });
 
   describe('getAllTokens', () => {
     it('should merge all tokens', () => {
-        mockedFs.readFileSync.mockImplementation((path) => {
-            if (path.toString().includes('colors.json')) return '{"color": "red"}';
-            if (path.toString().includes('typography.json')) return '{"font": "sans"}';
-            if (path.toString().includes('spacing.json')) return '{"space": "4px"}';
-            if (path.toString().includes('shadows.json')) return '{"shadow": "1px"}';
-            if (path.toString().includes('motion.json')) return '{"motion": "ease"}';
-            if (path.toString().includes('borders.json')) return '{"border": "1px"}';
-            return '{}';
-        });
+      mockedFs.readFileSync.mockImplementation((path) => {
+        if (path.toString().includes('colors.json')) return '{"color": "red"}';
+        if (path.toString().includes('typography.json')) return '{"font": "sans"}';
+        if (path.toString().includes('spacing.json')) return '{"space": "4px"}';
+        if (path.toString().includes('shadows.json')) return '{"shadow": "1px"}';
+        if (path.toString().includes('motion.json')) return '{"motion": "ease"}';
+        if (path.toString().includes('borders.json')) return '{"border": "1px"}';
+        if (path.toString().includes('breakpoints.json')) return '{"breakpoint": "768px"}';
+        return '{}';
+      });
 
-        const allTokens = getAllTokens();
-        expect(allTokens).toEqual({
-            "color": "red",
-            "font": "sans",
-            "space": "4px",
-            "shadow": "1px",
-            "motion": "ease",
-            "border": "1px"
-        });
+      const allTokens = getAllTokens();
+      expect(allTokens).toEqual({
+        "color": "red",
+        "font": "sans",
+        "space": "4px",
+        "shadow": "1px",
+        "motion": "ease",
+        "border": "1px",
+        "breakpoint": "768px"
+      });
     });
 
     it('should continue and warn if a file fails to load', () => {
-        mockedFs.readFileSync.mockImplementation((path) => {
-            if (path.toString().includes('typography.json')) throw new Error('File not found');
-            if (path.toString().includes('colors.json')) return '{"color": "red"}';
-            if (path.toString().includes('spacing.json')) return '{"space": "4px"}';
-            if (path.toString().includes('shadows.json')) return '{"shadow": "1px"}';
-            if (path.toString().includes('motion.json')) return '{"motion": "ease"}';
-            if (path.toString().includes('borders.json')) return '{"border": "1px"}';
-            return '{}';
-        });
+      mockedFs.readFileSync.mockImplementation((path) => {
+        if (path.toString().includes('typography.json')) throw new Error('File not found');
+        if (path.toString().includes('colors.json')) return '{"color": "red"}';
+        if (path.toString().includes('spacing.json')) return '{"space": "4px"}';
+        if (path.toString().includes('shadows.json')) return '{"shadow": "1px"}';
+        if (path.toString().includes('motion.json')) return '{"motion": "ease"}';
+        if (path.toString().includes('borders.json')) return '{"border": "1px"}';
+        if (path.toString().includes('breakpoints.json')) return '{"breakpoint": "768px"}';
+        return '{}';
+      });
 
-        const allTokens = getAllTokens();
+      const allTokens = getAllTokens();
 
-        // The failed file is omitted, every other file is still merged.
-        expect(allTokens).toEqual({
-            "color": "red",
-            "space": "4px",
-            "shadow": "1px",
-            "motion": "ease",
-            "border": "1px"
-        });
-        expect(allTokens).not.toHaveProperty('font');
+      expect(allTokens).toEqual({
+        "color": "red",
+        "space": "4px",
+        "shadow": "1px",
+        "motion": "ease",
+        "border": "1px",
+        "breakpoint": "768px"
+      });
+      expect(allTokens).not.toHaveProperty('font');
     });
 
     it('should warn with the name of the file that failed to load', () => {
-        mockedFs.readFileSync.mockImplementation((path) => {
-            if (path.toString().includes('typography.json')) throw new Error('File not found');
-            return '{}';
-        });
+      mockedFs.readFileSync.mockImplementation((path) => {
+        if (path.toString().includes('typography.json')) throw new Error('File not found');
+        return '{}';
+      });
 
-        getAllTokens();
+      getAllTokens();
 
-        expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith(
-            'Failed to load typography.json:',
-            expect.any(Error)
-        );
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(console.warn).toHaveBeenCalledWith(
+        'Failed to load typography.json:',
+        expect.any(Error)
+      );
     });
-    
+
     it('should continue and warn if a file has malformed JSON', () => {
-        mockedFs.readFileSync.mockImplementation((path) => {
-            if (path.toString().includes('typography.json')) return '{"invalid": }';
-            if (path.toString().includes('colors.json')) return '{"color": "red"}';
-            if (path.toString().includes('spacing.json')) return '{"space": "4px"}';
-            if (path.toString().includes('shadows.json')) return '{"shadow": "1px"}';
-            if (path.toString().includes('motion.json')) return '{"motion": "ease"}';
-            if (path.toString().includes('borders.json')) return '{"border": "1px"}';
-            return '{}';
-        });
+      mockedFs.readFileSync.mockImplementation((path) => {
+        if (path.toString().includes('typography.json')) return '{"invalid": }';
+        if (path.toString().includes('colors.json')) return '{"color": "red"}';
+        if (path.toString().includes('spacing.json')) return '{"space": "4px"}';
+        if (path.toString().includes('shadows.json')) return '{"shadow": "1px"}';
+        if (path.toString().includes('motion.json')) return '{"motion": "ease"}';
+        if (path.toString().includes('borders.json')) return '{"border": "1px"}';
+        if (path.toString().includes('breakpoints.json')) return '{"breakpoint": "768px"}';
+        return '{}';
+      });
 
-        const allTokens = getAllTokens();
+      const allTokens = getAllTokens();
 
-        // A parse error is caught just like a read error: the bad file is dropped.
-        expect(allTokens).toEqual({
-            "color": "red",
-            "space": "4px",
-            "shadow": "1px",
-            "motion": "ease",
-            "border": "1px"
-        });
-        expect(console.warn).toHaveBeenCalledWith(
-            'Failed to load typography.json:',
-            expect.any(SyntaxError)
-        );
+      expect(allTokens).toEqual({
+        "color": "red",
+        "space": "4px",
+        "shadow": "1px",
+        "motion": "ease",
+        "border": "1px",
+        "breakpoint": "768px"
+      });
+      expect(console.warn).toHaveBeenCalledWith(
+        'Failed to load typography.json:',
+        expect.any(SyntaxError)
+      );
     });
 
     it('should let later files override earlier keys via Object.assign', () => {
-        // colors.json is merged first, borders.json last; the shared "token"
-        // key must reflect the last file processed.
-        mockedFs.readFileSync.mockImplementation((path) => {
-            if (path.toString().includes('colors.json')) return '{"token": "from-colors"}';
-            if (path.toString().includes('borders.json')) return '{"token": "from-borders"}';
-            return '{}';
-        });
+      mockedFs.readFileSync.mockImplementation((path) => {
+        if (path.toString().includes('colors.json')) return '{"token": "from-colors"}';
+        if (path.toString().includes('breakpoints.json')) return '{"token": "from-breakpoints"}';
+        return '{}';
+      });
 
-        const allTokens = getAllTokens();
+      const allTokens = getAllTokens();
 
-        expect(allTokens).toEqual({"token": "from-borders"});
+      expect(allTokens).toEqual({"token": "from-breakpoints"});
     });
 
     it('should still merge a file ordered after a failing one', () => {
-        mockedFs.readFileSync.mockImplementation((path) => {
-            // colors (first) fails, borders (last) must still be merged.
-            if (path.toString().includes('colors.json')) throw new Error('File not found');
-            if (path.toString().includes('borders.json')) return '{"border": "1px"}';
-            return '{}';
-        });
+      mockedFs.readFileSync.mockImplementation((path) => {
+        if (path.toString().includes('colors.json')) throw new Error('File not found');
+        if (path.toString().includes('breakpoints.json')) return '{"breakpoint": "768px"}';
+        return '{}';
+      });
 
-        const allTokens = getAllTokens();
+      const allTokens = getAllTokens();
 
-        expect(allTokens).toEqual({"border": "1px"});
-        expect(console.warn).toHaveBeenCalledWith(
-            'Failed to load colors.json:',
-            expect.any(Error)
-        );
+      expect(allTokens).toEqual({"breakpoint": "768px"});
+      expect(console.warn).toHaveBeenCalledWith(
+        'Failed to load colors.json:',
+        expect.any(Error)
+      );
     });
 
     it('should return an empty object and warn once per file when all files fail', () => {
-        mockedFs.readFileSync.mockImplementation(() => {
-            throw new Error('File not found');
-        });
+      mockedFs.readFileSync.mockImplementation(() => {
+        throw new Error('File not found');
+      });
 
-        const allTokens = getAllTokens();
+      const allTokens = getAllTokens();
 
-        expect(allTokens).toEqual({});
-        expect(console.warn).toHaveBeenCalledTimes(7);
+      expect(allTokens).toEqual({});
+      expect(console.warn).toHaveBeenCalledTimes(8);
     });
   });
 });

--- a/design-system/src/__tests__/tokens.test.ts
+++ b/design-system/src/__tests__/tokens.test.ts
@@ -28,3 +28,17 @@ describe('z-index token layering scale', () => {
     });
   });
 });
+
+describe('breakpoint token scale', () => {
+  it('loads breakpoint tokens from breakpoints.json', () => {
+    const tokens = loadTokens('breakpoints.json');
+
+    expect(tokens).toHaveProperty('breakpoint');
+    expect(tokens.breakpoint).toMatchObject({
+      sm: { $value: '640px' },
+      md: { $value: '768px' },
+      lg: { $value: '1024px' },
+      xl: { $value: '1280px' },
+    });
+  });
+});

--- a/design-system/src/types/tokens.ts
+++ b/design-system/src/types/tokens.ts
@@ -80,5 +80,6 @@ export interface DesignTokens {
   motion?: Record<string, MotionToken>;
   border?: Record<string, BorderToken>;
   zIndex?: Record<string, ZIndexToken>;
+  breakpoint?: Record<string, SpacingToken>;
 }
 

--- a/design-system/src/utils/token-loader.ts
+++ b/design-system/src/utils/token-loader.ts
@@ -26,7 +26,7 @@ export function loadTokens(tokenFile: string): DesignTokens {
 }
 
 export function getAllTokens(): DesignTokens {
-  const tokenFiles = ['colors.json', 'typography.json', 'spacing.json', 'shadows.json', 'motion.json', 'borders.json', 'z-index.json'];
+  const tokenFiles = ['colors.json', 'typography.json', 'spacing.json', 'shadows.json', 'motion.json', 'borders.json', 'z-index.json', 'breakpoints.json'];
   const allTokens: DesignTokens = {};
   
   tokenFiles.forEach(file => {

--- a/design-system/tokens/breakpoints.json
+++ b/design-system/tokens/breakpoints.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://design-tokens.github.io/community-group/format.json",
+  "breakpoint": {
+    "sm": {
+      "$type": "dimension",
+      "$value": "640px",
+      "$description": "Large mobile and phablet breakpoint"
+    },
+    "md": {
+      "$type": "dimension",
+      "$value": "768px",
+      "$description": "Tablet portrait breakpoint"
+    },
+    "lg": {
+      "$type": "dimension",
+      "$value": "1024px",
+      "$description": "Small laptop breakpoint"
+    },
+    "xl": {
+      "$type": "dimension",
+      "$value": "1280px",
+      "$description": "Desktop breakpoint"
+    }
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -59,6 +59,12 @@
   --container-max: 1280px;
   --container-detail: 860px;
 
+  /* Breakpoint tokens */
+  --breakpoint-sm: 640px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 1024px;
+  --breakpoint-xl: 1280px;
+
   /* Touch target minimum */
   --touch-target: 44px;
 

--- a/src/utils/__tests__/useBreakpoint.test.tsx
+++ b/src/utils/__tests__/useBreakpoint.test.tsx
@@ -1,0 +1,111 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { breakpoints, getBreakpointQuery, useBreakpoint } from '../useBreakpoint'
+
+function createMatchMediaController(initialMatches: Record<string, boolean>) {
+  const listeners = new Map<string, Set<(event: MediaQueryListEvent) => void>>()
+  const matches = { ...initialMatches }
+
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((media: string) => {
+      if (!listeners.has(media)) {
+        listeners.set(media, new Set())
+      }
+
+      return {
+        get matches() {
+          return Boolean(matches[media])
+        },
+        media,
+        addEventListener: (_event: string, listener: (event: MediaQueryListEvent) => void) => {
+          listeners.get(media)?.add(listener)
+        },
+        removeEventListener: (_event: string, listener: (event: MediaQueryListEvent) => void) => {
+          listeners.get(media)?.delete(listener)
+        },
+        dispatchEvent: vi.fn(),
+      }
+    }),
+  })
+
+  return {
+    setMatches(media: string, nextValue: boolean) {
+      matches[media] = nextValue
+      const event = { matches: nextValue, media } as MediaQueryListEvent
+      listeners.get(media)?.forEach((listener) => listener(event))
+    },
+    listenerCount(media: string) {
+      const set = listeners.get(media)
+      return set ? set.size : 0
+    },
+  }
+}
+
+describe('useBreakpoint', () => {
+  it('exports the canonical breakpoint values', () => {
+    expect(breakpoints).toEqual({
+      sm: '640px',
+      md: '768px',
+      lg: '1024px',
+      xl: '1280px',
+    })
+    expect(getBreakpointQuery('md')).toBe('(min-width: 768px)')
+  })
+
+  it('reads matchMedia and updates when the media query changes', () => {
+    const mdQuery = getBreakpointQuery('md')
+    const media = createMatchMediaController({ [mdQuery]: false })
+    const { result } = renderHook(() => useBreakpoint('md'))
+
+    expect(window.matchMedia).toHaveBeenCalledWith(mdQuery)
+    expect(result.current).toBe(false)
+
+    act(() => {
+      media.setMatches(mdQuery, true)
+    })
+
+    expect(result.current).toBe(true)
+  })
+
+  it('resubscribes when the requested breakpoint changes', () => {
+    const mdQuery = getBreakpointQuery('md')
+    const lgQuery = getBreakpointQuery('lg')
+    const media = createMatchMediaController({ [mdQuery]: true, [lgQuery]: false })
+    const { rerender, result } = renderHook(({ breakpoint }) => useBreakpoint(breakpoint), {
+      initialProps: { breakpoint: 'md' as const },
+    })
+
+    expect(result.current).toBe(true)
+    expect(media.listenerCount(mdQuery)).toBe(1)
+
+    rerender({ breakpoint: 'lg' as const })
+
+    expect(result.current).toBe(false)
+    expect(media.listenerCount(mdQuery)).toBe(0)
+    expect(media.listenerCount(lgQuery)).toBe(1)
+  })
+
+  it('removes the media query listener on unmount', () => {
+    const xlQuery = getBreakpointQuery('xl')
+    const media = createMatchMediaController({ [xlQuery]: true })
+    const { unmount } = renderHook(() => useBreakpoint('xl'))
+
+    expect(media.listenerCount(xlQuery)).toBe(1)
+    unmount()
+    expect(media.listenerCount(xlQuery)).toBe(0)
+  })
+
+  it('returns false when matchMedia is unavailable', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    })
+
+    const { result } = renderHook(() => useBreakpoint('sm'))
+
+    expect(result.current).toBe(false)
+  })
+})

--- a/src/utils/useBreakpoint.ts
+++ b/src/utils/useBreakpoint.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+
+export const breakpoints = {
+  sm: '640px',
+  md: '768px',
+  lg: '1024px',
+  xl: '1280px',
+} as const
+
+export type Breakpoint = keyof typeof breakpoints
+
+export function getBreakpointQuery(breakpoint: Breakpoint) {
+  return `(min-width: ${breakpoints[breakpoint]})`
+}
+
+function getInitialMatch(breakpoint: Breakpoint) {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false
+  }
+
+  return window.matchMedia(getBreakpointQuery(breakpoint)).matches
+}
+
+export function useBreakpoint(breakpoint: Breakpoint) {
+  const [matches, setMatches] = useState(() => getInitialMatch(breakpoint))
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      setMatches(false)
+      return
+    }
+
+    const mediaQuery = window.matchMedia(getBreakpointQuery(breakpoint))
+    const syncMatch = (event?: MediaQueryListEvent) => {
+      setMatches(event ? event.matches : mediaQuery.matches)
+    }
+
+    syncMatch()
+    mediaQuery.addEventListener('change', syncMatch)
+
+    return () => mediaQuery.removeEventListener('change', syncMatch)
+  }, [breakpoint])
+
+  return matches
+}


### PR DESCRIPTION
Closes #471

## Summary
- add a breakpoint token set under `design-system/tokens/breakpoints.json`
- register breakpoint tokens in the token loader/type catalog and expose `--breakpoint-*` CSS variables
- add an SSR-safe `useBreakpoint` hook plus focused token/loader/hook tests and docs

## Verification
- Static API inspection confirmed the token JSON parses and expected references are present.
- I did not install dependencies or run the project locally in this environment.