### PR TITLE
feat: quiet-hours range with active indicator

### DIFF
--- a/design-system/documentation/notification-settings.md
+++ b/design-system/documentation/notification-settings.md
@@ -15,20 +15,37 @@ These tokens are backed by `design-system/tokens/colors.json` neutral and second
 Notification preferences are stored globally and persisted across page reloads using the `useNotificationPreferences` Zustand store (defined in `src/Zustand/notificationPreferences.ts` and exported from `src/Zustand/Store.ts`).
 
 ### Fields
+
 - `email`: boolean (default: `true`)
 - `push`: boolean (default: `false`)
 - `frequency`: string (default: `""`)
 - `quietHours`: string (default: `"12:00"`)
+- `quietStart`: string (default: `"22:00"`)
+- `quietEnd`: string (default: `"07:00"`)
 
 ### Actions
+
 - `setEmail(value: boolean)`: Update email preference.
 - `setPush(value: boolean)`: Update push notification preference.
 - `setFrequency(value: string)`: Update notification frequency.
 - `setQuietHours(value: string)`: Update quiet hours timing.
+- `setQuietRange(start: string, end: string)`: Update the quiet-hours start/end range while keeping `quietHours` backward compatible with the start time.
 - `reset()`: Reset preferences back to their default values.
 
 ### Persistence Details
+
 Preferences are stored in `localStorage` under the key `"notification-preferences"`. Any component in the app can read from or write to this store to coordinate user notification preferences across surfaces (e.g., the notification settings page, header notification bell, etc.).
+
+## Quiet Hours Validation
+
+NotificationSettings now stores quiet hours as a start/end range:
+
+- Times must use valid `HH:MM` 24-hour values.
+- Start and end cannot be equal.
+- Ranges can wrap around midnight, such as `22:00` to `07:00`.
+- The active badge uses `isQuietHoursActive(now, start, end)` from `src/utils/quietHours.ts`.
+- The start minute is inclusive and the end minute is exclusive, so a `22:00` to `07:00` window is inactive at exactly `07:00`.
+
 ## Header Notification Bell
 
 The `NotificationBell` component is integrated into the Layout header to provide an interactive and accessible entry point to notifications:
@@ -41,4 +58,3 @@ The `NotificationBell` component is integrated into the Layout header to provide
   - Mounted inside `desktop-nav` for screen resolutions >= 768px.
   - Mounted inside `.mobile-bell-wrapper` next to the mobile menu hamburger button for resolutions < 768px.
 - **Accessibility**: Includes a dynamic `aria-label` containing the unread count (e.g. `aria-label="Notifications, 3 unread"` or `aria-label="Notifications, 0 unread"`), ensuring screen readers can announce the notification status.
-

--- a/src/Zustand/__tests__/notificationPreferences.test.ts
+++ b/src/Zustand/__tests__/notificationPreferences.test.ts
@@ -19,6 +19,8 @@ describe("useNotificationPreferences store", () => {
     expect(state.push).toBe(false);
     expect(state.frequency).toBe("");
     expect(state.quietHours).toBe("12:00");
+    expect(state.quietStart).toBe("22:00");
+    expect(state.quietEnd).toBe("07:00");
   });
 
   it("should update email preference", () => {
@@ -45,13 +47,22 @@ describe("useNotificationPreferences store", () => {
   it("should update quietHours preference", () => {
     useNotificationPreferences.getState().setQuietHours("22:00");
     expect(useNotificationPreferences.getState().quietHours).toBe("22:00");
+    expect(useNotificationPreferences.getState().quietStart).toBe("22:00");
+  });
+
+  it("should update quiet-hours range preferences", () => {
+    useNotificationPreferences.getState().setQuietRange("21:30", "06:45");
+
+    expect(useNotificationPreferences.getState().quietStart).toBe("21:30");
+    expect(useNotificationPreferences.getState().quietEnd).toBe("06:45");
+    expect(useNotificationPreferences.getState().quietHours).toBe("21:30");
   });
 
   it("should reset to default state", () => {
     useNotificationPreferences.getState().setEmail(false);
     useNotificationPreferences.getState().setPush(true);
     useNotificationPreferences.getState().setFrequency("2");
-    useNotificationPreferences.getState().setQuietHours("09:00");
+    useNotificationPreferences.getState().setQuietRange("09:00", "17:00");
 
     useNotificationPreferences.getState().reset();
 
@@ -60,21 +71,25 @@ describe("useNotificationPreferences store", () => {
     expect(state.push).toBe(false);
     expect(state.frequency).toBe("");
     expect(state.quietHours).toBe("12:00");
+    expect(state.quietStart).toBe("22:00");
+    expect(state.quietEnd).toBe("07:00");
   });
 
   it("should persist state to localStorage", () => {
     useNotificationPreferences.getState().setEmail(false);
     useNotificationPreferences.getState().setPush(true);
     useNotificationPreferences.getState().setFrequency("3");
-    useNotificationPreferences.getState().setQuietHours("08:30");
+    useNotificationPreferences.getState().setQuietRange("08:30", "18:45");
 
     const stored = localStorage.getItem("notification-preferences");
     expect(stored).not.toBeNull();
-    
+
     const parsed = JSON.parse(stored!);
     expect(parsed.state.email).toBe(false);
     expect(parsed.state.push).toBe(true);
     expect(parsed.state.frequency).toBe("3");
     expect(parsed.state.quietHours).toBe("08:30");
+    expect(parsed.state.quietStart).toBe("08:30");
+    expect(parsed.state.quietEnd).toBe("18:45");
   });
 });

--- a/src/Zustand/notificationPreferences.ts
+++ b/src/Zustand/notificationPreferences.ts
@@ -6,34 +6,44 @@ export interface NotificationPreferencesState {
   push: boolean;
   frequency: string;
   quietHours: string;
+  quietStart: string;
+  quietEnd: string;
   setEmail: (value: boolean) => void;
   setPush: (value: boolean) => void;
   setFrequency: (value: string) => void;
   setQuietHours: (value: string) => void;
+  setQuietRange: (start: string, end: string) => void;
   reset: () => void;
 }
 
-export const useNotificationPreferences = create<NotificationPreferencesState>()(
-  persist(
-    (set) => ({
-      email: true,
-      push: false,
-      frequency: "",
-      quietHours: "12:00",
-      setEmail: (value) => set({ email: value }),
-      setPush: (value) => set({ push: value }),
-      setFrequency: (value) => set({ frequency: value }),
-      setQuietHours: (value) => set({ quietHours: value }),
-      reset: () =>
-        set({
-          email: true,
-          push: false,
-          frequency: "",
-          quietHours: "12:00",
-        }),
-    }),
-    {
-      name: "notification-preferences",
-    }
-  )
-);
+export const useNotificationPreferences =
+  create<NotificationPreferencesState>()(
+    persist(
+      (set) => ({
+        email: true,
+        push: false,
+        frequency: "",
+        quietHours: "12:00",
+        quietStart: "22:00",
+        quietEnd: "07:00",
+        setEmail: (value) => set({ email: value }),
+        setPush: (value) => set({ push: value }),
+        setFrequency: (value) => set({ frequency: value }),
+        setQuietHours: (value) => set({ quietHours: value, quietStart: value }),
+        setQuietRange: (start, end) =>
+          set({ quietStart: start, quietEnd: end, quietHours: start }),
+        reset: () =>
+          set({
+            email: true,
+            push: false,
+            frequency: "",
+            quietHours: "12:00",
+            quietStart: "22:00",
+            quietEnd: "07:00",
+          }),
+      }),
+      {
+        name: "notification-preferences",
+      },
+    ),
+  );

--- a/src/pages/NotificationSettings.tsx
+++ b/src/pages/NotificationSettings.tsx
@@ -1,7 +1,11 @@
 import { vaults } from "@/components/Notification/exampleNotification/example";
 import { Text } from "@/components/Text";
 import { useNotificationPreferences } from "../Zustand/Store";
-
+import {
+  isQuietHoursActive,
+  isValidQuietHoursRange,
+  isValidQuietTime,
+} from "@/utils/quietHours";
 
 type SettingsToggleProps = {
   checked?: boolean;
@@ -33,22 +37,50 @@ export default function NotificationSettings() {
     push: pushNotification,
     frequency,
     quietHours,
+    quietStart,
+    quietEnd,
     setEmail: setEmailNotification,
     setPush: setPushNotification,
     setFrequency,
     setQuietHours,
+    setQuietRange,
     reset,
   } = useNotificationPreferences();
+  const quietStartValue = quietStart ?? quietHours;
+  const quietEndValue = quietEnd ?? "07:00";
+  const quietRangeIsValid = isValidQuietHoursRange(
+    quietStartValue,
+    quietEndValue,
+  );
+  const quietHoursActive =
+    quietRangeIsValid &&
+    isQuietHoursActive(new Date(), quietStartValue, quietEndValue);
+
+  const updateQuietRange = (nextStart: string, nextEnd: string) => {
+    if (isValidQuietTime(nextStart) && isValidQuietTime(nextEnd)) {
+      setQuietRange(nextStart, nextEnd);
+      return;
+    }
+
+    if (isValidQuietTime(nextStart)) {
+      setQuietHours(nextStart);
+    }
+  };
+
   return (
     <>
-      <div 
+      <div
         className="w-full rounded-md px-3 py-3 notification-settings-panel"
-        style={{ zIndex: 'var(--z-index-base)' }}
+        style={{ zIndex: "var(--z-index-base)" }}
       >
-        <Text role="title" as="h2">Notification Settings</Text>
+        <Text role="title" as="h2">
+          Notification Settings
+        </Text>
         <div>
           <div className="grid grid-cols-2 justify-center items-center mt-5">
-            <Text role="body" as="p">Email Notification</Text>
+            <Text role="body" as="p">
+              Email Notification
+            </Text>
             <div className="flex flex-col items-end justify-end gap-4">
               <SettingsToggle
                 label="Email Notification"
@@ -58,7 +90,9 @@ export default function NotificationSettings() {
             </div>
           </div>
           <div className="grid grid-cols-2 justify-center items-center mt-5">
-            <Text role="body" as="p">Push Notification</Text>
+            <Text role="body" as="p">
+              Push Notification
+            </Text>
             <div className="flex flex-col items-end justify-end gap-4">
               <SettingsToggle
                 label="Push Notification"
@@ -69,7 +103,9 @@ export default function NotificationSettings() {
           </div>
           <div className="flex justify-between items-center mt-5">
             <label htmlFor="notification-frequency">
-              <Text role="body" as="span">Notification Frequency</Text>
+              <Text role="body" as="span">
+                Notification Frequency
+              </Text>
             </label>
             <select
               className="w-[200px] notification-settings-field"
@@ -86,19 +122,65 @@ export default function NotificationSettings() {
               <option value="4">Never</option>
             </select>
           </div>
-          <div className="flex justify-between items-center mt-5">
-            <label htmlFor="quiet-hours">
-              <Text role="body" as="span">Quiet Hours</Text>
-            </label>
-            <input
-              className="w-[200px] notification-settings-field"
-              type="time"
-              id="quiet-hours"
-              value={quietHours}
-              onChange={(e) => {
-                setQuietHours(e.target.value);
-              }}
-            />
+          <div className="mt-5">
+            <div className="flex items-center justify-between gap-4">
+              <Text role="body" as="span">
+                Quiet Hours
+              </Text>
+              <span
+                className={`notification-settings-badge ${
+                  quietHoursActive
+                    ? "notification-settings-badge-active"
+                    : "notification-settings-badge-inactive"
+                }`}
+                aria-live="polite"
+              >
+                {quietHoursActive
+                  ? "Quiet hours active now"
+                  : "Quiet hours inactive"}
+              </span>
+            </div>
+            <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <label className="flex flex-col gap-1" htmlFor="quiet-start">
+                <Text role="body" as="span">
+                  Quiet Hours Start
+                </Text>
+                <input
+                  className="notification-settings-field"
+                  type="time"
+                  id="quiet-start"
+                  value={quietStartValue}
+                  aria-invalid={!isValidQuietTime(quietStartValue)}
+                  onChange={(e) => {
+                    updateQuietRange(e.target.value, quietEndValue);
+                  }}
+                />
+              </label>
+              <label className="flex flex-col gap-1" htmlFor="quiet-end">
+                <Text role="body" as="span">
+                  Quiet Hours End
+                </Text>
+                <input
+                  className="notification-settings-field"
+                  type="time"
+                  id="quiet-end"
+                  value={quietEndValue}
+                  aria-invalid={!quietRangeIsValid}
+                  onChange={(e) => {
+                    updateQuietRange(quietStartValue, e.target.value);
+                  }}
+                />
+              </label>
+            </div>
+            {!quietRangeIsValid ? (
+              <p
+                className="mt-2 text-sm notification-settings-error"
+                role="alert"
+              >
+                Quiet hours need a valid start and end time, and they cannot be
+                the same.
+              </p>
+            ) : null}
           </div>
           <div className="flex justify-end items-center mt-5">
             <button
@@ -111,14 +193,21 @@ export default function NotificationSettings() {
         </div>
       </div>
 
-      <div 
+      <div
         className="w-full rounded-md px-3 py-3 mt-5 notification-settings-panel"
-        style={{ zIndex: 'var(--z-index-base)' }}
+        style={{ zIndex: "var(--z-index-base)" }}
       >
-        <Text role="title" as="h2">Vault Notifications</Text>
+        <Text role="title" as="h2">
+          Vault Notifications
+        </Text>
         {vaults.map((v) => (
-          <div className="grid grid-cols-2 justify-center items-center mt-5" key={v.name}>
-            <Text role="body" as="p">{v.name}</Text>
+          <div
+            className="grid grid-cols-2 justify-center items-center mt-5"
+            key={v.name}
+          >
+            <Text role="body" as="p">
+              {v.name}
+            </Text>
             <div className="flex flex-col items-end justify-end gap-4">
               <SettingsToggle label={`${v.name} notifications`} />
             </div>
@@ -199,6 +288,30 @@ export default function NotificationSettings() {
           background: var(--border);
         }
 
+        .notification-settings-badge {
+          display: inline-flex;
+          align-items: center;
+          border-radius: 9999px;
+          border: 1px solid var(--border);
+          padding: var(--spacing-1) var(--spacing-2);
+          font-size: 0.75rem;
+          font-weight: 600;
+        }
+
+        .notification-settings-badge-active {
+          background: var(--accent-transparent);
+          color: var(--accent);
+          border-color: var(--accent);
+        }
+
+        .notification-settings-badge-inactive {
+          background: var(--surface-raised);
+          color: var(--text-muted);
+        }
+
+        .notification-settings-error {
+          color: var(--danger, #dc2626);
+        }
       `}</style>
     </>
   );

--- a/src/pages/__tests__/NotificationSettings.test.tsx
+++ b/src/pages/__tests__/NotificationSettings.test.tsx
@@ -22,7 +22,8 @@ const sourceAssertions: SourceAssertion[] = [
   },
   {
     name: "themes checked toggle tracks with the accent token",
-    pattern: /\.peer:checked \+ \.notification-settings-toggle[\s\S]*background:\s*var\(--accent\)/,
+    pattern:
+      /\.peer:checked \+ \.notification-settings-toggle[\s\S]*background:\s*var\(--accent\)/,
   },
 ];
 
@@ -32,25 +33,29 @@ export function assertNotificationSettingsSource(source: string) {
     .map(({ name }) => name);
 
   if (missing.length > 0) {
-    throw new Error(`NotificationSettings theming assertions failed: ${missing.join(", ")}`);
+    throw new Error(
+      `NotificationSettings theming assertions failed: ${missing.join(", ")}`,
+    );
   }
 }
 
-export const notificationSettingsThemeTestCases = sourceAssertions.map(({ name }) => name);
-
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
-import { render, screen, fireEvent } from '@testing-library/react';
-import NotificationSettings from '../NotificationSettings';
-import { useNotificationPreferences } from '../../Zustand/Store';
-
-const source = readFileSync(
-  resolve(__dirname, '../NotificationSettings.tsx'),
-  'utf8',
+export const notificationSettingsThemeTestCases = sourceAssertions.map(
+  ({ name }) => name,
 );
 
-describe('NotificationSettings theming', () => {
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { render, screen, fireEvent } from "@testing-library/react";
+import NotificationSettings from "../NotificationSettings";
+import { useNotificationPreferences } from "../../Zustand/Store";
+
+const source = readFileSync(
+  resolve(__dirname, "../NotificationSettings.tsx"),
+  "utf8",
+);
+
+describe("NotificationSettings theming", () => {
   notificationSettingsThemeTestCases.forEach((name) => {
     it(name, () => {
       expect(() => assertNotificationSettingsSource(source)).not.toThrow();
@@ -58,120 +63,190 @@ describe('NotificationSettings theming', () => {
   });
 });
 
-describe('NotificationSettings component behavior', () => {
+describe("NotificationSettings component behavior", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 1, 23, 15));
     localStorage.clear();
     useNotificationPreferences.getState().reset();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     localStorage.clear();
   });
 
-  it('renders default notification preferences from store', () => {
+  it("renders default notification preferences from store", () => {
     render(<NotificationSettings />);
 
-    const emailToggle = screen.getByLabelText('Email Notification') as HTMLInputElement;
-    const pushToggle = screen.getByLabelText('Push Notification') as HTMLInputElement;
-    const frequencySelect = screen.getByLabelText('Notification Frequency') as HTMLSelectElement;
-    const quietHoursInput = screen.getByLabelText('Quiet Hours') as HTMLInputElement;
+    const emailToggle = screen.getByLabelText(
+      "Email Notification",
+    ) as HTMLInputElement;
+    const pushToggle = screen.getByLabelText(
+      "Push Notification",
+    ) as HTMLInputElement;
+    const frequencySelect = screen.getByLabelText(
+      "Notification Frequency",
+    ) as HTMLSelectElement;
+    const quietStartInput = screen.getByLabelText(
+      "Quiet Hours Start",
+    ) as HTMLInputElement;
+    const quietEndInput = screen.getByLabelText(
+      "Quiet Hours End",
+    ) as HTMLInputElement;
 
     expect(emailToggle.checked).toBe(true);
     expect(pushToggle.checked).toBe(false);
-    expect(frequencySelect.value).toBe('1');
-    expect(quietHoursInput.value).toBe('12:00');
+    expect(frequencySelect.value).toBe("1");
+    expect(quietStartInput.value).toBe("22:00");
+    expect(quietEndInput.value).toBe("07:00");
+    expect(screen.getByText("Quiet hours active now")).toBeInTheDocument();
   });
 
-  it('updates the store when email notification toggle is clicked', () => {
+  it("updates the store when email notification toggle is clicked", () => {
     render(<NotificationSettings />);
 
-    const emailToggle = screen.getByLabelText('Email Notification');
+    const emailToggle = screen.getByLabelText("Email Notification");
     fireEvent.click(emailToggle);
 
     expect(useNotificationPreferences.getState().email).toBe(false);
     expect(emailToggle).not.toBeChecked();
   });
 
-  it('updates the store when push notification toggle is clicked', () => {
+  it("updates the store when push notification toggle is clicked", () => {
     render(<NotificationSettings />);
 
-    const pushToggle = screen.getByLabelText('Push Notification');
+    const pushToggle = screen.getByLabelText("Push Notification");
     fireEvent.click(pushToggle);
 
     expect(useNotificationPreferences.getState().push).toBe(true);
     expect(pushToggle).toBeChecked();
   });
 
-  it('updates the store when frequency select is changed', () => {
+  it("updates the store when frequency select is changed", () => {
     render(<NotificationSettings />);
 
-    const frequencySelect = screen.getByLabelText('Notification Frequency');
-    fireEvent.change(frequencySelect, { target: { value: '2' } });
+    const frequencySelect = screen.getByLabelText("Notification Frequency");
+    fireEvent.change(frequencySelect, { target: { value: "2" } });
 
-    expect(useNotificationPreferences.getState().frequency).toBe('2');
-    expect(frequencySelect).toHaveValue('2');
+    expect(useNotificationPreferences.getState().frequency).toBe("2");
+    expect(frequencySelect).toHaveValue("2");
   });
 
-  it('updates the store when quiet hours input is changed', () => {
+  it("updates the store when quiet hours range inputs are changed", () => {
     render(<NotificationSettings />);
 
-    const quietHoursInput = screen.getByLabelText('Quiet Hours');
-    fireEvent.change(quietHoursInput, { target: { value: '18:30' } });
+    const quietStartInput = screen.getByLabelText("Quiet Hours Start");
+    const quietEndInput = screen.getByLabelText("Quiet Hours End");
+    fireEvent.change(quietStartInput, { target: { value: "18:30" } });
+    fireEvent.change(quietEndInput, { target: { value: "23:30" } });
 
-    expect(useNotificationPreferences.getState().quietHours).toBe('18:30');
-    expect(quietHoursInput).toHaveValue('18:30');
+    expect(useNotificationPreferences.getState().quietStart).toBe("18:30");
+    expect(useNotificationPreferences.getState().quietEnd).toBe("23:30");
+    expect(useNotificationPreferences.getState().quietHours).toBe("18:30");
+    expect(quietStartInput).toHaveValue("18:30");
+    expect(quietEndInput).toHaveValue("23:30");
   });
 
-  it('reflects values from the store when store values are updated elsewhere (remount / external state update)', () => {
+  it("reflects values from the store when store values are updated elsewhere (remount / external state update)", () => {
     useNotificationPreferences.getState().setEmail(false);
     useNotificationPreferences.getState().setPush(true);
-    useNotificationPreferences.getState().setFrequency('3');
-    useNotificationPreferences.getState().setQuietHours('09:45');
+    useNotificationPreferences.getState().setFrequency("3");
+    useNotificationPreferences.getState().setQuietRange("09:45", "17:30");
 
     render(<NotificationSettings />);
 
-    const emailToggle = screen.getByLabelText('Email Notification') as HTMLInputElement;
-    const pushToggle = screen.getByLabelText('Push Notification') as HTMLInputElement;
-    const frequencySelect = screen.getByLabelText('Notification Frequency') as HTMLSelectElement;
-    const quietHoursInput = screen.getByLabelText('Quiet Hours') as HTMLInputElement;
+    const emailToggle = screen.getByLabelText(
+      "Email Notification",
+    ) as HTMLInputElement;
+    const pushToggle = screen.getByLabelText(
+      "Push Notification",
+    ) as HTMLInputElement;
+    const frequencySelect = screen.getByLabelText(
+      "Notification Frequency",
+    ) as HTMLSelectElement;
+    const quietStartInput = screen.getByLabelText(
+      "Quiet Hours Start",
+    ) as HTMLInputElement;
+    const quietEndInput = screen.getByLabelText(
+      "Quiet Hours End",
+    ) as HTMLInputElement;
 
     expect(emailToggle.checked).toBe(false);
     expect(pushToggle.checked).toBe(true);
-    expect(frequencySelect.value).toBe('3');
-    expect(quietHoursInput.value).toBe('09:45');
+    expect(frequencySelect.value).toBe("3");
+    expect(quietStartInput.value).toBe("09:45");
+    expect(quietEndInput.value).toBe("17:30");
   });
 
-  it('resets all preferences to default values when reset button is clicked', () => {
+  it("resets all preferences to default values when reset button is clicked", () => {
     render(<NotificationSettings />);
 
-    const emailToggle = screen.getByLabelText('Email Notification') as HTMLInputElement;
-    const pushToggle = screen.getByLabelText('Push Notification') as HTMLInputElement;
-    const frequencySelect = screen.getByLabelText('Notification Frequency') as HTMLSelectElement;
-    const quietHoursInput = screen.getByLabelText('Quiet Hours') as HTMLInputElement;
+    const emailToggle = screen.getByLabelText(
+      "Email Notification",
+    ) as HTMLInputElement;
+    const pushToggle = screen.getByLabelText(
+      "Push Notification",
+    ) as HTMLInputElement;
+    const frequencySelect = screen.getByLabelText(
+      "Notification Frequency",
+    ) as HTMLSelectElement;
+    const quietStartInput = screen.getByLabelText(
+      "Quiet Hours Start",
+    ) as HTMLInputElement;
+    const quietEndInput = screen.getByLabelText(
+      "Quiet Hours End",
+    ) as HTMLInputElement;
 
     fireEvent.click(emailToggle);
     fireEvent.click(pushToggle);
-    fireEvent.change(frequencySelect, { target: { value: '4' } });
-    fireEvent.change(quietHoursInput, { target: { value: '23:00' } });
+    fireEvent.change(frequencySelect, { target: { value: "4" } });
+    fireEvent.change(quietStartInput, { target: { value: "23:00" } });
+    fireEvent.change(quietEndInput, { target: { value: "08:00" } });
 
     expect(emailToggle.checked).toBe(false);
     expect(pushToggle.checked).toBe(true);
-    expect(frequencySelect.value).toBe('4');
-    expect(quietHoursInput.value).toBe('23:00');
+    expect(frequencySelect.value).toBe("4");
+    expect(quietStartInput.value).toBe("23:00");
+    expect(quietEndInput.value).toBe("08:00");
 
-    const resetButton = screen.getByRole('button', { name: /Reset Preferences/i });
+    const resetButton = screen.getByRole("button", {
+      name: /Reset Preferences/i,
+    });
     fireEvent.click(resetButton);
 
     expect(emailToggle.checked).toBe(true);
     expect(pushToggle.checked).toBe(false);
-    expect(frequencySelect.value).toBe('1');
-    expect(quietHoursInput.value).toBe('12:00');
+    expect(frequencySelect.value).toBe("1");
+    expect(quietStartInput.value).toBe("22:00");
+    expect(quietEndInput.value).toBe("07:00");
 
     const storeState = useNotificationPreferences.getState();
     expect(storeState.email).toBe(true);
     expect(storeState.push).toBe(false);
-    expect(storeState.frequency).toBe('');
-    expect(storeState.quietHours).toBe('12:00');
+    expect(storeState.frequency).toBe("");
+    expect(storeState.quietHours).toBe("12:00");
+    expect(storeState.quietStart).toBe("22:00");
+    expect(storeState.quietEnd).toBe("07:00");
+  });
+
+  it("shows validation feedback when quiet hours start and end are equal", () => {
+    render(<NotificationSettings />);
+
+    fireEvent.change(screen.getByLabelText("Quiet Hours End"), {
+      target: { value: "22:00" },
+    });
+
+    expect(
+      screen.getByText(/Quiet hours need a valid start and end time/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the inactive badge outside the quiet-hours range", () => {
+    vi.setSystemTime(new Date(2026, 0, 1, 12, 0));
+
+    render(<NotificationSettings />);
+
+    expect(screen.getByText("Quiet hours inactive")).toBeInTheDocument();
   });
 });
-

--- a/src/utils/__tests__/quietHours.test.ts
+++ b/src/utils/__tests__/quietHours.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  isQuietHoursActive,
+  isValidQuietHoursRange,
+  isValidQuietTime,
+} from "../quietHours";
+
+const at = (hours: number, minutes = 0) => new Date(2026, 0, 1, hours, minutes);
+
+describe("quietHours utilities", () => {
+  it("validates HH:MM quiet time strings", () => {
+    expect(isValidQuietTime("00:00")).toBe(true);
+    expect(isValidQuietTime("23:59")).toBe(true);
+    expect(isValidQuietTime("24:00")).toBe(false);
+    expect(isValidQuietTime("9:00")).toBe(false);
+    expect(isValidQuietTime("12:60")).toBe(false);
+  });
+
+  it("rejects equal start and end times", () => {
+    expect(isValidQuietHoursRange("22:00", "07:00")).toBe(true);
+    expect(isValidQuietHoursRange("09:00", "09:00")).toBe(false);
+  });
+
+  it("detects active time inside a same-day window", () => {
+    expect(isQuietHoursActive(at(13), "12:00", "18:00")).toBe(true);
+    expect(isQuietHoursActive(at(18), "12:00", "18:00")).toBe(false);
+    expect(isQuietHoursActive(at(11, 59), "12:00", "18:00")).toBe(false);
+  });
+
+  it("detects active time inside a wrap-around window", () => {
+    expect(isQuietHoursActive(at(23), "22:00", "07:00")).toBe(true);
+    expect(isQuietHoursActive(at(6, 59), "22:00", "07:00")).toBe(true);
+    expect(isQuietHoursActive(at(7), "22:00", "07:00")).toBe(false);
+    expect(isQuietHoursActive(at(12), "22:00", "07:00")).toBe(false);
+  });
+
+  it("returns false for invalid ranges", () => {
+    expect(isQuietHoursActive(at(12), "bad", "07:00")).toBe(false);
+    expect(isQuietHoursActive(at(12), "10:00", "10:00")).toBe(false);
+  });
+});

--- a/src/utils/quietHours.ts
+++ b/src/utils/quietHours.ts
@@ -1,0 +1,44 @@
+const TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+function toMinuteOfDay(value: string): number | null {
+  const match = TIME_PATTERN.exec(value);
+  if (!match) {
+    return null;
+  }
+
+  return Number(match[1]) * 60 + Number(match[2]);
+}
+
+export function isValidQuietTime(value: string): boolean {
+  return toMinuteOfDay(value) !== null;
+}
+
+export function isValidQuietHoursRange(start: string, end: string): boolean {
+  const startMinute = toMinuteOfDay(start);
+  const endMinute = toMinuteOfDay(end);
+
+  return (
+    startMinute !== null && endMinute !== null && startMinute !== endMinute
+  );
+}
+
+export function isQuietHoursActive(
+  now: Date,
+  start: string,
+  end: string,
+): boolean {
+  const startMinute = toMinuteOfDay(start);
+  const endMinute = toMinuteOfDay(end);
+
+  if (startMinute === null || endMinute === null || startMinute === endMinute) {
+    return false;
+  }
+
+  const currentMinute = now.getHours() * 60 + now.getMinutes();
+
+  if (startMinute < endMinute) {
+    return currentMinute >= startMinute && currentMinute < endMinute;
+  }
+
+  return currentMinute >= startMinute || currentMinute < endMinute;
+}


### PR DESCRIPTION
## Summary
- add pure quiet-hours helpers for HH:MM validation, range validation, and wrap-around active-window checks
- extend notification preferences with backward-compatible quietStart/quietEnd state and setQuietRange
- update NotificationSettings with start/end time controls, validation feedback, and a live active/inactive badge
- document quiet-hours persistence and boundary behavior

Closes #456

## Validation
- npx vitest run src/utils/__tests__/quietHours.test.ts src/Zustand/__tests__/notificationPreferences.test.ts src/pages/__tests__/NotificationSettings.test.tsx (27 passed)
- npx prettier --check src/utils/quietHours.ts src/utils/__tests__/quietHours.test.ts src/Zustand/notificationPreferences.ts src/Zustand/__tests__/notificationPreferences.test.ts src/pages/NotificationSettings.tsx src/pages/__tests__/NotificationSettings.test.tsx design-system/documentation/notification-settings.md
- git diff --check

## Known existing blockers
- npm test -- ... runs the repo's coverage script and the selected tests pass, but the command exits non-zero because global coverage thresholds are applied to the whole repository for a partial test run.
- npm run lint is blocked by existing unrelated lint errors across the repo, including design-system/src/__tests__/chart-tokens.test.ts, src/__tests__/App.lazyRoutes.test.tsx, src/components/NavLink.tsx, src/pages/PendingValidations.tsx, and many existing test files.
- npm run build is blocked by existing unrelated syntax errors in src/utils/__tests__/csv.analytics.test.ts and src/utils/__tests__/verifierMetrics.test.ts.