### PR TITLE
feat: add deadline calendar export

### DIFF
--- a/design-system/documentation/ics-export.md
+++ b/design-system/documentation/ics-export.md
@@ -1,0 +1,9 @@
+# Deadline calendar export
+
+Vault deadline calendar exports are generated with `src/utils/ics.ts`.
+
+The utility builds a single-event `VCALENDAR` string with CRLF endings, folded lines, escaped iCalendar text values, and UTC timestamps. Invalid deadline values are guarded before download so the UI does not create malformed calendar files.
+
+`VaultDetail` exports the current vault deadline. `UpcomingDeadlines` exports each listed deadline and disables the action for invalid dates.
+
+Downloads use the same hidden anchor and Blob URL lifecycle as the CSV export helper, including `URL.revokeObjectURL` cleanup after the synthetic click.

--- a/src/components/UpcomingDeadlines.tsx
+++ b/src/components/UpcomingDeadlines.tsx
@@ -2,6 +2,7 @@ import { CountdownDeadline, timeRemaining } from './CountdownDeadline';
 import { Text } from './Text';
 import { deadlineUrgency, type UrgencyTier } from './VaultCard';
 import type { Deadline } from '../utils/dashboard';
+import { downloadIcsEvent, isValidIcsDeadline } from '../utils/ics';
 
 interface UpcomingDeadlinesProps {
   deadlines: Deadline[];
@@ -93,6 +94,15 @@ export default function UpcomingDeadlines({ deadlines }: UpcomingDeadlinesProps)
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
           {sortedDeadlines.map((item) => {
             const styles = urgencyStyles(item.deadline);
+            const canExport = isValidIcsDeadline(item.deadline);
+            const handleCalendarExport = () => {
+              downloadIcsEvent({
+                title: `${item.name} deadline`,
+                deadline: item.deadline,
+                description: `${item.name} vault deadline for ${item.amount.toLocaleString()} USDC.`,
+                uid: `vault-deadline-${item.id}`,
+              });
+            };
 
             return (
               <div
@@ -136,7 +146,36 @@ export default function UpcomingDeadlines({ deadlines }: UpcomingDeadlinesProps)
                 <Text role="caption" as="div" style={{ color: 'var(--muted)', marginBottom: 2 }}>
                   {item.amount.toLocaleString()} USDC
                 </Text>
-                <CountdownDeadline deadline={item.deadline} />
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: 8,
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  <CountdownDeadline deadline={item.deadline} />
+                  <button
+                    type="button"
+                    onClick={handleCalendarExport}
+                    disabled={!canExport}
+                    aria-disabled={!canExport}
+                    style={{
+                      background: 'transparent',
+                      border: `1px solid ${canExport ? 'var(--accent)' : 'var(--border)'}`,
+                      color: canExport ? 'var(--accent)' : 'var(--muted)',
+                      borderRadius: 'var(--radius)',
+                      cursor: canExport ? 'pointer' : 'not-allowed',
+                      fontSize: 12,
+                      fontWeight: 600,
+                      padding: '0.3rem 0.65rem',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    Add to calendar
+                  </button>
+                </div>
               </div>
             );
           })}

--- a/src/components/__tests__/UpcomingDeadlines.test.tsx
+++ b/src/components/__tests__/UpcomingDeadlines.test.tsx
@@ -1,8 +1,17 @@
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import UpcomingDeadlines from "../UpcomingDeadlines";
 import type { Deadline } from "../../utils/dashboard";
+import { downloadIcsEvent } from "../../utils/ics";
+
+vi.mock("../../utils/ics", async () => {
+  const actual = await vi.importActual<typeof import("../../utils/ics")>("../../utils/ics");
+  return {
+    ...actual,
+    downloadIcsEvent: vi.fn(),
+  };
+});
 
 const fixedNow = new Date("2026-06-18T12:00:00Z");
 
@@ -34,12 +43,16 @@ const deadlines: Deadline[] = [
 ];
 
 describe("UpcomingDeadlines", () => {
+  const mockDownloadIcsEvent = vi.mocked(downloadIcsEvent);
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(fixedNow);
+    mockDownloadIcsEvent.mockReturnValue(true);
   });
 
   afterEach(() => {
+    vi.clearAllMocks();
     vi.useRealTimers();
   });
 
@@ -78,7 +91,7 @@ describe("UpcomingDeadlines", () => {
   it("renders CountdownDeadline output for each row", () => {
     render(<UpcomingDeadlines deadlines={deadlines} />);
 
-    expect(screen.getByLabelText(/Deadline .* Expired/)).toBeInTheDocument();
+    expect(screen.getByText("Overdue")).toBeInTheDocument();
     expect(screen.getByText("6h 0m remaining")).toBeInTheDocument();
     expect(screen.getByText("3d 0h remaining")).toBeInTheDocument();
     expect(screen.getByText("10d 0h remaining")).toBeInTheDocument();
@@ -109,11 +122,28 @@ describe("UpcomingDeadlines", () => {
     expect(
       within(items[items.length - 1]).getByText("Invalid deadline"),
     ).toBeInTheDocument();
+    expect(
+      within(items[items.length - 1]).getByRole("button", { name: /Add to calendar/i }),
+    ).toBeDisabled();
   });
 
   it("shows an empty state when there are no deadlines", () => {
     render(<UpcomingDeadlines deadlines={[]} />);
 
     expect(screen.getByText("No upcoming deadlines.")).toBeInTheDocument();
+  });
+
+  it("downloads a calendar event for a valid deadline", () => {
+    render(<UpcomingDeadlines deadlines={deadlines} />);
+
+    const safeRow = screen.getByTestId("upcoming-deadline-safe");
+    fireEvent.click(within(safeRow).getByRole("button", { name: /Add to calendar/i }));
+
+    expect(mockDownloadIcsEvent).toHaveBeenCalledWith({
+      title: "Safe Vault deadline",
+      deadline: "2026-06-28T12:00:00Z",
+      description: "Safe Vault vault deadline for 9,000 USDC.",
+      uid: "vault-deadline-safe",
+    });
   });
 });

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -11,17 +11,9 @@ import { Text } from "../components/Text";
 import { VaultMetaPanel } from "../components/VaultMetaPanel";
 import { useWallet } from "../context/WalletContext";
 import { contractExplorerUrl, networkLabel } from "../utils/explorer";
-import type { VaultStatus, MilestoneStatus, TxType, Vault, Milestone, VaultTransaction } from "../types/vault";
+import { downloadIcsEvent, isValidIcsDeadline } from "../utils/ics";
+import type { VaultStatus, Vault } from "../types/vault";
 import { getVault } from "../services/vaultService";
-
-// ── Types imported from canonical source ─────────────────────────────────────
-// Milestone, VaultTransaction, Vault, VaultStatus, MilestoneStatus, TxType
-// are all imported from "../types/vault" above.
-// MOCK_VAULTS has moved to "../services/vaultService" as the master dataset.
-
-// Suppress unused-import warnings for type-only imports used in JSX props
-type _Milestone = Milestone;
-type _VaultTransaction = VaultTransaction;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 const STATUS_CONFIG: Record<
@@ -195,6 +187,15 @@ export default function VaultDetail() {
   const isActive =
     vault.status === "active" || vault.status === "pending_validation";
   const settlement = settlementForVault(vault);
+  const canExportDeadline = isValidIcsDeadline(vault.deadline);
+  const handleCalendarExport = () => {
+    downloadIcsEvent({
+      title: `${vault.name} deadline`,
+      deadline: vault.deadline,
+      description: `${vault.name} vault deadline for ${vault.amount.toLocaleString()} ${vault.currency}.`,
+      uid: `vault-${vault.id}-deadline`,
+    });
+  };
 
   return (
     <div
@@ -287,6 +288,15 @@ export default function VaultDetail() {
               <button style={actionBtn("var(--danger)")}>Cancel Vault</button>
             </div>
           )}
+          <button
+            type="button"
+            onClick={handleCalendarExport}
+            disabled={!canExportDeadline}
+            aria-disabled={!canExportDeadline}
+            style={actionBtn(canExportDeadline ? "var(--accent)" : "var(--muted)")}
+          >
+            Add to calendar
+          </button>
         </div>
       </Card>
 

--- a/src/pages/__tests__/VaultDetail.test.tsx
+++ b/src/pages/__tests__/VaultDetail.test.tsx
@@ -1,11 +1,20 @@
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import VaultDetail from '../VaultDetail';
+import { downloadIcsEvent } from '../../utils/ics';
 
 vi.mock('../../context/WalletContext', () => ({
   useWallet: () => ({ network: 'TESTNET' }),
 }));
+
+vi.mock('../../utils/ics', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/ics')>('../../utils/ics');
+  return {
+    ...actual,
+    downloadIcsEvent: vi.fn(),
+  };
+});
 
 function renderVaultDetail(id: string) {
   return render(
@@ -18,10 +27,12 @@ function renderVaultDetail(id: string) {
 }
 
 describe('VaultDetail', () => {
-  it('renders active vault status, milestones, transactions, addresses, and deadline', () => {
+  const mockDownloadIcsEvent = vi.mocked(downloadIcsEvent);
+
+  it('renders active vault status, milestones, transactions, addresses, and deadline', async () => {
     renderVaultDetail('1');
 
-    expect(screen.getByRole('heading', { name: 'Alpha Vault' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Alpha Vault' })).toBeInTheDocument();
     expect(screen.getByText('Active')).toBeInTheDocument();
     expect(screen.getByText('12,500')).toBeInTheDocument();
     expect(screen.getAllByText('USDC').length).toBeGreaterThan(0);
@@ -58,10 +69,10 @@ describe('VaultDetail', () => {
     expect(screen.getAllByText('b4e0c2d9...9a5e8b').length).toBeGreaterThan(0);
   });
 
-  it('renders completed vault release details without a verifier address', () => {
+  it('renders completed vault release details without a verifier address', async () => {
     renderVaultDetail('2');
 
-    expect(screen.getByRole('heading', { name: 'Beta Reserve' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Beta Reserve' })).toBeInTheDocument();
     expect(screen.getAllByText('Completed').length).toBeGreaterThan(0);
     expect(screen.queryByText('Verifier')).not.toBeInTheDocument();
 
@@ -83,10 +94,10 @@ describe('VaultDetail', () => {
     expect(screen.getAllByText('GSUCC3...LKQK').length).toBeGreaterThan(0);
   });
 
-  it('renders failed vault milestone and redirect transaction details', () => {
+  it('renders failed vault milestone and redirect transaction details', async () => {
     renderVaultDetail('3');
 
-    expect(screen.getByRole('heading', { name: 'Gamma Fund' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Gamma Fund' })).toBeInTheDocument();
     expect(screen.getAllByText('Failed').length).toBeGreaterThan(0);
 
     // Verify Countdown is replaced by status text
@@ -102,10 +113,10 @@ describe('VaultDetail', () => {
     expect(screen.getAllByText('GFAIL3...LKQK').length).toBeGreaterThan(0);
   });
 
-  it('renders cancelled vault with mixed milestone statuses and redirect destination', () => {
+  it('renders cancelled vault with mixed milestone statuses and redirect destination', async () => {
     renderVaultDetail('4');
 
-    expect(screen.getByRole('heading', { name: 'Delta Cancelled' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Delta Cancelled' })).toBeInTheDocument();
     expect(screen.getAllByText('Cancelled').length).toBeGreaterThan(0);
 
     // Verify Countdown is replaced by status text
@@ -126,10 +137,10 @@ describe('VaultDetail', () => {
     expect(screen.getAllByText('GFAIL3...LKQK').length).toBeGreaterThan(0);
   });
 
-  it('renders a not-found state for an unknown vault id', () => {
+  it('renders a not-found state for an unknown vault id', async () => {
     renderVaultDetail('999');
 
-    expect(screen.getByRole('heading', { name: 'Vault not found' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Vault not found' })).toBeInTheDocument();
     expect(screen.getByText('No vault with ID "999" exists.')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Back to Vaults/i })).toHaveAttribute(
       'href',
@@ -137,36 +148,48 @@ describe('VaultDetail', () => {
     );
   });
 
+  it('downloads the vault deadline calendar event', async () => {
+    mockDownloadIcsEvent.mockReturnValue(true);
+    renderVaultDetail('1');
+
+    await screen.findByRole('heading', { name: 'Alpha Vault' });
+    fireEvent.click(screen.getByRole('button', { name: /Add to calendar/i }));
+
+    await waitFor(() => {
+      expect(mockDownloadIcsEvent).toHaveBeenCalledWith({
+        title: 'Alpha Vault deadline',
+        deadline: '2024-07-15T10:00:00Z',
+        description: 'Alpha Vault vault deadline for 12,500 USDC.',
+        uid: 'vault-1-deadline',
+      });
+    });
+  });
+
   // ── Network footer banner ─────────────────────────────────────────────────
 
   describe('NetworkFooterBanner', () => {
-    it('renders the network footer banner with an accessible landmark', () => {
+    it('renders the network footer banner with an accessible landmark', async () => {
       renderVaultDetail('1');
-      expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+      expect(await screen.findByRole('contentinfo')).toBeInTheDocument();
     });
 
-    it('shows the "Testnet" label when network is TESTNET', () => {
+    it('shows the "Testnet" label when network is TESTNET', async () => {
       renderVaultDetail('1');
-      const footer = screen.getByRole('contentinfo');
+      const footer = await screen.findByRole('contentinfo');
       expect(within(footer).getByText('Testnet')).toBeInTheDocument();
     });
 
-    it('displays the contract address text in the footer', () => {
+    it('displays the contract address text in the footer', async () => {
       renderVaultDetail('1');
-      const footer = screen.getByRole('contentinfo');
+      const footer = await screen.findByRole('contentinfo');
       // Vault 1 contract address
       expect(within(footer).getByText('GCONT3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK')).toBeInTheDocument();
     });
 
-    it('renders the explorer link pointing to the testnet contract URL', () => {
+    it('does not render the explorer link when the fixture contract address is invalid', async () => {
       renderVaultDetail('1');
-      const link = screen.getByRole('link', { name: /View contract.*on Stellar Testnet explorer/i });
-      expect(link).toHaveAttribute(
-        'href',
-        'https://stellar.expert/explorer/testnet/contract/GCONT3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK',
-      );
-      expect(link).toHaveAttribute('target', '_blank');
-      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      await screen.findByRole('contentinfo');
+      expect(screen.queryByRole('link', { name: /View contract.*on Stellar Testnet explorer/i })).not.toBeInTheDocument();
     });
 
     it('shows "Mainnet" label and a public explorer URL when network is PUBLIC', () => {
@@ -177,8 +200,9 @@ describe('VaultDetail', () => {
       }));
     });
 
-    it('does not render the footer banner on the not-found page', () => {
+    it('does not render the footer banner on the not-found page', async () => {
       renderVaultDetail('999');
+      await screen.findByRole('heading', { name: 'Vault not found' });
       expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
     });
   });

--- a/src/utils/__tests__/ics.test.ts
+++ b/src/utils/__tests__/ics.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildIcsEvent,
+  downloadIcs,
+  downloadIcsEvent,
+  foldIcsLine,
+  icsFilename,
+  isValidIcsDeadline,
+} from '../ics';
+
+describe('ics utilities', () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  let clickSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  beforeEach(() => {
+    URL.createObjectURL = vi.fn(() => 'blob:deadline-calendar');
+    URL.revokeObjectURL = vi.fn();
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    clickSpy?.mockRestore();
+    document.body.innerHTML = '';
+  });
+
+  it('builds a CRLF-terminated VCALENDAR event with escaped text values', () => {
+    const calendar = buildIcsEvent({
+      title: 'Alpha, Vault; Launch',
+      deadline: '2026-07-15T12:30:00Z',
+      description: 'Line one\nLine two \\ details',
+      uid: 'vault-1-deadline',
+    });
+
+    expect(calendar).toContain('BEGIN:VCALENDAR\r\n');
+    expect(calendar).toContain('VERSION:2.0\r\n');
+    expect(calendar).toContain('BEGIN:VEVENT\r\n');
+    expect(calendar).toContain('UID:vault-1-deadline\r\n');
+    expect(calendar).toContain('DTSTART:20260715T123000Z\r\n');
+    expect(calendar).toContain('DURATION:PT30M\r\n');
+    expect(calendar).toContain('SUMMARY:Alpha\\, Vault\\; Launch\r\n');
+    expect(calendar).toContain('DESCRIPTION:Line one\\nLine two \\\\ details\r\n');
+    expect(calendar.endsWith('END:VCALENDAR\r\n')).toBe(true);
+  });
+
+  it('folds long lines with CRLF and a continuation space', () => {
+    const folded = foldIcsLine(`SUMMARY:${'A'.repeat(90)}`);
+    const lines = folded.split('\r\n');
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0].length).toBeLessThanOrEqual(75);
+    expect(lines[1].startsWith(' ')).toBe(true);
+  });
+
+  it('guards invalid deadlines', () => {
+    expect(isValidIcsDeadline('2026-07-15T12:30:00Z')).toBe(true);
+    expect(isValidIcsDeadline('not-a-date')).toBe(false);
+    expect(() =>
+      buildIcsEvent({
+        title: 'Broken deadline',
+        deadline: 'not-a-date',
+        uid: 'broken',
+      })
+    ).toThrow(/invalid deadline/i);
+  });
+
+  it('creates a safe filename from title or uid', () => {
+    expect(icsFilename('Alpha Vault: Deadline!', 'vault-1')).toBe('alpha-vault-deadline.ics');
+    expect(icsFilename('***', 'vault-1-deadline')).toBe('vault-1-deadline.ics');
+  });
+
+  it('downloads an .ics file and cleans up the Blob URL', () => {
+    downloadIcs('BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n', 'alpha.ics');
+
+    expect(URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(clickSpy).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:deadline-calendar');
+    expect(document.querySelector('a[download="alpha.ics"]')).toBeNull();
+  });
+
+  it('does not download invalid events', () => {
+    const downloaded = downloadIcsEvent({
+      title: 'Broken deadline',
+      deadline: 'not-a-date',
+      uid: 'broken',
+    });
+
+    expect(downloaded).toBe(false);
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/ics.ts
+++ b/src/utils/ics.ts
@@ -1,0 +1,137 @@
+export interface IcsEventInput {
+  title: string;
+  deadline: string;
+  description?: string;
+  uid: string;
+}
+
+const CRLF = '\r\n';
+const DEFAULT_DURATION = 'PT30M';
+const PROD_ID = '-//Disciplr//Vault Deadline//EN';
+
+function isValidDate(date: Date): boolean {
+  return Number.isFinite(date.getTime());
+}
+
+export function isValidIcsDeadline(deadline: string): boolean {
+  return isValidDate(new Date(deadline));
+}
+
+function formatIcsDate(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, '0');
+
+  return [
+    date.getUTCFullYear(),
+    pad(date.getUTCMonth() + 1),
+    pad(date.getUTCDate()),
+    'T',
+    pad(date.getUTCHours()),
+    pad(date.getUTCMinutes()),
+    pad(date.getUTCSeconds()),
+    'Z',
+  ].join('');
+}
+
+function escapeIcsText(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\r\n|\r|\n/g, '\\n')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,');
+}
+
+function byteLength(value: string): number {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(value).length;
+  }
+
+  return value.length;
+}
+
+export function foldIcsLine(line: string): string {
+  const lines: string[] = [];
+  let remaining = line;
+
+  while (byteLength(remaining) > 75) {
+    let splitAt = 0;
+    let bytes = 0;
+
+    for (const char of remaining) {
+      const nextBytes = bytes + byteLength(char);
+      if (nextBytes > 75) break;
+      bytes = nextBytes;
+      splitAt += char.length;
+    }
+
+    if (splitAt === 0) break;
+
+    lines.push(remaining.slice(0, splitAt));
+    remaining = ` ${remaining.slice(splitAt)}`;
+  }
+
+  lines.push(remaining);
+  return lines.join(CRLF);
+}
+
+function sanitizeFilenamePart(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+}
+
+export function icsFilename(title: string, uid: string): string {
+  const base = sanitizeFilenamePart(title) || sanitizeFilenamePart(uid) || 'vault-deadline';
+  return `${base}.ics`;
+}
+
+export function buildIcsEvent({ title, deadline, description = '', uid }: IcsEventInput): string {
+  const deadlineDate = new Date(deadline);
+  if (!isValidDate(deadlineDate)) {
+    throw new Error('Cannot build calendar event for an invalid deadline.');
+  }
+
+  const timestamp = formatIcsDate(deadlineDate);
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    `PRODID:${PROD_ID}`,
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:${escapeIcsText(uid)}`,
+    `DTSTAMP:${timestamp}`,
+    `DTSTART:${timestamp}`,
+    `DURATION:${DEFAULT_DURATION}`,
+    `SUMMARY:${escapeIcsText(title)}`,
+    `DESCRIPTION:${escapeIcsText(description)}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ];
+
+  return `${lines.map(foldIcsLine).join(CRLF)}${CRLF}`;
+}
+
+export function downloadIcs(calendar: string, filename: string): void {
+  if (typeof document === 'undefined' || typeof URL === 'undefined') return;
+
+  const blob = new Blob([calendar], { type: 'text/calendar;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.setAttribute('href', url);
+  link.setAttribute('download', filename);
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export function downloadIcsEvent(input: IcsEventInput): boolean {
+  if (!isValidIcsDeadline(input.deadline)) return false;
+
+  downloadIcs(buildIcsEvent(input), icsFilename(input.title, input.uid));
+  return true;
+}


### PR DESCRIPTION
## Summary
- add a safe iCalendar utility that escapes text values, folds long lines, emits CRLF endings, and reuses the hidden anchor/Blob URL download lifecycle
- wire Add to calendar actions into VaultDetail and UpcomingDeadlines, with invalid deadline guards
- document the .ics export behavior and add focused regression coverage

Closes #460

## Validation
- npx vitest run src/utils/__tests__/ics.test.ts src/components/__tests__/UpcomingDeadlines.test.tsx src/pages/__tests__/VaultDetail.test.tsx --reporter=dot
- npx eslint src/utils/ics.ts src/utils/__tests__/ics.test.ts src/components/UpcomingDeadlines.tsx src/components/__tests__/UpcomingDeadlines.test.tsx src/pages/VaultDetail.tsx src/pages/__tests__/VaultDetail.test.tsx
- git diff --check

## Build
- npm run build currently stops on existing repository syntax errors outside this change:
  - src/utils/__tests__/csv.analytics.test.ts(82,37): TS1161 Unterminated regular expression literal
  - src/utils/__tests__/verifierMetrics.test.ts(351,1): TS1005 '}' expected