### PR TITLE
feat: persist ValidationHistory page size

### DIFF
--- a/design-system/documentation/validation-history.md
+++ b/design-system/documentation/validation-history.md
@@ -10,11 +10,14 @@ pagination for completed milestone decisions.
 - From date: filters to records with a `deadline` on or after the given ISO date (inclusive, open-ended when blank).
 - To date: filters to records with a `deadline` on or before the given ISO date (inclusive, open-ended when blank).
 - Milestone: case-insensitive substring match against each record's `milestone` field (blank = no filter).
-- Page size: verifier-selectable page size values of 5, 10, or 25.
+- Page size: verifier-selectable page size values of 10, 25, or 50. The selected
+  value is persisted in `localStorage` under `validation-history-page-size` and
+  safely falls back to 10 when storage is unavailable or contains an invalid
+  value.
 - Pagination: Previous and Next buttons expose explicit `aria-label` text and
   disabled states at the first and last pages.
 
-All filter changes reset pagination to page 1.
+All filter changes and page-size changes reset pagination to page 1.
 
 ## Empty States
 

--- a/src/pages/ValidationHistory.tsx
+++ b/src/pages/ValidationHistory.tsx
@@ -9,8 +9,15 @@ import {
 import type { ValidationHistoryStatusFilter } from '../utils/paginate';
 import { downloadCsv, toCsv } from '../utils/csv';
 import { StatusChip } from '../components/StatusChip';
+import {
+  coerceValidationHistoryPageSize,
+  readValidationHistoryPageSize,
+  VALIDATION_HISTORY_PAGE_SIZES,
+  writeValidationHistoryPageSize,
+} from '../utils/pageSizePref';
 
-const PAGE_SIZE_OPTIONS = [5, 10, 25];
+const toChipStatus = (status: 'pending' | 'approved' | 'rejected') =>
+  status === 'pending' ? 'pending_validation' : status;
 
 export default function ValidationHistory() {
   const navigate = useNavigate();
@@ -20,7 +27,7 @@ export default function ValidationHistory() {
   const [fromDate, setFromDate] = useState('');
   const [toDate, setToDate] = useState('');
   const [milestoneFilter, setMilestoneFilter] = useState('');
-  const [pageSize, setPageSize] = useState(5);
+  const [pageSize, setPageSize] = useState(readValidationHistoryPageSize);
   const [page, setPage] = useState(1);
 
   // Calculate the Approve/Reject Ratio
@@ -49,7 +56,9 @@ export default function ValidationHistory() {
   const updateMilestoneFilter = (value: string) => { setMilestoneFilter(value); setPage(1); };
 
   const updatePageSize = (size: number) => {
-    setPageSize(size);
+    const nextSize = coerceValidationHistoryPageSize(size);
+    setPageSize(nextSize);
+    writeValidationHistoryPageSize(nextSize);
     setPage(1);
   };
 
@@ -199,7 +208,7 @@ export default function ValidationHistory() {
               padding: '0.65rem 0.75rem',
             }}
           >
-            {PAGE_SIZE_OPTIONS.map((size) => (
+            {VALIDATION_HISTORY_PAGE_SIZES.map((size) => (
               <option key={size} value={size}>{size} per page</option>
             ))}
           </select>
@@ -252,7 +261,7 @@ export default function ValidationHistory() {
               >
                 <div className="flex flex-col gap-2 md:w-1/3">
                   <div className="flex items-center gap-3">
-                    <StatusChip status={task.status as any} className="uppercase" size="sm" />
+                    <StatusChip status={toChipStatus(task.status)} className="uppercase" size="sm" />
                     <Text role="body" as="span" className="text-sm" style={{ color: 'var(--muted)' }}>
                       ID: {task.id}
                     </Text>

--- a/src/pages/__tests__/ValidationHistory.test.tsx
+++ b/src/pages/__tests__/ValidationHistory.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ValidationTask } from '../../Zustand/Store';
 import { useVerifierStore } from '../../Zustand/Store';
+import { VALIDATION_HISTORY_PAGE_SIZE_KEY } from '../../utils/pageSizePref';
 import ValidationHistory from '../ValidationHistory';
 
 const { mockDownloadCsv } = vi.hoisted(() => ({
@@ -91,6 +92,22 @@ const baseHistory: ValidationTask[] = [
   },
 ];
 
+const makeExtraHistoryItem = (index: number): ValidationTask => ({
+  id: `v-${String(index).padStart(3, '0')}`,
+  vaultName: `History Vault ${index}`,
+  owner: `GOWNER${index}`,
+  amount: `${index},000 USDC`,
+  deadline: `2026-01-${String(index).padStart(2, '0')}`,
+  daysRemaining: 0,
+  status: index % 2 === 0 ? 'approved' : 'rejected',
+  milestone: `Milestone ${index}`,
+});
+
+const longHistory = [
+  ...baseHistory,
+  ...Array.from({ length: 6 }, (_, index) => makeExtraHistoryItem(index + 7)),
+];
+
 function renderHistory(history = baseHistory) {
   vi.mocked(useVerifierStore).mockReturnValue({
     validationHistory: history,
@@ -102,6 +119,7 @@ function renderHistory(history = baseHistory) {
 describe('ValidationHistory', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   it('renders summary stats and first page of validation history', () => {
@@ -115,8 +133,9 @@ describe('ValidationHistory', () => {
 
     expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
     expect(screen.getByText('Epsilon Pool')).toBeInTheDocument();
-    expect(screen.queryByText('Zeta Treasury')).not.toBeInTheDocument();
-    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+    expect(screen.getByText('Zeta Treasury')).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Validation history page size')).toHaveValue('10');
   });
 
   it('filters by rejected status', () => {
@@ -151,7 +170,7 @@ describe('ValidationHistory', () => {
   });
 
   it('paginates results with accessible controls', () => {
-    renderHistory();
+    renderHistory(longHistory);
 
     const nav = screen.getByRole('navigation', { name: 'Validation history pagination' });
     const previous = within(nav).getByRole('button', { name: 'Go to previous validation history page' });
@@ -162,7 +181,7 @@ describe('ValidationHistory', () => {
 
     fireEvent.click(next);
 
-    expect(screen.getByText('Zeta Treasury')).toBeInTheDocument();
+    expect(screen.getByText('History Vault 11')).toBeInTheDocument();
     expect(screen.queryByText('Alpha Vault')).not.toBeInTheDocument();
     expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
     expect(next).toBeDisabled();
@@ -170,13 +189,13 @@ describe('ValidationHistory', () => {
   });
 
   it('updates page size and shows no-match empty state', () => {
-    renderHistory();
+    renderHistory(longHistory);
 
     fireEvent.change(screen.getByLabelText('Validation history page size'), {
-      target: { value: '10' },
+      target: { value: '25' },
     });
 
-    expect(screen.getByText('Zeta Treasury')).toBeInTheDocument();
+    expect(screen.getByText('History Vault 12')).toBeInTheDocument();
     expect(screen.getByText('Page 1 of 1')).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Search validation history by vault or owner'), {
@@ -185,6 +204,50 @@ describe('ValidationHistory', () => {
 
     expect(screen.getByText('No matching validations')).toBeInTheDocument();
     expect(screen.queryByRole('navigation', { name: 'Validation history pagination' })).not.toBeInTheDocument();
+  });
+
+  it('persists the selected page size', () => {
+    renderHistory();
+
+    fireEvent.change(screen.getByLabelText('Validation history page size'), {
+      target: { value: '50' },
+    });
+
+    expect(localStorage.getItem(VALIDATION_HISTORY_PAGE_SIZE_KEY)).toBe('50');
+  });
+
+  it('loads a valid stored page size', () => {
+    localStorage.setItem(VALIDATION_HISTORY_PAGE_SIZE_KEY, '25');
+
+    renderHistory(longHistory);
+
+    expect(screen.getByLabelText('Validation history page size')).toHaveValue('25');
+    expect(screen.getByText('History Vault 12')).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 1')).toBeInTheDocument();
+  });
+
+  it('falls back to 10 rows when the stored page size is invalid', () => {
+    localStorage.setItem(VALIDATION_HISTORY_PAGE_SIZE_KEY, '5');
+
+    renderHistory(longHistory);
+
+    expect(screen.getByLabelText('Validation history page size')).toHaveValue('10');
+    expect(screen.queryByText('History Vault 11')).not.toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+  });
+
+  it('resets to page 1 when page size changes', () => {
+    renderHistory(longHistory);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to next validation history page' }));
+    expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Validation history page size'), {
+      target: { value: '25' },
+    });
+
+    expect(screen.getByText('Page 1 of 1')).toBeInTheDocument();
+    expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
   });
 
   it('navigates back to the verifier dashboard', () => {
@@ -231,7 +294,7 @@ describe('ValidationHistory', () => {
     });
 
     it('resets to page 1 when from date changes', () => {
-      renderHistory();
+      renderHistory(longHistory);
 
       fireEvent.click(screen.getByRole('button', { name: 'Go to next validation history page' }));
       expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
@@ -268,7 +331,7 @@ describe('ValidationHistory', () => {
     });
 
     it('resets to page 1 when milestone changes', () => {
-      renderHistory();
+      renderHistory(longHistory);
 
       fireEvent.click(screen.getByRole('button', { name: 'Go to next validation history page' }));
       expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();

--- a/src/utils/__tests__/pageSizePref.test.ts
+++ b/src/utils/__tests__/pageSizePref.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  coerceValidationHistoryPageSize,
+  DEFAULT_VALIDATION_HISTORY_PAGE_SIZE,
+  readValidationHistoryPageSize,
+  VALIDATION_HISTORY_PAGE_SIZE_KEY,
+  VALIDATION_HISTORY_PAGE_SIZES,
+  writeValidationHistoryPageSize,
+} from '../pageSizePref';
+
+const storage = (initialValue: string | null = null) => ({
+  getItem: vi.fn(() => initialValue),
+  setItem: vi.fn(),
+});
+
+describe('pageSizePref', () => {
+  it('exports the supported validation history page sizes', () => {
+    expect(VALIDATION_HISTORY_PAGE_SIZES).toEqual([10, 25, 50]);
+  });
+
+  it('coerces invalid values to the default page size', () => {
+    expect(coerceValidationHistoryPageSize(10)).toBe(10);
+    expect(coerceValidationHistoryPageSize('25')).toBe(25);
+    expect(coerceValidationHistoryPageSize(5)).toBe(DEFAULT_VALIDATION_HISTORY_PAGE_SIZE);
+    expect(coerceValidationHistoryPageSize('not-a-size')).toBe(DEFAULT_VALIDATION_HISTORY_PAGE_SIZE);
+  });
+
+  it('reads a valid stored page size', () => {
+    expect(readValidationHistoryPageSize(storage('50'))).toBe(50);
+  });
+
+  it('falls back when storage has an invalid value', () => {
+    expect(readValidationHistoryPageSize(storage('5'))).toBe(DEFAULT_VALIDATION_HISTORY_PAGE_SIZE);
+  });
+
+  it('falls back when storage reads throw', () => {
+    const blockedStorage = {
+      getItem: vi.fn(() => {
+        throw new Error('storage blocked');
+      }),
+      setItem: vi.fn(),
+    };
+
+    expect(readValidationHistoryPageSize(blockedStorage)).toBe(DEFAULT_VALIDATION_HISTORY_PAGE_SIZE);
+  });
+
+  it('writes a supported page size', () => {
+    const writableStorage = storage();
+
+    writeValidationHistoryPageSize(25, writableStorage);
+
+    expect(writableStorage.setItem).toHaveBeenCalledWith(VALIDATION_HISTORY_PAGE_SIZE_KEY, '25');
+  });
+
+  it('ignores storage write failures', () => {
+    const blockedStorage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(() => {
+        throw new Error('storage blocked');
+      }),
+    };
+
+    expect(() => writeValidationHistoryPageSize(50, blockedStorage)).not.toThrow();
+  });
+});

--- a/src/utils/pageSizePref.ts
+++ b/src/utils/pageSizePref.ts
@@ -1,0 +1,53 @@
+export const VALIDATION_HISTORY_PAGE_SIZE_KEY = 'validation-history-page-size';
+export const VALIDATION_HISTORY_PAGE_SIZES = [10, 25, 50] as const;
+export const DEFAULT_VALIDATION_HISTORY_PAGE_SIZE = 10;
+
+export type ValidationHistoryPageSize = (typeof VALIDATION_HISTORY_PAGE_SIZES)[number];
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem'>;
+
+const getStorage = (): StorageLike | undefined => {
+  try {
+    return globalThis.localStorage;
+  } catch {
+    return undefined;
+  }
+};
+
+export function isValidationHistoryPageSize(
+  value: number,
+): value is ValidationHistoryPageSize {
+  return VALIDATION_HISTORY_PAGE_SIZES.includes(value as ValidationHistoryPageSize);
+}
+
+export function coerceValidationHistoryPageSize(value: unknown): ValidationHistoryPageSize {
+  const numericValue = Number(value);
+  return isValidationHistoryPageSize(numericValue)
+    ? numericValue
+    : DEFAULT_VALIDATION_HISTORY_PAGE_SIZE;
+}
+
+export function readValidationHistoryPageSize(
+  storage: StorageLike | undefined = getStorage(),
+): ValidationHistoryPageSize {
+  if (!storage) return DEFAULT_VALIDATION_HISTORY_PAGE_SIZE;
+
+  try {
+    return coerceValidationHistoryPageSize(storage.getItem(VALIDATION_HISTORY_PAGE_SIZE_KEY));
+  } catch {
+    return DEFAULT_VALIDATION_HISTORY_PAGE_SIZE;
+  }
+}
+
+export function writeValidationHistoryPageSize(
+  pageSize: ValidationHistoryPageSize,
+  storage: StorageLike | undefined = getStorage(),
+): void {
+  if (!storage) return;
+
+  try {
+    storage.setItem(VALIDATION_HISTORY_PAGE_SIZE_KEY, String(pageSize));
+  } catch {
+    // Storage can fail in private browsing or locked-down environments.
+  }
+}


### PR DESCRIPTION
## Summary
- add safe validation-history page-size preference helpers backed by localStorage
- update `ValidationHistory` to use 10/25/50 row options, persist the selected size, and reset pagination on changes
- expand page, persistence, fallback, and filtering tests; update validation-history docs

Closes #464

## Validation
- `npx vitest run src/utils/__tests__/pageSizePref.test.ts src/pages/__tests__/ValidationHistory.test.tsx --reporter=dot`
- `npx eslint src/pages/ValidationHistory.tsx src/pages/__tests__/ValidationHistory.test.tsx src/utils/pageSizePref.ts src/utils/__tests__/pageSizePref.test.ts`
- `git diff --check`

## Note
- `npm run build` is currently blocked by pre-existing syntax errors in `src/utils/__tests__/csv.analytics.test.ts(82,37)` and `src/utils/__tests__/verifierMetrics.test.ts(351,1)`.