### PR TITLE
Add reusable pagination for notifications

### DIFF
--- a/design-system/documentation/pagination.md
+++ b/design-system/documentation/pagination.md
@@ -1,0 +1,19 @@
+# Pagination
+
+`src/components/Pagination.tsx` is the shared pagination control for list pages.
+It renders from the existing `paginate` utility result so item slicing remains
+owned by `src/utils/paginate.ts`.
+
+## Contract
+
+- Previous and next controls are disabled at the first and last page.
+- Numbered page buttons call `onPageChange(page)`.
+- The active page uses `aria-current="page"`.
+- Every control has an `aria-label`.
+- Empty lists still render as page `1 of 1` with a `0 items` status.
+
+## Notification Page
+
+`src/pages/Notification.tsx` keeps the existing `itemsPerPage = 5` behavior and
+uses `Pagination` for navigation. Filtering, dismissing, and clearing
+notifications continue to reset the current page to `1`.

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,75 @@
+import type { PaginationResult } from "@/utils/paginate";
+
+interface PaginationProps {
+  pagination: PaginationResult<unknown>;
+  onPageChange: (page: number) => void;
+  label?: string;
+}
+
+function buildPages(pageCount: number): number[] {
+  return Array.from({ length: pageCount }, (_, index) => index + 1);
+}
+
+export function Pagination({
+  pagination,
+  onPageChange,
+  label = "Pagination",
+}: PaginationProps) {
+  const { currentPage, pageCount, totalItems } = pagination;
+  const isFirstPage = currentPage <= 1;
+  const isLastPage = currentPage >= pageCount;
+
+  return (
+    <nav
+      aria-label={label}
+      className="flex flex-wrap items-center justify-center gap-3 mt-8"
+    >
+      <button
+        type="button"
+        disabled={isFirstPage}
+        onClick={() => onPageChange(currentPage - 1)}
+        aria-label="Go to previous page"
+        className="px-4 py-2 bg-[#121a2a] rounded disabled:opacity-50 text-white"
+      >
+        Previous
+      </button>
+
+      <ol className="flex flex-wrap items-center justify-center gap-2">
+        {buildPages(pageCount).map((page) => (
+          <li key={page}>
+            <button
+              type="button"
+              onClick={() => onPageChange(page)}
+              aria-label={`Go to page ${page}`}
+              aria-current={page === currentPage ? "page" : undefined}
+              className={`min-w-10 rounded px-3 py-2 ${
+                page === currentPage
+                  ? "bg-[#00c389] text-[#07111f]"
+                  : "bg-[#121a2a] text-white"
+              }`}
+            >
+              {page}
+            </button>
+          </li>
+        ))}
+      </ol>
+
+      <button
+        type="button"
+        disabled={isLastPage}
+        onClick={() => onPageChange(currentPage + 1)}
+        aria-label="Go to next page"
+        className="px-4 py-2 bg-[#00c389] rounded disabled:opacity-50"
+      >
+        Next
+      </button>
+
+      <span className="basis-full text-center text-sm" aria-live="polite">
+        Page {currentPage} of {pageCount}
+        {totalItems === 0 ? " (0 items)" : ""}
+      </span>
+    </nav>
+  );
+}
+
+export default Pagination;

--- a/src/components/__tests__/Pagination.test.tsx
+++ b/src/components/__tests__/Pagination.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Pagination from "../Pagination";
+import { paginate } from "@/utils/paginate";
+
+describe("Pagination", () => {
+  it("renders page controls from paginate results", () => {
+    const onPageChange = vi.fn();
+
+    render(
+      <Pagination
+        pagination={paginate(["a", "b", "c", "d", "e", "f"], 2, 2)}
+        onPageChange={onPageChange}
+      />,
+    );
+
+    expect(
+      screen.getByRole("navigation", { name: "Pagination" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Go to page 2" }),
+    ).toHaveAttribute("aria-current", "page");
+    expect(screen.getByText("Page 2 of 3")).toBeInTheDocument();
+  });
+
+  it("moves to previous, next, and numbered pages", () => {
+    const onPageChange = vi.fn();
+
+    render(
+      <Pagination
+        pagination={paginate(["a", "b", "c", "d", "e", "f"], 2, 2)}
+        onPageChange={onPageChange}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Go to previous page" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Go to next page" }));
+    fireEvent.click(screen.getByRole("button", { name: "Go to page 3" }));
+
+    expect(onPageChange).toHaveBeenNthCalledWith(1, 1);
+    expect(onPageChange).toHaveBeenNthCalledWith(2, 3);
+    expect(onPageChange).toHaveBeenNthCalledWith(3, 3);
+  });
+
+  it("disables previous and next controls on a single page", () => {
+    render(
+      <Pagination pagination={paginate(["a"], 1, 5)} onPageChange={vi.fn()} />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Go to previous page" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Go to next page" }),
+    ).toBeDisabled();
+  });
+
+  it("handles an empty item set", () => {
+    render(
+      <Pagination pagination={paginate([], 1, 5)} onPageChange={vi.fn()} />,
+    );
+
+    expect(screen.getByText("Page 1 of 1 (0 items)")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Go to page 1" }),
+    ).toHaveAttribute("aria-current", "page");
+  });
+
+  it("supports a custom navigation label", () => {
+    render(
+      <Pagination
+        pagination={paginate(["a", "b"], 1, 1)}
+        onPageChange={vi.fn()}
+        label="Notifications pagination"
+      />,
+    );
+
+    expect(
+      screen.getByRole("navigation", { name: "Notifications pagination" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/Notification.tsx
+++ b/src/pages/Notification.tsx
@@ -7,6 +7,8 @@ import { MdOutlineSettingsInputComposite } from "react-icons/md";
 import { Link } from "react-router-dom";
 import { ConfirmationModal } from "@/components/ConfirmationModal";
 import { X } from "lucide-react";
+import Pagination from "@/components/Pagination";
+import { paginate } from "@/utils/paginate";
 
 export default function Notification() {
   const notifications = useNotification((state) => state.notification);
@@ -23,13 +25,12 @@ export default function Notification() {
   const [isPreferenceOpen, setIsPreferenceOpen] = useState(false);
   const [showClearModal, setShowClearModal] = useState(false);
   const itemsPerPage = 5;
-
-  // 1. Calculate the data for the current page
-  const startIndex = (currentPage - 1) * itemsPerPage;
-  const currentData = currentNotification.slice(
-    startIndex,
-    startIndex + itemsPerPage,
+  const paginatedNotifications = paginate(
+    currentNotification,
+    currentPage,
+    itemsPerPage,
   );
+  const currentData = paginatedNotifications.items;
 
   const containerRef = useRef<HTMLDivElement | null>(null); // 1. Create a reference to the container
 
@@ -76,9 +77,6 @@ export default function Notification() {
   useEffect(() => {
     filterNotification();
   }, [currentFilterReadSeletion, currentFilterTypeSeletion, notifications]);
-
-  // 2. Calculate total pages
-  const totalPages = Math.ceil(currentNotification.length / itemsPerPage);
 
   // Reset to page 1 when the underlying notification list changes
   useEffect(() => {
@@ -151,7 +149,7 @@ export default function Notification() {
                   exit={{ opacity: 0, y: -10, scale: 0.95 }}
                   transition={transitionEnter}
                   className="absolute w-[300px] h-[200px] translate-x-[-100%] bg-white text-black px-3 py-2 rounded-md"
-                  style={{ zIndex: 'var(--z-index-drawer)' }}
+                  style={{ zIndex: "var(--z-index-drawer)" }}
                 >
                   <h2>Filter By : </h2>
                   <div className="flex justify-between">
@@ -235,27 +233,11 @@ export default function Notification() {
 
       {/* Pagination Controls */}
       <div className="flex flex-col justify-end">
-        <div className="flex justify-center gap-4 mt-8">
-          <button
-            disabled={currentPage === 1}
-            onClick={() => setCurrentPage((prev) => prev - 1)}
-            className="px-4 py-2 bg-[#121a2a] rounded disabled:opacity-50 text-white"
-          >
-            Previous
-          </button>
-
-          <span className="flex items-center">
-            Page {currentPage} of {totalPages}
-          </span>
-
-          <button
-            disabled={currentPage === totalPages}
-            onClick={() => setCurrentPage((prev) => prev + 1)}
-            className="px-4 py-2 bg-[#00c389] rounded disabled:opacity-50"
-          >
-            Next
-          </button>
-        </div>
+        <Pagination
+          pagination={paginatedNotifications}
+          onPageChange={setCurrentPage}
+          label="Notifications pagination"
+        />
       </div>
 
       <ConfirmationModal

--- a/src/pages/__tests__/Notification.test.tsx
+++ b/src/pages/__tests__/Notification.test.tsx
@@ -15,6 +15,7 @@ vi.mock("framer-motion", () => ({
     ),
   },
   AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  useReducedMotion: vi.fn(() => false),
 }));
 
 vi.mock("focus-trap-react", () => ({
@@ -53,8 +54,12 @@ describe("Notification page", () => {
     renderNotification();
     const totalPages = Math.ceil(initialNotifications.length / 5);
     expect(
-      screen.getByText(`Page 1 of ${totalPages}`),
+      screen.getByRole("navigation", { name: "Notifications pagination" }),
     ).toBeInTheDocument();
+    expect(screen.getByText(`Page 1 of ${totalPages}`)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Go to page 1" }),
+    ).toHaveAttribute("aria-current", "page");
   });
 
   it("navigates to the next page", () => {
@@ -62,9 +67,7 @@ describe("Notification page", () => {
     const nextButton = screen.getByText("Next");
     fireEvent.click(nextButton);
     const totalPages = Math.ceil(initialNotifications.length / 5);
-    expect(
-      screen.getByText(`Page 2 of ${totalPages}`),
-    ).toBeInTheDocument();
+    expect(screen.getByText(`Page 2 of ${totalPages}`)).toBeInTheDocument();
   });
 
   it("disables previous button on first page", () => {
@@ -129,9 +132,7 @@ describe("Notification page", () => {
     const nextButton = screen.getByText("Next");
     fireEvent.click(nextButton);
     const totalPages = Math.ceil(initialNotifications.length / 5);
-    expect(
-      screen.getByText(`Page 2 of ${totalPages}`),
-    ).toBeInTheDocument();
+    expect(screen.getByText(`Page 2 of ${totalPages}`)).toBeInTheDocument();
 
     const filterButton = screen.getByText("Filter");
     fireEvent.click(filterButton);
@@ -149,9 +150,7 @@ describe("Notification page", () => {
     const nextButton = screen.getByText("Next");
     fireEvent.click(nextButton);
     const totalPages = Math.ceil(initialNotifications.length / 5);
-    expect(
-      screen.getByText(`Page 2 of ${totalPages}`),
-    ).toBeInTheDocument();
+    expect(screen.getByText(`Page 2 of ${totalPages}`)).toBeInTheDocument();
 
     const filterButton = screen.getByText("Filter");
     fireEvent.click(filterButton);
@@ -185,9 +184,7 @@ describe("Notification page", () => {
     renderNotification();
     const clearButton = screen.getByText("Clear all");
     fireEvent.click(clearButton);
-    expect(
-      screen.getByText("Clear all notifications"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Clear all notifications")).toBeInTheDocument();
     expect(
       screen.getByText(
         `Are you sure you want to clear all ${initialNotifications.length} notifications? This action cannot be undone.`,
@@ -245,5 +242,20 @@ describe("Notification page", () => {
 
     // Should reset to page 1
     expect(screen.getByText(/Page 1 of 1/)).toBeInTheDocument();
+  });
+
+  it("navigates with numbered page buttons", () => {
+    renderNotification();
+    const totalPages = Math.ceil(initialNotifications.length / 5);
+    if (totalPages < 2) {
+      return;
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: "Go to page 2" }));
+
+    expect(screen.getByText(`Page 2 of ${totalPages}`)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Go to page 2" }),
+    ).toHaveAttribute("aria-current", "page");
   });
 });


### PR DESCRIPTION
## Summary
- add a shared Pagination component powered by the existing paginate utility
- adopt the reusable control on the Notification page while keeping itemsPerPage = 5
- cover the new component and Notification numbered-page navigation with tests
- document the Pagination contract in the design-system docs

Closes #455

## Tests
- npx vitest run src/components/__tests__/Pagination.test.tsx src/pages/__tests__/Notification.test.tsx
- npx prettier --check src/components/Pagination.tsx src/components/__tests__/Pagination.test.tsx src/pages/Notification.tsx src/pages/__tests__/Notification.test.tsx design-system/documentation/pagination.md
- git diff --check

## Known repo-level blockers
- npm run lint currently fails on existing unrelated lint/parsing errors across the repo, including src/utils/__tests__/csv.analytics.test.ts and src/utils/__tests__/verifierMetrics.test.ts.
- npm run build currently fails before this change due the same existing test-file syntax errors: src/utils/__tests__/csv.analytics.test.ts(82,37) and src/utils/__tests__/verifierMetrics.test.ts(351,1).