### PR TITLE
feat: add PendingValidations sort selector

### DIFF
--- a/design-system/documentation/pending-sort.md
+++ b/design-system/documentation/pending-sort.md
@@ -1,0 +1,21 @@
+# Pending Validation Sorting
+
+`PendingValidations` uses the shared `sortPending` utility to keep queue ordering predictable across UI and tests.
+
+## Sort Keys
+
+- `deadline`: compares the submitted deadline date, with `daysRemaining` as a fallback for invalid dates.
+- `amount`: parses readable token strings, such as `20,000 USDC`, into numeric values before comparing.
+- `vaultName`: compares vault names case-insensitively.
+
+## Direction
+
+The queue supports ascending and descending order for every sort key. The table exposes the active sort state with `aria-sort` on the matching column header and `none` on sortable inactive headers.
+
+## Stability
+
+`sortPending` preserves the original relative order when two tasks compare equally. This prevents repeated render churn when several validations share the same deadline, amount, or vault name.
+
+## Filtering
+
+The page applies `filterPending` first, then passes the filtered queue into `sortPending`. Select-all and batch actions therefore operate only on the visible filtered and sorted set.

--- a/src/pages/PendingValidations.tsx
+++ b/src/pages/PendingValidations.tsx
@@ -8,6 +8,11 @@ import { computeVerifierMetrics } from '../utils/verifierMetrics';
 import { useVerifierStore } from '../Zustand/Store';
 import { StatusChip } from '../components/StatusChip';
 import { filterPending } from '../utils/filterPending';
+import {
+  sortPending,
+  type PendingSortDirection,
+  type PendingSortKey,
+} from '../utils/sortPending';
 
 export default function PendingValidations() {
   const navigate = useNavigate();
@@ -22,7 +27,8 @@ export default function PendingValidations() {
   // Filter and sort state
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedMilestone, setSelectedMilestone] = useState('');
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+  const [sortKey, setSortKey] = useState<PendingSortKey>('deadline');
+  const [sortDirection, setSortDirection] = useState<PendingSortDirection>('asc');
 
   // Multi-select state for batch actions.
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -45,13 +51,8 @@ export default function PendingValidations() {
   }, [pendingValidations, searchQuery, selectedMilestone]);
 
   const sortedValidations = useMemo(
-    () =>
-      [...filteredValidations].sort((a, b) =>
-        sortOrder === 'asc'
-          ? a.daysRemaining - b.daysRemaining
-          : b.daysRemaining - a.daysRemaining,
-      ),
-    [filteredValidations, sortOrder],
+    () => sortPending(filteredValidations, sortKey, sortDirection),
+    [filteredValidations, sortDirection, sortKey],
   );
 
   // Keep selection in sync with the queue and reset it when the active filters change.
@@ -104,6 +105,11 @@ export default function PendingValidations() {
   };
 
   const hasSelection = selectedIds.length > 0;
+  const sortLabel = sortDirection === 'asc' ? 'Ascending' : 'Descending';
+  const headerSort = (key: PendingSortKey) => {
+    if (sortKey !== key) return 'none';
+    return sortDirection === 'asc' ? 'ascending' : 'descending';
+  };
 
   return (
     <div className="flex flex-col gap-6 p-6">
@@ -122,14 +128,74 @@ export default function PendingValidations() {
           </Text>
         </div>
 
-        <button
-          onClick={() => setSortOrder(prev => prev === 'asc' ? 'desc' : 'asc')}
-          className="px-4 py-2 border rounded text-sm font-medium transition"
-          style={{ borderColor: 'var(--border)', color: 'var(--text)', background: 'var(--bg)' }}
-        >
-          Sort by Urgency: {sortOrder === 'asc' ? 'High to Low' : 'Low to High'}
-        </button>
+        <div className="flex flex-col sm:flex-row gap-3">
+          <label className="flex flex-col gap-1 text-sm font-medium" style={{ color: 'var(--muted)' }}>
+            Sort pending validations
+            <select
+              aria-label="Sort pending validations"
+              value={sortKey}
+              onChange={(event) => setSortKey(event.target.value as PendingSortKey)}
+              className="px-3 py-2 border rounded text-sm font-medium transition"
+              style={{
+                borderColor: 'var(--border)',
+                color: 'var(--text)',
+                background: 'var(--bg)',
+              }}
+            >
+              <option value="deadline">Deadline</option>
+              <option value="amount">Amount</option>
+              <option value="vaultName">Vault name</option>
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={() => setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc')}
+            className="self-end px-4 py-2 border rounded text-sm font-medium transition"
+            style={{ borderColor: 'var(--border)', color: 'var(--text)', background: 'var(--bg)' }}
+          >
+            Sort direction: {sortLabel}
+          </button>
+        </div>
       </header>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <label className="flex flex-col gap-1 text-sm font-medium" style={{ color: 'var(--muted)' }}>
+          Search by Vault Name or Owner
+          <input
+            aria-label="Search by Vault Name or Owner"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search vault or owner"
+            className="px-3 py-2 border rounded text-sm transition"
+            style={{
+              borderColor: 'var(--border)',
+              color: 'var(--text)',
+              background: 'var(--bg)',
+            }}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm font-medium" style={{ color: 'var(--muted)' }}>
+          Filter by Milestone
+          <select
+            aria-label="Filter by Milestone"
+            value={selectedMilestone}
+            onChange={(event) => setSelectedMilestone(event.target.value)}
+            className="px-3 py-2 border rounded text-sm transition"
+            style={{
+              borderColor: 'var(--border)',
+              color: 'var(--text)',
+              background: 'var(--bg)',
+            }}
+          >
+            <option value="">All Milestones</option>
+            {availableMilestones.map((milestone) => (
+              <option key={milestone} value={milestone}>
+                {milestone}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
 
       <VerifierMetricsBar metrics={metrics} />
 
@@ -164,10 +230,10 @@ export default function PendingValidations() {
                     className="h-4 w-4 cursor-pointer accent-[var(--accent)]"
                   />
                 </th>
-                <th scope="col" className="p-4 font-medium text-sm" style={{ color: 'var(--muted)' }}>Vault & Milestone</th>
+                <th scope="col" className="p-4 font-medium text-sm" style={{ color: 'var(--muted)' }} aria-sort={headerSort('vaultName')}>Vault & Milestone</th>
                 <th scope="col" className="p-4 font-medium text-sm" style={{ color: 'var(--muted)' }}>Owner</th>
-                <th scope="col" className="p-4 font-medium text-sm" style={{ color: 'var(--muted)' }}>Amount at Stake</th>
-                <th scope="col" className="p-4 font-medium text-sm" style={{ color: 'var(--muted)' }} aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>Deadline</th>
+                <th scope="col" className="p-4 font-medium text-sm" style={{ color: 'var(--muted)' }} aria-sort={headerSort('amount')}>Amount at Stake</th>
+                <th scope="col" className="p-4 font-medium text-sm" style={{ color: 'var(--muted)' }} aria-sort={headerSort('deadline')}>Deadline</th>
                 <th scope="col" className="p-4 font-medium text-sm text-right" style={{ color: 'var(--muted)' }}>Actions</th>
               </tr>
             </thead>

--- a/src/pages/__tests__/PendingValidations.test.tsx
+++ b/src/pages/__tests__/PendingValidations.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach, type Mock } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import PendingValidations from '../PendingValidations';
 import { useVerifierStore } from '../../Zustand/Store';
@@ -50,6 +50,14 @@ const makeTasks = () => [
   },
 ];
 
+const verifierState = (pendingValidations = makeTasks()) => ({
+  pendingValidations,
+  validationHistory: [],
+  batchApprove: vi.fn(),
+  batchReject: vi.fn(),
+});
+const mockUseVerifierStore = useVerifierStore as unknown as Mock;
+
 function renderPage() {
   return render(
     <MemoryRouter>
@@ -63,7 +71,7 @@ describe('PendingValidations', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-21T00:00:00Z'));
     vi.clearAllMocks();
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: makeTasks() });
+    mockUseVerifierStore.mockReturnValue(verifierState());
   });
 
   afterEach(() => {
@@ -76,14 +84,14 @@ describe('PendingValidations', () => {
   });
 
   it('shows "All caught up!" when there are no pending validations', () => {
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+    mockUseVerifierStore.mockReturnValue(verifierState([]));
     renderPage();
     expect(screen.getByText('All caught up!')).toBeInTheDocument();
     expect(screen.getByText(/no pending validations/i)).toBeInTheDocument();
   });
 
   it('does not render the table when queue is empty', () => {
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+    mockUseVerifierStore.mockReturnValue(verifierState([]));
     renderPage();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
@@ -95,9 +103,10 @@ describe('PendingValidations', () => {
     expect(screen.getByText('Gamma Vault')).toBeInTheDocument();
   });
 
-  it('default sort is ascending (most urgent first) and button shows "High to Low"', () => {
+  it('default sort is by deadline ascending and direction button shows "Ascending"', () => {
     renderPage();
-    expect(screen.getByRole('button', { name: /High to Low/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Sort pending validations/i)).toHaveValue('deadline');
+    expect(screen.getByRole('button', { name: /Ascending/i })).toBeInTheDocument();
 
     // ascending: v-2 (2 days) → v-1 (10 days) → v-3 (20 days)
     const vaultCells = screen.getAllByText(/Vault$/);
@@ -106,11 +115,11 @@ describe('PendingValidations', () => {
     expect(vaultCells[2].textContent).toBe('Gamma Vault');
   });
 
-  it('toggling sort reverses the order and button shows "Low to High"', () => {
+  it('toggling sort direction reverses the order and button shows "Descending"', () => {
     renderPage();
-    fireEvent.click(screen.getByRole('button', { name: /High to Low/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Ascending/i }));
 
-    expect(screen.getByRole('button', { name: /Low to High/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Descending/i })).toBeInTheDocument();
 
     // descending: v-3 (20 days) → v-1 (10 days) → v-2 (2 days)
     const vaultCells = screen.getAllByText(/Vault$/);
@@ -121,10 +130,10 @@ describe('PendingValidations', () => {
 
   it('toggling twice returns to original ascending order', () => {
     renderPage();
-    fireEvent.click(screen.getByRole('button', { name: /High to Low/i }));
-    fireEvent.click(screen.getByRole('button', { name: /Low to High/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Ascending/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Descending/i }));
 
-    expect(screen.getByRole('button', { name: /High to Low/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Ascending/i })).toBeInTheDocument();
 
     // back to ascending: v-2 → v-1 → v-3
     const vaultCells = screen.getAllByText(/Vault$/);
@@ -148,21 +157,19 @@ describe('PendingValidations', () => {
   });
 
   it('renders a single task without crashing', () => {
-    (useVerifierStore as any).mockReturnValue({
-      pendingValidations: [makeTasks()[0]],
-    });
+    mockUseVerifierStore.mockReturnValue(verifierState([makeTasks()[0]]));
     renderPage();
     expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
     expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 row
   });
 
   it('handles ties in daysRemaining (stable relative order preserved)', () => {
-    (useVerifierStore as any).mockReturnValue({
-      pendingValidations: [
+    mockUseVerifierStore.mockReturnValue(
+      verifierState([
         { ...makeTasks()[0], id: 'v-a', daysRemaining: 5 },
         { ...makeTasks()[1], id: 'v-b', daysRemaining: 5 },
-      ],
-    });
+      ]),
+    );
     renderPage();
     const rows = screen.getAllByRole('row').slice(1);
     expect(rows).toHaveLength(2);
@@ -201,19 +208,29 @@ describe('PendingValidations', () => {
       expect(deadlineHeader).toHaveAttribute('aria-sort', 'ascending');
     });
 
-    it('aria-sort becomes "descending" after toggling sort to Low to High', () => {
+    it('aria-sort becomes "descending" after toggling sort direction', () => {
       renderPage();
-      fireEvent.click(screen.getByRole('button', { name: /High to Low/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Ascending/i }));
       const deadlineHeader = screen.getByRole('columnheader', { name: /Deadline/i });
       expect(deadlineHeader).toHaveAttribute('aria-sort', 'descending');
     });
 
     it('toggling sort twice restores aria-sort to "ascending"', () => {
       renderPage();
-      fireEvent.click(screen.getByRole('button', { name: /High to Low/i }));
-      fireEvent.click(screen.getByRole('button', { name: /Low to High/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Ascending/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Descending/i }));
       const deadlineHeader = screen.getByRole('columnheader', { name: /Deadline/i });
       expect(deadlineHeader).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('moves aria-sort to the selected sort column', () => {
+      renderPage();
+      fireEvent.change(screen.getByLabelText(/Sort pending validations/i), {
+        target: { value: 'amount' },
+      });
+
+      expect(screen.getByRole('columnheader', { name: /Deadline/i })).toHaveAttribute('aria-sort', 'none');
+      expect(screen.getByRole('columnheader', { name: /Amount at Stake/i })).toHaveAttribute('aria-sort', 'ascending');
     });
 
     it('urgent rows (≤3 days) include a non-color sr-only urgency cue', () => {
@@ -231,9 +248,36 @@ describe('PendingValidations', () => {
     });
 
     it('empty table state renders no table role', () => {
-      (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+      mockUseVerifierStore.mockReturnValue(verifierState([]));
       renderPage();
       expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('sort selector', () => {
+    it('sorts by amount numerically', () => {
+      renderPage();
+      fireEvent.change(screen.getByLabelText(/Sort pending validations/i), {
+        target: { value: 'amount' },
+      });
+
+      const vaultCells = screen.getAllByText(/Vault$/);
+      expect(vaultCells[0].textContent).toBe('Beta Vault');
+      expect(vaultCells[1].textContent).toBe('Alpha Vault');
+      expect(vaultCells[2].textContent).toBe('Gamma Vault');
+    });
+
+    it('sorts by vault name and reverses with the direction toggle', () => {
+      renderPage();
+      fireEvent.change(screen.getByLabelText(/Sort pending validations/i), {
+        target: { value: 'vaultName' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /Ascending/i }));
+
+      const vaultCells = screen.getAllByText(/Vault$/);
+      expect(vaultCells[0].textContent).toBe('Gamma Vault');
+      expect(vaultCells[1].textContent).toBe('Beta Vault');
+      expect(vaultCells[2].textContent).toBe('Alpha Vault');
     });
   });
 
@@ -473,7 +517,7 @@ describe('PendingValidations', () => {
 
   describe('empty state messaging', () => {
     it('shows "All caught up!" when there are no pending validations', () => {
-      (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+      mockUseVerifierStore.mockReturnValue(verifierState([]));
       renderPage();
 
       expect(screen.getByText('All caught up!')).toBeInTheDocument();

--- a/src/utils/__tests__/sortPending.test.ts
+++ b/src/utils/__tests__/sortPending.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { sortPending } from '../sortPending';
+import type { ValidationTask } from '../../Zustand/Store';
+
+const task = (overrides: Partial<ValidationTask>): ValidationTask => ({
+  id: 'task',
+  vaultName: 'Vault',
+  owner: '0xowner',
+  amount: '1,000 USDC',
+  deadline: '2026-07-01',
+  daysRemaining: 10,
+  status: 'pending',
+  milestone: 'Phase 1',
+  ...overrides,
+});
+
+const ids = (tasks: ValidationTask[]) => tasks.map((item) => item.id);
+
+describe('sortPending', () => {
+  it('sorts by deadline ascending and descending', () => {
+    const tasks = [
+      task({ id: 'late', deadline: '2026-08-01', daysRemaining: 40 }),
+      task({ id: 'early', deadline: '2026-06-20', daysRemaining: 1 }),
+      task({ id: 'middle', deadline: '2026-07-01', daysRemaining: 10 }),
+    ];
+
+    expect(ids(sortPending(tasks, 'deadline', 'asc'))).toEqual(['early', 'middle', 'late']);
+    expect(ids(sortPending(tasks, 'deadline', 'desc'))).toEqual(['late', 'middle', 'early']);
+  });
+
+  it('sorts amount strings numerically', () => {
+    const tasks = [
+      task({ id: 'large', amount: '20,000 USDC' }),
+      task({ id: 'small', amount: '750 USDC' }),
+      task({ id: 'medium', amount: '5,000 USDC' }),
+    ];
+
+    expect(ids(sortPending(tasks, 'amount', 'asc'))).toEqual(['small', 'medium', 'large']);
+  });
+
+  it('sorts vault names without case sensitivity', () => {
+    const tasks = [
+      task({ id: 'gamma', vaultName: 'gamma vault' }),
+      task({ id: 'alpha', vaultName: 'Alpha Vault' }),
+      task({ id: 'beta', vaultName: 'Beta Vault' }),
+    ];
+
+    expect(ids(sortPending(tasks, 'vaultName', 'asc'))).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it('keeps equal values in their original relative order', () => {
+    const tasks = [
+      task({ id: 'first', amount: '1,000 USDC' }),
+      task({ id: 'second', amount: '1,000 USDC' }),
+      task({ id: 'third', amount: '2,000 USDC' }),
+    ];
+
+    expect(ids(sortPending(tasks, 'amount', 'asc'))).toEqual(['first', 'second', 'third']);
+  });
+
+  it('does not mutate the input array', () => {
+    const tasks = [
+      task({ id: 'b', vaultName: 'Beta Vault' }),
+      task({ id: 'a', vaultName: 'Alpha Vault' }),
+    ];
+
+    const sorted = sortPending(tasks, 'vaultName', 'asc');
+
+    expect(ids(sorted)).toEqual(['a', 'b']);
+    expect(ids(tasks)).toEqual(['b', 'a']);
+  });
+});

--- a/src/utils/sortPending.ts
+++ b/src/utils/sortPending.ts
@@ -1,0 +1,44 @@
+import type { ValidationTask } from '../Zustand/Store';
+
+export type PendingSortKey = 'deadline' | 'amount' | 'vaultName';
+export type PendingSortDirection = 'asc' | 'desc';
+
+type PendingTask = ValidationTask;
+
+const parseAmount = (amount: string): number => {
+  const parsed = Number.parseFloat(amount.replace(/[^0-9.-]/g, ''));
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const parseDeadline = (task: PendingTask): number => {
+  const parsed = Date.parse(task.deadline);
+  return Number.isFinite(parsed) ? parsed : task.daysRemaining;
+};
+
+const compareTasks = (a: PendingTask, b: PendingTask, key: PendingSortKey): number => {
+  if (key === 'amount') {
+    return parseAmount(a.amount) - parseAmount(b.amount);
+  }
+
+  if (key === 'vaultName') {
+    return a.vaultName.localeCompare(b.vaultName, undefined, { sensitivity: 'base' });
+  }
+
+  return parseDeadline(a) - parseDeadline(b);
+};
+
+export function sortPending(
+  tasks: PendingTask[],
+  key: PendingSortKey,
+  direction: PendingSortDirection,
+): PendingTask[] {
+  const multiplier = direction === 'asc' ? 1 : -1;
+
+  return tasks
+    .map((task, index) => ({ task, index }))
+    .sort((a, b) => {
+      const result = compareTasks(a.task, b.task, key) * multiplier;
+      return result === 0 ? a.index - b.index : result;
+    })
+    .map(({ task }) => task);
+}


### PR DESCRIPTION
## Summary
- add a shared `sortPending` utility for verifier queue ordering by deadline, amount, and vault name
- add a sort selector and direction toggle to `PendingValidations`, composed after `filterPending`
- expose the active sort column with `aria-sort` and document the sorting behavior

Closes #458

## Validation
- `npx vitest run src/utils/__tests__/sortPending.test.ts src/pages/__tests__/PendingValidations.test.tsx --reporter=dot`
- `npx eslint src/pages/PendingValidations.tsx src/pages/__tests__/PendingValidations.test.tsx src/utils/sortPending.ts src/utils/__tests__/sortPending.test.ts`
- `git diff --check`

## Note
- `npm run build` is currently blocked by pre-existing syntax errors in `src/utils/__tests__/csv.analytics.test.ts(82,37)` and `src/utils/__tests__/verifierMetrics.test.ts(351,1)`.