### PR TITLE
feat: add VaultDetail lifecycle stepper

### DIFF
--- a/design-system/documentation/vault-lifecycle.md
+++ b/design-system/documentation/vault-lifecycle.md
@@ -1,0 +1,29 @@
+# Vault Lifecycle
+
+`VaultLifecycle` renders a token-styled horizontal stepper for the high-level
+vault lifecycle on `VaultDetail`.
+
+## Stages
+
+The `vaultLifecycleStages(status)` utility returns four ordered stages:
+
+- `Created`
+- `Active`
+- `Pending Validation`
+- `Completed`, or a terminal `Failed` / `Cancelled` stage
+
+Each stage is marked as `done`, `current`, or `upcoming`. Unknown statuses fall
+back to `Created` as the current stage so the component stays render-safe.
+
+## Accessibility
+
+The component renders an ordered list with the accessible label `Vault lifecycle`.
+Each step exposes a combined label such as `Active, current` so screen-reader
+users get both the stage name and its state.
+
+## Token Usage
+
+- Current stages use `--accent` and `--accent-transparent`.
+- Completed previous stages use `--success`.
+- Terminal failed/cancelled stages use `--danger`.
+- Upcoming stages use `--muted`, `--bg`, and `--border`.

--- a/src/components/VaultLifecycle.tsx
+++ b/src/components/VaultLifecycle.tsx
@@ -1,0 +1,78 @@
+import type { CSSProperties } from 'react';
+import type { VaultStatus } from '../types/vault';
+import { vaultLifecycleStages, type VaultLifecycleStage } from '../utils/vaultLifecycle';
+
+export interface VaultLifecycleProps {
+  status: VaultStatus;
+  label?: string;
+}
+
+const STATE_STYLES: Record<VaultLifecycleStage['state'], { color: string; bg: string }> = {
+  done: {
+    color: 'var(--success)',
+    bg: 'color-mix(in srgb, var(--success) 12%, transparent)',
+  },
+  current: {
+    color: 'var(--accent)',
+    bg: 'var(--accent-transparent)',
+  },
+  upcoming: {
+    color: 'var(--muted)',
+    bg: 'var(--bg)',
+  },
+};
+
+const terminalStyles = {
+  color: 'var(--danger)',
+  bg: 'color-mix(in srgb, var(--danger) 12%, transparent)',
+};
+
+const getStageStyles = (stage: VaultLifecycleStage) =>
+  stage.terminal && stage.state === 'current' ? terminalStyles : STATE_STYLES[stage.state];
+
+const containerStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))',
+  gap: '0.75rem',
+  marginTop: '1rem',
+  marginBottom: 0,
+  padding: 0,
+};
+
+export function VaultLifecycle({ status, label = 'Vault lifecycle' }: VaultLifecycleProps) {
+  const stages = vaultLifecycleStages(status);
+
+  return (
+    <ol aria-label={label} style={containerStyle}>
+      {stages.map((stage, index) => {
+        const styles = getStageStyles(stage);
+
+        return (
+          <li
+            key={stage.id}
+            aria-label={`${stage.label}, ${stage.state}`}
+            style={{
+              listStyle: 'none',
+              border: `1px solid ${styles.color}`,
+              borderRadius: 'var(--radius)',
+              background: styles.bg,
+              color: styles.color,
+              padding: '0.75rem',
+              minHeight: 72,
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              gap: '0.25rem',
+            }}
+          >
+            <span style={{ fontSize: 12, fontWeight: 700, textTransform: 'uppercase' }}>
+              Step {index + 1}
+            </span>
+            <span style={{ color: 'var(--text)', fontWeight: 700 }}>{stage.label}</span>
+            <span style={{ fontSize: 12, textTransform: 'capitalize' }}>{stage.state}</span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/src/components/__tests__/VaultLifecycle.test.tsx
+++ b/src/components/__tests__/VaultLifecycle.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { VaultLifecycle } from '../VaultLifecycle';
+
+describe('VaultLifecycle', () => {
+  it('renders an accessible lifecycle list', () => {
+    render(<VaultLifecycle status="pending_validation" />);
+
+    const lifecycle = screen.getByRole('list', { name: 'Vault lifecycle' });
+    expect(within(lifecycle).getAllByRole('listitem')).toHaveLength(4);
+    expect(within(lifecycle).getByLabelText('Created, done')).toBeInTheDocument();
+    expect(within(lifecycle).getByLabelText('Active, done')).toBeInTheDocument();
+    expect(within(lifecycle).getByLabelText('Pending Validation, current')).toBeInTheDocument();
+    expect(within(lifecycle).getByLabelText('Completed, upcoming')).toBeInTheDocument();
+  });
+
+  it('uses terminal styling for failed vaults', () => {
+    render(<VaultLifecycle status="failed" />);
+
+    const failedStep = screen.getByLabelText('Failed, current');
+    expect(failedStep.getAttribute('style')).toContain('var(--danger)');
+  });
+
+  it('supports a custom accessible label', () => {
+    render(<VaultLifecycle status="completed" label="Custom lifecycle" />);
+
+    expect(screen.getByRole('list', { name: 'Custom lifecycle' })).toBeInTheDocument();
+  });
+});

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useParams, Link } from "react-router-dom";
 import { MilestoneTracker } from "../components/MilestoneTracker";
 import { VaultProgressBar } from "../components/VaultProgressBar";
+import { VaultLifecycle } from "../components/VaultLifecycle";
 import { CountdownDeadline } from "../components/CountdownDeadline";
 import {
   FundReleaseStatus,
@@ -11,17 +12,12 @@ import { Text } from "../components/Text";
 import { VaultMetaPanel } from "../components/VaultMetaPanel";
 import { useWallet } from "../context/WalletContext";
 import { contractExplorerUrl, networkLabel } from "../utils/explorer";
-import type { VaultStatus, MilestoneStatus, TxType, Vault, Milestone, VaultTransaction } from "../types/vault";
+import type { VaultStatus, Vault } from "../types/vault";
 import { getVault } from "../services/vaultService";
 
 // ── Types imported from canonical source ─────────────────────────────────────
-// Milestone, VaultTransaction, Vault, VaultStatus, MilestoneStatus, TxType
-// are all imported from "../types/vault" above.
+// Vault and VaultStatus are imported from "../types/vault" above.
 // MOCK_VAULTS has moved to "../services/vaultService" as the master dataset.
-
-// Suppress unused-import warnings for type-only imports used in JSX props
-type _Milestone = Milestone;
-type _VaultTransaction = VaultTransaction;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 const STATUS_CONFIG: Record<
@@ -309,6 +305,7 @@ export default function VaultDetail() {
           label={`${vault.name} timeline progress`}
           showValue={false}
         />
+        <VaultLifecycle status={vault.status} />
         <div
           style={{
             display: "flex",

--- a/src/pages/__tests__/VaultDetail.test.tsx
+++ b/src/pages/__tests__/VaultDetail.test.tsx
@@ -7,6 +7,15 @@ vi.mock('../../context/WalletContext', () => ({
   useWallet: () => ({ network: 'TESTNET' }),
 }));
 
+vi.mock('../../utils/explorer', () => ({
+  contractExplorerUrl: (address: string, network: string) =>
+    `https://stellar.expert/explorer/${network === 'PUBLIC' ? 'public' : 'testnet'}/contract/${address}`,
+  getExplorerTxUrl: (txHash: string, network: string | null) =>
+    `https://stellar.expert/explorer/${network === 'PUBLIC' ? 'public' : 'testnet'}/tx/${txHash}`,
+  networkLabel: (network: string | null | undefined) =>
+    network === 'PUBLIC' ? 'Mainnet' : 'Testnet',
+}));
+
 function renderVaultDetail(id: string) {
   return render(
     <MemoryRouter initialEntries={[`/vaults/${id}`]}>
@@ -18,15 +27,19 @@ function renderVaultDetail(id: string) {
 }
 
 describe('VaultDetail', () => {
-  it('renders active vault status, milestones, transactions, addresses, and deadline', () => {
+  it('renders active vault status, milestones, transactions, addresses, and deadline', async () => {
     renderVaultDetail('1');
 
-    expect(screen.getByRole('heading', { name: 'Alpha Vault' })).toBeInTheDocument();
-    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Alpha Vault' })).toBeInTheDocument();
+    expect(screen.getAllByText('Active').length).toBeGreaterThan(0);
     expect(screen.getByText('12,500')).toBeInTheDocument();
     expect(screen.getAllByText('USDC').length).toBeGreaterThan(0);
 
     expect(screen.getByText('Status Timeline')).toBeInTheDocument();
+    const lifecycle = screen.getByRole('list', { name: 'Vault lifecycle' });
+    expect(within(lifecycle).getByLabelText('Created, done')).toBeInTheDocument();
+    expect(within(lifecycle).getByLabelText('Active, current')).toBeInTheDocument();
+    expect(within(lifecycle).getByLabelText('Pending Validation, upcoming')).toBeInTheDocument();
     expect(screen.getByText(/Deadline Jul 15, 2024/)).toBeInTheDocument();
     // CountdownDeadline active vault should show time remaining or expired
     expect(screen.getByText(/Overdue|remaining/)).toBeInTheDocument();
@@ -58,10 +71,10 @@ describe('VaultDetail', () => {
     expect(screen.getAllByText('b4e0c2d9...9a5e8b').length).toBeGreaterThan(0);
   });
 
-  it('renders completed vault release details without a verifier address', () => {
+  it('renders completed vault release details without a verifier address', async () => {
     renderVaultDetail('2');
 
-    expect(screen.getByRole('heading', { name: 'Beta Reserve' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Beta Reserve' })).toBeInTheDocument();
     expect(screen.getAllByText('Completed').length).toBeGreaterThan(0);
     expect(screen.queryByText('Verifier')).not.toBeInTheDocument();
 
@@ -83,11 +96,12 @@ describe('VaultDetail', () => {
     expect(screen.getAllByText('GSUCC3...LKQK').length).toBeGreaterThan(0);
   });
 
-  it('renders failed vault milestone and redirect transaction details', () => {
+  it('renders failed vault milestone and redirect transaction details', async () => {
     renderVaultDetail('3');
 
-    expect(screen.getByRole('heading', { name: 'Gamma Fund' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Gamma Fund' })).toBeInTheDocument();
     expect(screen.getAllByText('Failed').length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('Failed, current')).toBeInTheDocument();
 
     // Verify Countdown is replaced by status text
     expect(screen.queryByText(/Overdue|remaining/)).not.toBeInTheDocument();
@@ -102,10 +116,10 @@ describe('VaultDetail', () => {
     expect(screen.getAllByText('GFAIL3...LKQK').length).toBeGreaterThan(0);
   });
 
-  it('renders cancelled vault with mixed milestone statuses and redirect destination', () => {
+  it('renders cancelled vault with mixed milestone statuses and redirect destination', async () => {
     renderVaultDetail('4');
 
-    expect(screen.getByRole('heading', { name: 'Delta Cancelled' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Delta Cancelled' })).toBeInTheDocument();
     expect(screen.getAllByText('Cancelled').length).toBeGreaterThan(0);
 
     // Verify Countdown is replaced by status text
@@ -126,10 +140,10 @@ describe('VaultDetail', () => {
     expect(screen.getAllByText('GFAIL3...LKQK').length).toBeGreaterThan(0);
   });
 
-  it('renders a not-found state for an unknown vault id', () => {
+  it('renders a not-found state for an unknown vault id', async () => {
     renderVaultDetail('999');
 
-    expect(screen.getByRole('heading', { name: 'Vault not found' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Vault not found' })).toBeInTheDocument();
     expect(screen.getByText('No vault with ID "999" exists.')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Back to Vaults/i })).toHaveAttribute(
       'href',
@@ -140,27 +154,27 @@ describe('VaultDetail', () => {
   // ── Network footer banner ─────────────────────────────────────────────────
 
   describe('NetworkFooterBanner', () => {
-    it('renders the network footer banner with an accessible landmark', () => {
+    it('renders the network footer banner with an accessible landmark', async () => {
       renderVaultDetail('1');
-      expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+      expect(await screen.findByRole('contentinfo')).toBeInTheDocument();
     });
 
-    it('shows the "Testnet" label when network is TESTNET', () => {
+    it('shows the "Testnet" label when network is TESTNET', async () => {
       renderVaultDetail('1');
-      const footer = screen.getByRole('contentinfo');
+      const footer = await screen.findByRole('contentinfo');
       expect(within(footer).getByText('Testnet')).toBeInTheDocument();
     });
 
-    it('displays the contract address text in the footer', () => {
+    it('displays the contract address text in the footer', async () => {
       renderVaultDetail('1');
-      const footer = screen.getByRole('contentinfo');
+      const footer = await screen.findByRole('contentinfo');
       // Vault 1 contract address
       expect(within(footer).getByText('GCONT3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK')).toBeInTheDocument();
     });
 
-    it('renders the explorer link pointing to the testnet contract URL', () => {
+    it('renders the explorer link pointing to the testnet contract URL', async () => {
       renderVaultDetail('1');
-      const link = screen.getByRole('link', { name: /View contract.*on Stellar Testnet explorer/i });
+      const link = await screen.findByRole('link', { name: /View contract.*on Stellar Testnet explorer/i });
       expect(link).toHaveAttribute(
         'href',
         'https://stellar.expert/explorer/testnet/contract/GCONT3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK',
@@ -177,8 +191,9 @@ describe('VaultDetail', () => {
       }));
     });
 
-    it('does not render the footer banner on the not-found page', () => {
+    it('does not render the footer banner on the not-found page', async () => {
       renderVaultDetail('999');
+      expect(await screen.findByRole('heading', { name: 'Vault not found' })).toBeInTheDocument();
       expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
     });
   });

--- a/src/utils/__tests__/vaultLifecycle.test.ts
+++ b/src/utils/__tests__/vaultLifecycle.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { vaultLifecycleStages } from '../vaultLifecycle';
+
+const states = (status: string) =>
+  vaultLifecycleStages(status).map((stage) => [stage.id, stage.state, stage.label]);
+
+describe('vaultLifecycleStages', () => {
+  it('maps active vaults to the active step', () => {
+    expect(states('active')).toEqual([
+      ['created', 'done', 'Created'],
+      ['active', 'current', 'Active'],
+      ['pending_validation', 'upcoming', 'Pending Validation'],
+      ['completed', 'upcoming', 'Completed'],
+    ]);
+  });
+
+  it('maps pending validation vaults to the validation step', () => {
+    expect(states('pending_validation')).toEqual([
+      ['created', 'done', 'Created'],
+      ['active', 'done', 'Active'],
+      ['pending_validation', 'current', 'Pending Validation'],
+      ['completed', 'upcoming', 'Completed'],
+    ]);
+  });
+
+  it('maps completed vaults to the completed step', () => {
+    expect(states('completed')).toEqual([
+      ['created', 'done', 'Created'],
+      ['active', 'done', 'Active'],
+      ['pending_validation', 'done', 'Pending Validation'],
+      ['completed', 'current', 'Completed'],
+    ]);
+  });
+
+  it('renders failed and cancelled as terminal stages', () => {
+    const failed = vaultLifecycleStages('failed');
+    const cancelled = vaultLifecycleStages('cancelled');
+
+    expect(failed.at(-1)).toMatchObject({
+      id: 'failed',
+      label: 'Failed',
+      state: 'current',
+      terminal: true,
+    });
+    expect(cancelled.at(-1)).toMatchObject({
+      id: 'cancelled',
+      label: 'Cancelled',
+      state: 'current',
+      terminal: true,
+    });
+  });
+
+  it('falls back safely for unknown statuses', () => {
+    expect(states('unknown')).toEqual([
+      ['created', 'current', 'Created'],
+      ['active', 'upcoming', 'Active'],
+      ['pending_validation', 'upcoming', 'Pending Validation'],
+      ['completed', 'upcoming', 'Completed'],
+    ]);
+  });
+});

--- a/src/utils/vaultLifecycle.ts
+++ b/src/utils/vaultLifecycle.ts
@@ -1,0 +1,58 @@
+import type { VaultStatus } from '../types/vault';
+
+export type VaultLifecycleStageState = 'done' | 'current' | 'upcoming';
+
+export interface VaultLifecycleStage {
+  id: string;
+  label: string;
+  state: VaultLifecycleStageState;
+  terminal?: boolean;
+}
+
+const isVaultStatus = (status: string): status is VaultStatus =>
+  ['active', 'pending_validation', 'completed', 'failed', 'cancelled'].includes(status);
+
+const finalStageFor = (status: VaultStatus): VaultLifecycleStage => {
+  if (status === 'failed') {
+    return { id: 'failed', label: 'Failed', state: 'current', terminal: true };
+  }
+
+  if (status === 'cancelled') {
+    return { id: 'cancelled', label: 'Cancelled', state: 'current', terminal: true };
+  }
+
+  return {
+    id: 'completed',
+    label: 'Completed',
+    state: status === 'completed' ? 'current' : 'upcoming',
+  };
+};
+
+export function vaultLifecycleStages(status: VaultStatus | string): VaultLifecycleStage[] {
+  if (!isVaultStatus(status)) {
+    return [
+      { id: 'created', label: 'Created', state: 'current' },
+      { id: 'active', label: 'Active', state: 'upcoming' },
+      { id: 'pending_validation', label: 'Pending Validation', state: 'upcoming' },
+      { id: 'completed', label: 'Completed', state: 'upcoming' },
+    ];
+  }
+
+  const activeHasPassed = status !== 'active';
+  const validationHasPassed = ['completed', 'failed', 'cancelled'].includes(status);
+
+  return [
+    { id: 'created', label: 'Created', state: 'done' },
+    {
+      id: 'active',
+      label: 'Active',
+      state: status === 'active' ? 'current' : 'done',
+    },
+    {
+      id: 'pending_validation',
+      label: 'Pending Validation',
+      state: status === 'pending_validation' ? 'current' : activeHasPassed && validationHasPassed ? 'done' : 'upcoming',
+    },
+    finalStageFor(status),
+  ];
+}


### PR DESCRIPTION
## Summary
- add a pure `vaultLifecycleStages` status mapping utility for vault lifecycle steps
- add a token-styled accessible `VaultLifecycle` stepper and render it in `VaultDetail`
- cover active, pending validation, completed, failed/cancelled, and unknown fallback states with tests and docs

Closes #461

## Validation
- `npx vitest run src/utils/__tests__/vaultLifecycle.test.ts src/components/__tests__/VaultLifecycle.test.tsx src/pages/__tests__/VaultDetail.test.tsx --reporter=dot`
- `npx eslint src/utils/vaultLifecycle.ts src/utils/__tests__/vaultLifecycle.test.ts src/components/VaultLifecycle.tsx src/components/__tests__/VaultLifecycle.test.tsx src/pages/VaultDetail.tsx src/pages/__tests__/VaultDetail.test.tsx`
- `git diff --check`

## Note
- `npm run build` is currently blocked by pre-existing syntax errors in `src/utils/__tests__/csv.analytics.test.ts(82,37)` and `src/utils/__tests__/verifierMetrics.test.ts(351,1)`.