### PR TITLE
Add duplicate vault prefill flow

### DIFF
--- a/design-system/documentation/vault-duplicate.md
+++ b/design-system/documentation/vault-duplicate.md
@@ -1,0 +1,37 @@
+# Vault Duplicate Prefill
+
+The duplicate-vault action lets creators start a new vault from an existing
+vault without copying fields manually.
+
+## Entry Points
+
+- `VaultDetail` exposes a `Duplicate Vault` action in the header actions.
+- `Vaults` exposes a `Duplicate` action for each vault row.
+
+Both actions navigate to `/vaults/create` with React Router location state under
+`createVaultPrefill`.
+
+## Prefilled Fields
+
+The prefill state carries:
+
+- source vault id and name for user-facing context
+- amount
+- success destination address
+- failure destination address
+- milestone title and criteria metadata for the creation flow to consume as the
+  form grows
+
+The current `CreateVault` form seeds the fields it owns today: amount, success
+destination, and failure destination.
+
+## Deadline Handling
+
+Deadline is intentionally never copied. A duplicated vault is a new contract, so
+the creator must choose a fresh deadline before validation can pass.
+
+## Validation
+
+Prefill does not bypass `validateCreateVault`. Invalid copied values remain in
+the fields so the creator can edit them, and the existing inline validation
+surfaces errors on submit.

--- a/src/pages/CreateVault.tsx
+++ b/src/pages/CreateVault.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { Text } from "../components/Text";
 import { Field } from "../components/Field";
 import type { CreateVaultErrors } from "../utils/vaultValidation";
@@ -12,18 +13,29 @@ import { CreateVaultReview } from "../components/CreateVaultReview";
 import { formatUsdcInput, parseUsdcInput } from "../utils/usdcInput";
 import { logger } from "../utils/logger";
 import { useWallet } from "../context/WalletContext";
-import { DEADLINE_PRESETS, computeFutureDeadline, getPresetLabel } from "../utils/deadlinePresets";
+import {
+  DEADLINE_PRESETS,
+  computeFutureDeadline,
+  getPresetLabel,
+} from "../utils/deadlinePresets";
+import { getCreateVaultPrefill } from "../utils/vaultPrefill";
 
 export default function CreateVault() {
+  const location = useLocation();
+  const prefill = getCreateVaultPrefill(location.state);
   const { balance, balanceStatus } = useWallet();
   const amountRef = useRef<HTMLInputElement>(null);
   const deadlineRef = useRef<HTMLInputElement>(null);
   const successAddressRef = useRef<HTMLInputElement>(null);
   const failureAddressRef = useRef<HTMLInputElement>(null);
-  const [amount, setAmount] = useState("");
+  const [amount, setAmount] = useState(prefill?.amount ?? "");
   const [deadline, setDeadline] = useState("");
-  const [successAddress, setSuccessAddress] = useState("");
-  const [failureAddress, setFailureAddress] = useState("");
+  const [successAddress, setSuccessAddress] = useState(
+    prefill?.successAddress ?? "",
+  );
+  const [failureAddress, setFailureAddress] = useState(
+    prefill?.failureAddress ?? "",
+  );
   const [errors, setErrors] = useState<CreateVaultErrors>({});
   const [evidenceUrl, setEvidenceUrl] = useState<string | undefined>();
   const [showReview, setShowReview] = useState(false);
@@ -57,7 +69,9 @@ export default function CreateVault() {
     setErrors(nextErrors);
 
     if (hasCreateVaultErrors(nextErrors)) {
-      const firstInvalidField = errorFieldOrder.find((field) => nextErrors[field]);
+      const firstInvalidField = errorFieldOrder.find(
+        (field) => nextErrors[field],
+      );
       if (firstInvalidField) {
         fieldRefs[firstInvalidField].current?.focus();
       }
@@ -114,7 +128,8 @@ export default function CreateVault() {
                 border: "1px solid var(--danger)",
                 borderRadius: "var(--radius)",
                 padding: "0.75rem",
-                background: "color-mix(in srgb, var(--danger) 10%, var(--surface))",
+                background:
+                  "color-mix(in srgb, var(--danger) 10%, var(--surface))",
                 marginBottom: "1rem",
                 maxWidth: 400,
               }}
@@ -126,11 +141,37 @@ export default function CreateVault() {
               >
                 Please fix the highlighted fields before creating the vault.
               </Text>
-              <ul style={{ margin: 0, paddingLeft: "1.25rem", color: "var(--danger)" }}>
+              <ul
+                style={{
+                  margin: 0,
+                  paddingLeft: "1.25rem",
+                  color: "var(--danger)",
+                }}
+              >
                 {errorEntries.map(({ field, message }, index) => (
                   <li key={`${field}-${index}`}>{message}</li>
                 ))}
               </ul>
+            </div>
+          )}
+
+          {prefill && (
+            <div
+              role="status"
+              style={{
+                border: "1px solid var(--border)",
+                borderRadius: "var(--radius)",
+                padding: "0.75rem",
+                background: "var(--surface)",
+                marginBottom: "1rem",
+                maxWidth: 400,
+              }}
+            >
+              <Text role="caption" as="p" style={{ margin: 0 }}>
+                Duplicating {prefill.sourceVaultName ?? "an existing vault"}.
+                Amount and destination addresses are prefilled; choose a fresh
+                deadline for this new vault.
+              </Text>
             </div>
           )}
 
@@ -162,7 +203,11 @@ export default function CreateVault() {
             {balanceStatus === "success" && exceedsBalance(amount, balance) && (
               <p
                 role="status"
-                style={{ color: "var(--warning)", margin: 0, fontSize: "0.875rem" }}
+                style={{
+                  color: "var(--warning)",
+                  margin: 0,
+                  fontSize: "0.875rem",
+                }}
               >
                 Amount exceeds your available USDC balance ({balance}).
               </p>
@@ -175,7 +220,10 @@ export default function CreateVault() {
                   onClick={() => {
                     const days = parseInt(preset, 10);
                     setDeadline(computeFutureDeadline(days));
-                    setErrors((current) => ({ ...current, deadline: undefined }));
+                    setErrors((current) => ({
+                      ...current,
+                      deadline: undefined,
+                    }));
                   }}
                   style={{
                     padding: "0.4rem 0.875rem",

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -11,17 +11,13 @@ import { Text } from "../components/Text";
 import { VaultMetaPanel } from "../components/VaultMetaPanel";
 import { useWallet } from "../context/WalletContext";
 import { contractExplorerUrl, networkLabel } from "../utils/explorer";
-import type { VaultStatus, MilestoneStatus, TxType, Vault, Milestone, VaultTransaction } from "../types/vault";
+import type { VaultStatus, Vault } from "../types/vault";
 import { getVault } from "../services/vaultService";
+import { createVaultPrefillFromVault } from "../utils/vaultPrefill";
 
 // ── Types imported from canonical source ─────────────────────────────────────
-// Milestone, VaultTransaction, Vault, VaultStatus, MilestoneStatus, TxType
-// are all imported from "../types/vault" above.
+// Vault and VaultStatus are imported from "../types/vault" above.
 // MOCK_VAULTS has moved to "../services/vaultService" as the master dataset.
-
-// Suppress unused-import warnings for type-only imports used in JSX props
-type _Milestone = Milestone;
-type _VaultTransaction = VaultTransaction;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 const STATUS_CONFIG: Record<
@@ -274,19 +270,33 @@ export default function VaultDetail() {
           </div>
 
           {/* Quick Actions */}
-          {isActive && (
-            <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
-              {vault.status === "pending_validation" && (
-                <button style={actionBtn("var(--accent)")}>
-                  Validate Milestone
+          <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+            <Link
+              to="/vaults/create"
+              state={createVaultPrefillFromVault(vault)}
+              style={{
+                ...actionBtn("var(--accent)"),
+                textDecoration: "none",
+                display: "inline-flex",
+                alignItems: "center",
+              }}
+            >
+              Duplicate Vault
+            </Link>
+            {isActive && (
+              <>
+                {vault.status === "pending_validation" && (
+                  <button style={actionBtn("var(--accent)")}>
+                    Validate Milestone
+                  </button>
+                )}
+                <button style={actionBtn("var(--warning)")}>
+                  Extend Deadline
                 </button>
-              )}
-              <button style={actionBtn("var(--warning)")}>
-                Extend Deadline
-              </button>
-              <button style={actionBtn("var(--danger)")}>Cancel Vault</button>
-            </div>
-          )}
+                <button style={actionBtn("var(--danger)")}>Cancel Vault</button>
+              </>
+            )}
+          </div>
         </div>
       </Card>
 

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -1,16 +1,15 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
-import { Link, MemoryRouter } from 'react-router-dom'
-import { Text } from '../components/Text'
-import { StatusChip } from '../components/StatusChip'
-import type { VaultStatus, Vault } from '../types/vault'
-import { listVaults } from '../services/vaultService'
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Link, MemoryRouter } from "react-router-dom";
+import { Text } from "../components/Text";
+import { StatusChip } from "../components/StatusChip";
+import type { Vault } from "../types/vault";
+import { listVaults } from "../services/vaultService";
+import { createVaultPrefillFromVault } from "../utils/vaultPrefill";
 
-// VaultStatus is imported from '../types/vault' for use in the JSX below.
 // The Vault type is imported from '../types/vault' via vaultService.
 // Local MOCK_VAULTS removed — listVaults() in vaultService is the single source.
-type _VaultStatus = VaultStatus; // suppress unused-import lint
 
-const DEFAULT_FETCH = () => listVaults()
+const DEFAULT_FETCH = () => listVaults();
 
 function Skeleton() {
   return (
@@ -18,119 +17,196 @@ function Skeleton() {
       data-testid="skeleton"
       style={{
         height: 72,
-        background: 'var(--surface, #1e293b)',
-        border: '1px solid var(--border, #334155)',
-        borderRadius: 'var(--radius, 8px)',
-        animation: 'pulse 1.5s ease-in-out infinite',
+        background: "var(--surface, #1e293b)",
+        border: "1px solid var(--border, #334155)",
+        borderRadius: "var(--radius, 8px)",
+        animation: "pulse 1.5s ease-in-out infinite",
       }}
     />
-  )
+  );
 }
 
 interface VaultsInnerProps {
-  fetchVaults?: () => Promise<Vault[]>
+  fetchVaults?: () => Promise<Vault[]>;
 }
 
-function VaultsInner({ fetchVaults = DEFAULT_FETCH }: VaultsInnerProps) {
-  const [vaults, setVaults] = useState<Vault[]>([])
-  const [status, setStatus] = useState<'loading' | 'empty' | 'data' | 'error'>('loading')
-  const [retryCount, setRetryCount] = useState(0)
+export function VaultsInner({ fetchVaults = DEFAULT_FETCH }: VaultsInnerProps) {
+  const [vaults, setVaults] = useState<Vault[]>([]);
+  const [status, setStatus] = useState<"loading" | "empty" | "data" | "error">(
+    "loading",
+  );
+  const [retryCount, setRetryCount] = useState(0);
   // Use a ref so changing the fetchVaults prop identity doesn't re-trigger the effect
-  const fetchRef = useRef(fetchVaults)
-  fetchRef.current = fetchVaults
+  const fetchRef = useRef(fetchVaults);
+  fetchRef.current = fetchVaults;
 
   useEffect(() => {
-    let cancelled = false
-    setStatus('loading')
-    fetchRef.current()
+    let cancelled = false;
+    setStatus("loading");
+    fetchRef
+      .current()
       .then((data) => {
-        if (cancelled) return
-        setVaults(data)
-        setStatus(data.length === 0 ? 'empty' : 'data')
+        if (cancelled) return;
+        setVaults(data);
+        setStatus(data.length === 0 ? "empty" : "data");
       })
       .catch(() => {
-        if (!cancelled) setStatus('error')
-      })
-    return () => { cancelled = true }
-  }, [retryCount])  // only re-run on explicit retry
+        if (!cancelled) setStatus("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [retryCount]); // only re-run on explicit retry
 
-  const retry = useCallback(() => setRetryCount((c) => c + 1), [])
+  const retry = useCallback(() => setRetryCount((c) => c + 1), []);
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2rem', flexWrap: 'wrap', gap: '1rem' }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "2rem",
+          flexWrap: "wrap",
+          gap: "1rem",
+        }}
+      >
         <div>
-          <Text role="display" as="h1" style={{ marginBottom: '0.25rem' }}>Your Vaults</Text>
-          <Text role="body" as="p" style={{ color: 'var(--muted)', margin: 0 }}>
+          <Text role="display" as="h1" style={{ marginBottom: "0.25rem" }}>
+            Your Vaults
+          </Text>
+          <Text role="body" as="p" style={{ color: "var(--muted)", margin: 0 }}>
             View and manage your productivity vaults.
           </Text>
         </div>
         <Link
           to="/vaults/create"
           style={{
-            background: 'var(--accent)', color: 'var(--bg)',
-            padding: '0.6rem 1.25rem', borderRadius: 'var(--radius)',
-            fontWeight: 600, fontSize: 14, textDecoration: 'none',
-            display: 'inline-block',
+            background: "var(--accent)",
+            color: "var(--bg)",
+            padding: "0.6rem 1.25rem",
+            borderRadius: "var(--radius)",
+            fontWeight: 600,
+            fontSize: 14,
+            textDecoration: "none",
+            display: "inline-block",
           }}
         >
           + Create Vault
         </Link>
       </div>
 
-      {status === 'loading' && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-          <Skeleton /><Skeleton /><Skeleton />
+      {status === "loading" && (
+        <div
+          style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}
+        >
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
         </div>
       )}
 
-      {status === 'empty' && (
-        <div style={{ textAlign: 'center', padding: '3rem 1rem' }}>
-          <Text role="body" as="p">You don’t have any vaults yet.</Text>
+      {status === "empty" && (
+        <div style={{ textAlign: "center", padding: "3rem 1rem" }}>
+          <Text role="body" as="p">
+            You don’t have any vaults yet.
+          </Text>
           <Link to="/vaults/create">Create your first vault</Link>
         </div>
       )}
 
-      {status === 'error' && (
-        <div style={{ textAlign: 'center', padding: '3rem 1rem' }}>
-          <Text role="body" as="p">Failed to load vaults.</Text>
+      {status === "error" && (
+        <div style={{ textAlign: "center", padding: "3rem 1rem" }}>
+          <Text role="body" as="p">
+            Failed to load vaults.
+          </Text>
           <button onClick={retry}>Retry</button>
         </div>
       )}
 
-      {status === 'data' && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+      {status === "data" && (
+        <div
+          style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}
+        >
           {vaults.map((vault) => (
-            <Link
+            <div
               key={vault.id}
-              to={`/vaults/${vault.id}`}
-              style={{ textDecoration: 'none', color: 'inherit' }}
+              style={{
+                background: "var(--surface)",
+                border: "1px solid var(--border)",
+                borderRadius: "var(--radius)",
+                padding: "1rem 1.25rem",
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                flexWrap: "wrap",
+                gap: "0.75rem",
+              }}
             >
-              <div style={{
-                background: 'var(--surface)', border: '1px solid var(--border)',
-                borderRadius: 'var(--radius)', padding: '1rem 1.25rem',
-                display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                flexWrap: 'wrap', gap: '0.75rem',
-              }}>
-                <div>
-                  <Text role="body" as="div" style={{ fontWeight: 600, marginBottom: 4 }}>{vault.name}</Text>
-                  <Text role="caption" as="div" style={{ color: 'var(--muted)' }}>
-                    Deadline: {new Date(vault.deadline).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                  </Text>
-                </div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-                  <Text role="body" as="span" style={{ fontWeight: 700, color: 'var(--accent)' }}>
-                    {vault.amount.toLocaleString()} {vault.currency}
-                  </Text>
-                  <StatusChip status={vault.status} />
-                </div>
+              <div>
+                <Text
+                  role="body"
+                  as="div"
+                  style={{ fontWeight: 600, marginBottom: 4 }}
+                >
+                  {vault.name}
+                </Text>
+                <Text role="caption" as="div" style={{ color: "var(--muted)" }}>
+                  Deadline:{" "}
+                  {new Date(vault.deadline).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </Text>
               </div>
-            </Link>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "1rem",
+                  flexWrap: "wrap",
+                }}
+              >
+                <Text
+                  role="body"
+                  as="span"
+                  style={{ fontWeight: 700, color: "var(--accent)" }}
+                >
+                  {vault.amount.toLocaleString()} {vault.currency}
+                </Text>
+                <StatusChip status={vault.status} />
+                <Link
+                  to={`/vaults/${vault.id}`}
+                  style={{
+                    color: "var(--accent)",
+                    fontSize: 14,
+                    fontWeight: 600,
+                    textDecoration: "none",
+                  }}
+                >
+                  View Details
+                </Link>
+                <Link
+                  to="/vaults/create"
+                  state={createVaultPrefillFromVault(vault)}
+                  style={{
+                    color: "var(--accent)",
+                    fontSize: 14,
+                    fontWeight: 600,
+                    textDecoration: "none",
+                  }}
+                >
+                  Duplicate
+                </Link>
+              </div>
+            </div>
           ))}
         </div>
       )}
     </div>
-  )
+  );
 }
 
 // Default export wraps with MemoryRouter for standalone usage;
@@ -142,5 +218,5 @@ export default function Vaults({ fetchVaults }: VaultsInnerProps = {}) {
     <MemoryRouter>
       <VaultsInner fetchVaults={fetchVaults} />
     </MemoryRouter>
-  )
+  );
 }

--- a/src/pages/__tests__/CreateVault.test.tsx
+++ b/src/pages/__tests__/CreateVault.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import CreateVault from "../CreateVault";
 
@@ -16,6 +17,21 @@ function fillField(label: RegExp, value: string) {
   fireEvent.change(screen.getByLabelText(label), { target: { value } });
 }
 
+function renderCreateVault(state?: unknown) {
+  return render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: "/vaults/create",
+          state,
+        },
+      ]}
+    >
+      <CreateVault />
+    </MemoryRouter>,
+  );
+}
+
 describe("CreateVault", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -29,7 +45,7 @@ describe("CreateVault", () => {
     const consoleDebug = vi
       .spyOn(console, "debug")
       .mockImplementation(() => undefined);
-    render(<CreateVault />);
+    renderCreateVault();
 
     fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
 
@@ -75,7 +91,7 @@ describe("CreateVault", () => {
   });
 
   it("rejects identical destination addresses", () => {
-    render(<CreateVault />);
+    renderCreateVault();
 
     fillField(/amount/i, "100");
     fillField(/deadline/i, "2030-01-01T00:00");
@@ -98,7 +114,7 @@ describe("CreateVault", () => {
     const consoleDebug = vi
       .spyOn(console, "debug")
       .mockImplementation(() => undefined);
-    render(<CreateVault />);
+    renderCreateVault();
 
     fillField(/amount/i, "100.1234567");
     fillField(/deadline/i, "2030-01-01T00:00");
@@ -126,7 +142,7 @@ describe("CreateVault", () => {
   });
 
   it("returns to edit mode without losing entered values", () => {
-    render(<CreateVault />);
+    renderCreateVault();
 
     fillField(/amount/i, "55");
     fillField(/deadline/i, "2030-02-02T00:00");
@@ -146,8 +162,65 @@ describe("CreateVault", () => {
     );
   });
 
+  it("keeps the blank form unchanged when no duplicate prefill is present", () => {
+    renderCreateVault();
+
+    expect(screen.getByLabelText(/amount/i)).toHaveValue("");
+    expect(screen.getByLabelText(/deadline/i)).toHaveValue("");
+    expect(screen.getByLabelText(/success destination/i)).toHaveValue("");
+    expect(screen.getByLabelText(/failure destination/i)).toHaveValue("");
+    expect(screen.queryByText(/duplicating/i)).not.toBeInTheDocument();
+  });
+
+  it("prefills duplicated vault amount and destinations while clearing deadline", () => {
+    renderCreateVault({
+      createVaultPrefill: {
+        sourceVaultName: "Alpha Vault",
+        amount: "12500",
+        successAddress,
+        failureAddress,
+        milestones: [{ title: "Phase 1", criteria: "Ship it" }],
+      },
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /duplicating alpha vault/i,
+    );
+    expect(screen.getByLabelText(/amount/i)).toHaveValue("12,500");
+    expect(screen.getByLabelText(/deadline/i)).toHaveValue("");
+    expect(screen.getByLabelText(/success destination/i)).toHaveValue(
+      successAddress,
+    );
+    expect(screen.getByLabelText(/failure destination/i)).toHaveValue(
+      failureAddress,
+    );
+  });
+
+  it("surfaces validation errors for invalid duplicated values", () => {
+    renderCreateVault({
+      createVaultPrefill: {
+        sourceVaultName: "Broken Vault",
+        amount: "0",
+        successAddress: "not-a-stellar-address",
+        failureAddress: failureAddress,
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
+
+    expect(
+      screen.getAllByText(
+        "Enter a positive USDC amount with up to 7 decimal places.",
+      ),
+    ).toHaveLength(2);
+    expect(screen.getAllByText("Choose a future deadline.")).toHaveLength(2);
+    expect(
+      screen.getAllByText("Enter a valid Stellar public key starting with G."),
+    ).toHaveLength(2);
+  });
+
   it("formats amount with thousands grouping while typing", () => {
-    render(<CreateVault />);
+    renderCreateVault();
     const input = screen.getByLabelText(/amount/i);
 
     fireEvent.change(input, { target: { value: "1234" } });
@@ -161,7 +234,7 @@ describe("CreateVault", () => {
   });
 
   it("caps decimal places at 7 while typing", () => {
-    render(<CreateVault />);
+    renderCreateVault();
     const input = screen.getByLabelText(/amount/i);
 
     fireEvent.change(input, { target: { value: "1.123456789" } });
@@ -169,7 +242,7 @@ describe("CreateVault", () => {
   });
 
   it("strips non-numeric paste content", () => {
-    render(<CreateVault />);
+    renderCreateVault();
     const input = screen.getByLabelText(/amount/i);
 
     fireEvent.change(input, { target: { value: "abc1.5def" } });
@@ -177,7 +250,7 @@ describe("CreateVault", () => {
   });
 
   it("normalises leading zeros", () => {
-    render(<CreateVault />);
+    renderCreateVault();
     const input = screen.getByLabelText(/amount/i);
 
     fireEvent.change(input, { target: { value: "001" } });
@@ -185,7 +258,7 @@ describe("CreateVault", () => {
   });
 
   it("handles empty input gracefully", () => {
-    render(<CreateVault />);
+    renderCreateVault();
     const input = screen.getByLabelText(/amount/i);
 
     fireEvent.change(input, { target: { value: "" } });
@@ -196,7 +269,7 @@ describe("CreateVault", () => {
     const consoleDebug = vi
       .spyOn(console, "debug")
       .mockImplementation(() => undefined);
-    render(<CreateVault />);
+    renderCreateVault();
 
     fireEvent.change(screen.getByLabelText(/amount/i), {
       target: { value: "1234.5678" },
@@ -225,7 +298,7 @@ describe("CreateVault", () => {
       balance: "50",
       balanceStatus: "success",
     } as ReturnType<typeof useWallet>);
-    render(<CreateVault />);
+    renderCreateVault();
 
     fireEvent.change(screen.getByLabelText(/amount/i), {
       target: { value: "100" },
@@ -241,7 +314,7 @@ describe("CreateVault", () => {
       balance: "100",
       balanceStatus: "success",
     } as ReturnType<typeof useWallet>);
-    render(<CreateVault />);
+    renderCreateVault();
 
     fireEvent.change(screen.getByLabelText(/amount/i), {
       target: { value: "100" },
@@ -254,7 +327,7 @@ describe("CreateVault", () => {
   /*  Deadline preset buttons                                            */
   /* ------------------------------------------------------------------ */
   it("renders deadline preset buttons", () => {
-    render(<CreateVault />);
+    renderCreateVault();
 
     expect(screen.getByRole("button", { name: "7 days" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "30 days" })).toBeInTheDocument();
@@ -262,7 +335,7 @@ describe("CreateVault", () => {
   });
 
   it("preset buttons populate deadline field with future timestamp", () => {
-    render(<CreateVault />);
+    renderCreateVault();
 
     const now = new Date();
     fireEvent.click(screen.getByRole("button", { name: "7 days" }));
@@ -276,23 +349,23 @@ describe("CreateVault", () => {
   });
 
   it("selecting preset clears deadline error", () => {
-    const consoleDebug = vi
-      .spyOn(console, "debug")
-      .mockImplementation(() => undefined);
-    render(<CreateVault />);
+    vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    renderCreateVault();
 
     fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
-    expect(screen.getByText("Choose a future deadline.")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Choose a future deadline.").length,
+    ).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole("button", { name: "30 days" }));
-    expect(screen.queryByText("Choose a future deadline.")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Choose a future deadline."),
+    ).not.toBeInTheDocument();
   });
 
   it("computed deadline satisfies isFutureDeadline validation", () => {
-    const consoleDebug = vi
-      .spyOn(console, "debug")
-      .mockImplementation(() => undefined);
-    render(<CreateVault />);
+    vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    renderCreateVault();
 
     fillField(/amount/i, "100");
     fillField(/success destination/i, successAddress);
@@ -301,6 +374,8 @@ describe("CreateVault", () => {
     fireEvent.click(screen.getByRole("button", { name: "90 days" }));
     fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
 
-    expect(screen.queryByText("Choose a future deadline.")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Choose a future deadline."),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/pages/__tests__/VaultDetail.test.tsx
+++ b/src/pages/__tests__/VaultDetail.test.tsx
@@ -1,11 +1,24 @@
-import { render, screen, within } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
-import VaultDetail from '../VaultDetail';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MASTER_VAULTS } from "../../fixtures/vaults";
+import VaultDetail from "../VaultDetail";
 
-vi.mock('../../context/WalletContext', () => ({
-  useWallet: () => ({ network: 'TESTNET' }),
+vi.mock("../../context/WalletContext", () => ({
+  useWallet: () => ({ network: "TESTNET" }),
 }));
+
+const ORIGINAL_VAULT_1_CONTRACT = MASTER_VAULTS["1"].contractAddress;
+
+afterEach(() => {
+  MASTER_VAULTS["1"].contractAddress = ORIGINAL_VAULT_1_CONTRACT;
+});
 
 function renderVaultDetail(id: string) {
   return render(
@@ -17,169 +30,250 @@ function renderVaultDetail(id: string) {
   );
 }
 
-describe('VaultDetail', () => {
-  it('renders active vault status, milestones, transactions, addresses, and deadline', () => {
-    renderVaultDetail('1');
+function CreateVaultStateProbe() {
+  const location = useLocation();
+  return (
+    <pre data-testid="create-vault-state">
+      {JSON.stringify(location.state ?? {})}
+    </pre>
+  );
+}
 
-    expect(screen.getByRole('heading', { name: 'Alpha Vault' })).toBeInTheDocument();
-    expect(screen.getByText('Active')).toBeInTheDocument();
-    expect(screen.getByText('12,500')).toBeInTheDocument();
-    expect(screen.getAllByText('USDC').length).toBeGreaterThan(0);
+describe("VaultDetail", () => {
+  it("renders active vault status, milestones, transactions, addresses, and deadline", async () => {
+    renderVaultDetail("1");
 
-    expect(screen.getByText('Status Timeline')).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Alpha Vault" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("12,500")).toBeInTheDocument();
+    expect(screen.getAllByText("USDC").length).toBeGreaterThan(0);
+
+    expect(screen.getByText("Status Timeline")).toBeInTheDocument();
     expect(screen.getByText(/Deadline Jul 15, 2024/)).toBeInTheDocument();
     // CountdownDeadline active vault should show time remaining or expired
     expect(screen.getByText(/Overdue|remaining/)).toBeInTheDocument();
 
-    const addresses = screen.getByText('Addresses').closest('div')?.parentElement;
+    const addresses = screen
+      .getByText("Addresses")
+      .closest("div")?.parentElement;
     expect(addresses).toBeInTheDocument();
-    expect(within(addresses!).getByText('Creator')).toBeInTheDocument();
-    expect(within(addresses!).getByText('Verifier')).toBeInTheDocument();
-    expect(within(addresses!).getByText('Success destination')).toBeInTheDocument();
-    expect(within(addresses!).getByText('Failure destination')).toBeInTheDocument();
-    expect(within(addresses!).getByText('Contract')).toBeInTheDocument();
-    expect(within(addresses!).getByText('GBVZ3K...QK7L')).toBeInTheDocument();
+    expect(within(addresses!).getByText("Creator")).toBeInTheDocument();
+    expect(within(addresses!).getByText("Verifier")).toBeInTheDocument();
+    expect(
+      within(addresses!).getByText("Success destination"),
+    ).toBeInTheDocument();
+    expect(
+      within(addresses!).getByText("Failure destination"),
+    ).toBeInTheDocument();
+    expect(within(addresses!).getByText("Contract")).toBeInTheDocument();
+    expect(within(addresses!).getByText("GBVZ3K...QK7L")).toBeInTheDocument();
 
-    expect(screen.getByText('Phase 1 Complete')).toBeInTheDocument();
-    expect(screen.getByText('Complete initial development phase')).toBeInTheDocument();
-    expect(screen.getByText(/All unit tests passing, code reviewed/)).toBeInTheDocument();
-    expect(screen.getByText('Validated')).toBeInTheDocument();
-    expect(screen.getByText('Beta Launch')).toBeInTheDocument();
-    expect(screen.getByText('Pending')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /View evidence/i })).toHaveAttribute(
-      'href',
-      'https://github.com/org/repo/pull/42',
-    );
+    expect(screen.getByText("Phase 1 Complete")).toBeInTheDocument();
+    expect(
+      screen.getByText("Complete initial development phase"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/All unit tests passing, code reviewed/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Validated")).toBeInTheDocument();
+    expect(screen.getByText("Beta Launch")).toBeInTheDocument();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /View evidence/i }),
+    ).toHaveAttribute("href", "https://github.com/org/repo/pull/42");
 
-    expect(screen.getByText('Transaction History')).toBeInTheDocument();
-    expect(screen.getByText('Vault Created')).toBeInTheDocument();
-    expect(screen.getByText('Milestone Validated')).toBeInTheDocument();
-    expect(screen.getAllByText('a3f9d1c8...8f0a4d').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('b4e0c2d9...9a5e8b').length).toBeGreaterThan(0);
+    expect(screen.getByText("Transaction History")).toBeInTheDocument();
+    expect(screen.getByText("Vault Created")).toBeInTheDocument();
+    expect(screen.getByText("Milestone Validated")).toBeInTheDocument();
+    expect(screen.getAllByText("a3f9d1c8...8f0a4d").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("b4e0c2d9...9a5e8b").length).toBeGreaterThan(0);
   });
 
-  it('renders completed vault release details without a verifier address', () => {
-    renderVaultDetail('2');
+  it("renders completed vault release details without a verifier address", async () => {
+    renderVaultDetail("2");
 
-    expect(screen.getByRole('heading', { name: 'Beta Reserve' })).toBeInTheDocument();
-    expect(screen.getAllByText('Completed').length).toBeGreaterThan(0);
-    expect(screen.queryByText('Verifier')).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Beta Reserve" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Completed").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Verifier")).not.toBeInTheDocument();
 
     // Verify Countdown is replaced by status text
     expect(screen.queryByText(/Overdue|remaining/)).not.toBeInTheDocument();
-    expect(screen.getByText('Deadline Jan 1, 2024')).toBeInTheDocument();
+    expect(screen.getByText("Deadline Jan 1, 2024")).toBeInTheDocument();
 
-    expect(screen.getByText('Project Delivery')).toBeInTheDocument();
-    expect(screen.getByText(/All deliverables submitted and approved/)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /View evidence/i })).toHaveAttribute(
-      'href',
-      'https://docs.example.com/delivery',
-    );
+    expect(screen.getByText("Project Delivery")).toBeInTheDocument();
+    expect(
+      screen.getByText(/All deliverables submitted and approved/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /View evidence/i }),
+    ).toHaveAttribute("href", "https://docs.example.com/delivery");
 
-    expect(screen.getByText('Funds released')).toBeInTheDocument();
-    expect(screen.getAllByText('4,200.5 USDC').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('c5f1d3e0...0b6f9c').length).toBeGreaterThan(0);
+    expect(screen.getByText("Funds released")).toBeInTheDocument();
+    expect(screen.getAllByText("4,200.5 USDC").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("c5f1d3e0...0b6f9c").length).toBeGreaterThan(0);
     // Success destination
-    expect(screen.getAllByText('GSUCC3...LKQK').length).toBeGreaterThan(0);
+    expect(screen.getAllByText("GSUCC3...LKQK").length).toBeGreaterThan(0);
   });
 
-  it('renders failed vault milestone and redirect transaction details', () => {
-    renderVaultDetail('3');
+  it("renders failed vault milestone and redirect transaction details", async () => {
+    renderVaultDetail("3");
 
-    expect(screen.getByRole('heading', { name: 'Gamma Fund' })).toBeInTheDocument();
-    expect(screen.getAllByText('Failed').length).toBeGreaterThan(0);
+    expect(
+      await screen.findByRole("heading", { name: "Gamma Fund" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Failed").length).toBeGreaterThan(0);
 
     // Verify Countdown is replaced by status text
     expect(screen.queryByText(/Overdue|remaining/)).not.toBeInTheDocument();
 
-    expect(screen.getByText('Milestone 1')).toBeInTheDocument();
-    expect(screen.getByText('Criteria not met')).toBeInTheDocument();
+    expect(screen.getByText("Milestone 1")).toBeInTheDocument();
+    expect(screen.getByText("Criteria not met")).toBeInTheDocument();
 
-    expect(screen.getByText('Funds redirected')).toBeInTheDocument();
-    expect(screen.getAllByText('8,800 USDC').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('d6a2e4f1...1c7a0d').length).toBeGreaterThan(0);
+    expect(screen.getByText("Funds redirected")).toBeInTheDocument();
+    expect(screen.getAllByText("8,800 USDC").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("d6a2e4f1...1c7a0d").length).toBeGreaterThan(0);
     // Failure destination
-    expect(screen.getAllByText('GFAIL3...LKQK').length).toBeGreaterThan(0);
+    expect(screen.getAllByText("GFAIL3...LKQK").length).toBeGreaterThan(0);
   });
 
-  it('renders cancelled vault with mixed milestone statuses and redirect destination', () => {
-    renderVaultDetail('4');
+  it("renders cancelled vault with mixed milestone statuses and redirect destination", async () => {
+    renderVaultDetail("4");
 
-    expect(screen.getByRole('heading', { name: 'Delta Cancelled' })).toBeInTheDocument();
-    expect(screen.getAllByText('Cancelled').length).toBeGreaterThan(0);
+    expect(
+      await screen.findByRole("heading", { name: "Delta Cancelled" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Cancelled").length).toBeGreaterThan(0);
 
     // Verify Countdown is replaced by status text
     expect(screen.queryByText(/Overdue|remaining/)).not.toBeInTheDocument();
 
     // Mixed milestones
-    expect(screen.getByText('Milestone 1')).toBeInTheDocument();
-    expect(screen.getByText('Validated')).toBeInTheDocument();
-    expect(screen.getByText('Milestone 2')).toBeInTheDocument();
+    expect(screen.getByText("Milestone 1")).toBeInTheDocument();
+    expect(screen.getByText("Validated")).toBeInTheDocument();
+    expect(screen.getByText("Milestone 2")).toBeInTheDocument();
     // Use getAllByText for "Failed" since it appears for the status label too
-    expect(screen.getAllByText('Failed').length).toBeGreaterThan(0);
-    expect(screen.getByText('Milestone 3')).toBeInTheDocument();
-    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getAllByText("Failed").length).toBeGreaterThan(0);
+    expect(screen.getByText("Milestone 3")).toBeInTheDocument();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
 
-    expect(screen.getByText('Funds redirected')).toBeInTheDocument();
-    expect(screen.getAllByText('5,000 USDC').length).toBeGreaterThan(0);
+    expect(screen.getByText("Funds redirected")).toBeInTheDocument();
+    expect(screen.getAllByText("5,000 USDC").length).toBeGreaterThan(0);
     // Failure destination
-    expect(screen.getAllByText('GFAIL3...LKQK').length).toBeGreaterThan(0);
+    expect(screen.getAllByText("GFAIL3...LKQK").length).toBeGreaterThan(0);
   });
 
-  it('renders a not-found state for an unknown vault id', () => {
-    renderVaultDetail('999');
+  it("renders a not-found state for an unknown vault id", async () => {
+    renderVaultDetail("999");
 
-    expect(screen.getByRole('heading', { name: 'Vault not found' })).toBeInTheDocument();
-    expect(screen.getByText('No vault with ID "999" exists.')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Back to Vaults/i })).toHaveAttribute(
-      'href',
-      '/vaults',
+    expect(
+      await screen.findByRole("heading", { name: "Vault not found" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('No vault with ID "999" exists.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Back to Vaults/i }),
+    ).toHaveAttribute("href", "/vaults");
+  });
+
+  it("links duplicate action to CreateVault with prefilled state and no deadline", async () => {
+    render(
+      <MemoryRouter initialEntries={["/vaults/1"]}>
+        <Routes>
+          <Route path="/vaults/:id" element={<VaultDetail />} />
+          <Route path="/vaults/create" element={<CreateVaultStateProbe />} />
+        </Routes>
+      </MemoryRouter>,
     );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "Alpha Vault" }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("link", { name: /duplicate vault/i }));
+
+    const state = JSON.parse(
+      screen.getByTestId("create-vault-state").textContent ?? "{}",
+    );
+    expect(state.createVaultPrefill).toMatchObject({
+      sourceVaultId: "1",
+      sourceVaultName: "Alpha Vault",
+      amount: "12500",
+      successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+      failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+    });
+    expect(state.createVaultPrefill).not.toHaveProperty("deadline");
+    expect(state.createVaultPrefill.milestones).toEqual([
+      {
+        title: "Phase 1 Complete",
+        criteria: "All unit tests passing, code reviewed",
+      },
+      {
+        title: "Beta Launch",
+        criteria: "Beta deployed, 100 active users onboarded",
+      },
+    ]);
   });
 
   // ── Network footer banner ─────────────────────────────────────────────────
 
-  describe('NetworkFooterBanner', () => {
-    it('renders the network footer banner with an accessible landmark', () => {
-      renderVaultDetail('1');
-      expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  describe("NetworkFooterBanner", () => {
+    it("renders the network footer banner with an accessible landmark", async () => {
+      renderVaultDetail("1");
+      expect(await screen.findByRole("contentinfo")).toBeInTheDocument();
     });
 
-    it('shows the "Testnet" label when network is TESTNET', () => {
-      renderVaultDetail('1');
-      const footer = screen.getByRole('contentinfo');
-      expect(within(footer).getByText('Testnet')).toBeInTheDocument();
+    it('shows the "Testnet" label when network is TESTNET', async () => {
+      renderVaultDetail("1");
+      const footer = await screen.findByRole("contentinfo");
+      expect(within(footer).getByText("Testnet")).toBeInTheDocument();
     });
 
-    it('displays the contract address text in the footer', () => {
-      renderVaultDetail('1');
-      const footer = screen.getByRole('contentinfo');
+    it("displays the contract address text in the footer", async () => {
+      renderVaultDetail("1");
+      const footer = await screen.findByRole("contentinfo");
       // Vault 1 contract address
-      expect(within(footer).getByText('GCONT3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK')).toBeInTheDocument();
+      expect(
+        within(footer).getByText("GCONT3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK"),
+      ).toBeInTheDocument();
     });
 
-    it('renders the explorer link pointing to the testnet contract URL', () => {
-      renderVaultDetail('1');
-      const link = screen.getByRole('link', { name: /View contract.*on Stellar Testnet explorer/i });
+    it("renders the explorer link pointing to the testnet contract URL", async () => {
+      const validContractAddress = `C${"A".repeat(55)}`;
+      MASTER_VAULTS["1"].contractAddress = validContractAddress;
+
+      renderVaultDetail("1");
+      const footer = await screen.findByRole("contentinfo");
+      const link = within(footer)
+        .getByText(/View on Explorer/i)
+        .closest("a");
+
+      expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute(
-        'href',
-        'https://stellar.expert/explorer/testnet/contract/GCONT3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK',
+        "href",
+        `https://stellar.expert/explorer/testnet/contract/${validContractAddress}`,
       );
-      expect(link).toHaveAttribute('target', '_blank');
-      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
     });
 
     it('shows "Mainnet" label and a public explorer URL when network is PUBLIC', () => {
       vi.resetModules();
       // Override the mock for this specific test
-      vi.doMock('../../context/WalletContext', () => ({
-        useWallet: () => ({ network: 'PUBLIC' }),
+      vi.doMock("../../context/WalletContext", () => ({
+        useWallet: () => ({ network: "PUBLIC" }),
       }));
     });
 
-    it('does not render the footer banner on the not-found page', () => {
-      renderVaultDetail('999');
-      expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
+    it("does not render the footer banner on the not-found page", async () => {
+      renderVaultDetail("999");
+      await screen.findByRole("heading", { name: "Vault not found" });
+      expect(screen.queryByRole("contentinfo")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/pages/__tests__/Vaults.test.tsx
+++ b/src/pages/__tests__/Vaults.test.tsx
@@ -1,42 +1,112 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { vi } from 'vitest';
-import Vaults from '../../pages/Vaults';
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { vi } from "vitest";
+import Vaults, { VaultsInner } from "../../pages/Vaults";
 
 // Helper to mock fetch function
 const mockSuccess = <T,>(data: T) => vi.fn().mockResolvedValue(data);
-const mockFailure = (message = 'Network error') => vi.fn().mockRejectedValue(new Error(message));
+const mockFailure = (message = "Network error") =>
+  vi.fn().mockRejectedValue(new Error(message));
 
-describe('Vaults page states', () => {
-  test('shows loading skeletons initially', async () => {
+function CreateVaultStateProbe() {
+  const location = useLocation();
+  return (
+    <pre data-testid="create-vault-state">
+      {JSON.stringify(location.state ?? {})}
+    </pre>
+  );
+}
+
+describe("Vaults page states", () => {
+  test("shows loading skeletons initially", async () => {
     render(<Vaults fetchVaults={mockSuccess([])} />);
     // Skeletons should be present immediately
-    const skeletons = screen.getAllByTestId('skeleton');
+    const skeletons = screen.getAllByTestId("skeleton");
     expect(skeletons.length).toBeGreaterThanOrEqual(3);
     // Wait for loading to finish (no data)
-    await waitFor(() => expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByTestId("skeleton")).not.toBeInTheDocument(),
+    );
   });
 
-  test('shows empty state when no vaults', async () => {
+  test("shows empty state when no vaults", async () => {
     render(<Vaults fetchVaults={mockSuccess([])} />);
     await waitFor(() => screen.getByText(/You don’t have any vaults yet./i));
-    expect(screen.getByRole('link', { name: /Create your first vault/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Create your first vault/i }),
+    ).toBeInTheDocument();
   });
 
-  test('shows data state when vaults exist', async () => {
+  test("shows data state when vaults exist", async () => {
     const mockData = [
-      { id: '1', name: 'Test Vault', amount: 1000, currency: 'USDC', status: 'active' as any, deadline: '2025-01-01T00:00:00Z' },
+      {
+        id: "1",
+        name: "Test Vault",
+        amount: 1000,
+        currency: "USDC",
+        status: "active" as const,
+        deadline: "2025-01-01T00:00:00Z",
+      },
     ];
     render(<Vaults fetchVaults={mockSuccess(mockData)} />);
-    await waitFor(() => screen.getByText('Test Vault'));
+    await waitFor(() => screen.getByText("Test Vault"));
     expect(screen.getByText(/Test Vault/i)).toBeInTheDocument();
   });
 
-  test('shows error state and can retry', async () => {
+  test("duplicate action navigates to CreateVault with prefilled state", async () => {
+    const mockData = [
+      {
+        id: "1",
+        name: "Test Vault",
+        amount: 1000,
+        currency: "USDC",
+        status: "active" as const,
+        deadline: "2025-01-01T00:00:00Z",
+        successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+        failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+        milestones: [{ title: "Milestone A", criteria: "Criteria A" }],
+        createdAt: "2024-01-01T00:00:00Z",
+        creatorAddress: "GCREA3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+        contractAddress: "GCONT3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+        transactions: [],
+      },
+    ];
+
+    render(
+      <MemoryRouter initialEntries={["/vaults"]}>
+        <Routes>
+          <Route
+            path="/vaults"
+            element={<VaultsInner fetchVaults={mockSuccess(mockData)} />}
+          />
+          <Route path="/vaults/create" element={<CreateVaultStateProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => screen.getByText("Test Vault"));
+    await userEvent.click(screen.getByRole("link", { name: /duplicate/i }));
+
+    const state = JSON.parse(
+      screen.getByTestId("create-vault-state").textContent ?? "{}",
+    );
+    expect(state.createVaultPrefill).toMatchObject({
+      sourceVaultId: "1",
+      sourceVaultName: "Test Vault",
+      amount: "1000",
+      successAddress: "GSUCC3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+      failureAddress: "GFAIL3KQKM4XNQPBEZMXPOLKQKM4XNQPBEZMXPOLKQK",
+      milestones: [{ title: "Milestone A", criteria: "Criteria A" }],
+    });
+    expect(state.createVaultPrefill).not.toHaveProperty("deadline");
+  });
+
+  test("shows error state and can retry", async () => {
     const fetchMock = mockFailure();
     render(<Vaults fetchVaults={fetchMock} />);
     await waitFor(() => screen.getByText(/Failed to load vaults./i));
-    const retryBtn = screen.getByRole('button', { name: /Retry/i });
+    const retryBtn = screen.getByRole("button", { name: /Retry/i });
     expect(retryBtn).toBeInTheDocument();
     // Mock success on retry
     fetchMock.mockImplementationOnce(() => Promise.resolve([]));

--- a/src/utils/vaultPrefill.ts
+++ b/src/utils/vaultPrefill.ts
@@ -1,0 +1,65 @@
+import type { Milestone, Vault } from "../types/vault";
+
+export interface CreateVaultPrefillState {
+  sourceVaultId?: string;
+  sourceVaultName?: string;
+  amount?: string;
+  successAddress?: string;
+  failureAddress?: string;
+  milestones?: Array<Pick<Milestone, "title" | "criteria">>;
+}
+
+interface CreateVaultLocationState {
+  createVaultPrefill?: CreateVaultPrefillState;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+export function createVaultPrefillFromVault(
+  vault: Vault,
+): CreateVaultLocationState {
+  return {
+    createVaultPrefill: {
+      sourceVaultId: vault.id,
+      sourceVaultName: vault.name,
+      amount: String(vault.amount),
+      successAddress: vault.successAddress,
+      failureAddress: vault.failureAddress,
+      milestones: (vault.milestones ?? []).map(({ title, criteria }) => ({
+        title,
+        criteria,
+      })),
+    },
+  };
+}
+
+export function getCreateVaultPrefill(
+  state: unknown,
+): CreateVaultPrefillState | undefined {
+  if (!isRecord(state) || !isRecord(state.createVaultPrefill)) {
+    return undefined;
+  }
+
+  const { createVaultPrefill } = state;
+  const milestones = Array.isArray(createVaultPrefill.milestones)
+    ? createVaultPrefill.milestones.filter(isRecord).map((milestone) => ({
+        title: optionalString(milestone.title) ?? "",
+        criteria: optionalString(milestone.criteria) ?? "",
+      }))
+    : undefined;
+
+  return {
+    sourceVaultId: optionalString(createVaultPrefill.sourceVaultId),
+    sourceVaultName: optionalString(createVaultPrefill.sourceVaultName),
+    amount: optionalString(createVaultPrefill.amount),
+    successAddress: optionalString(createVaultPrefill.successAddress),
+    failureAddress: optionalString(createVaultPrefill.failureAddress),
+    milestones,
+  };
+}


### PR DESCRIPTION
## Summary
- add duplicate-vault entry points on VaultDetail and each Vaults row
- carry CreateVault prefill state through React Router for amount, destination addresses, and milestone metadata
- seed CreateVault owned fields from prefill while forcing a fresh deadline choice
- cover blank, valid, invalid, detail, and list prefill paths with tests
- document the duplicate-vault flow

Closes #452

## Validation
- npx eslint src/pages/CreateVault.tsx src/pages/VaultDetail.tsx src/pages/Vaults.tsx src/pages/__tests__/CreateVault.test.tsx src/pages/__tests__/VaultDetail.test.tsx src/pages/__tests__/Vaults.test.tsx src/utils/vaultPrefill.ts
- npx vitest run src/pages/__tests__/CreateVault.test.tsx src/pages/__tests__/VaultDetail.test.tsx src/pages/__tests__/Vaults.test.tsx
- npx prettier --check src/pages/CreateVault.tsx src/pages/VaultDetail.tsx src/pages/Vaults.tsx src/pages/__tests__/CreateVault.test.tsx src/pages/__tests__/VaultDetail.test.tsx src/pages/__tests__/Vaults.test.tsx src/utils/vaultPrefill.ts design-system/documentation/vault-duplicate.md
- git diff --check

## Notes
- `npm run build` is currently blocked by existing syntax errors outside this change in `src/utils/__tests__/csv.analytics.test.ts` and `src/utils/__tests__/verifierMetrics.test.ts`.