### PR TITLE
Add global vault command palette

### DIFF
--- a/design-system/documentation/command-palette.md
+++ b/design-system/documentation/command-palette.md
@@ -1,0 +1,37 @@
+# Command Palette
+
+The command palette gives power users a keyboard-first way to jump across vaults
+and core routes from anywhere in the app.
+
+## Entry Points
+
+- The header search button opens the palette.
+- `Cmd+K` and `Ctrl+K` open the same palette globally.
+
+The palette is mounted in `Layout` so every route gets the same command surface.
+
+## Results
+
+The palette lists quick actions first:
+
+- Create Vault
+- Verifier Queue
+- Analytics
+
+Vault results are loaded from `listVaults()` and search by vault name and id.
+Matching uses lightweight fuzzy subsequence matching so short queries still work
+without adding another dependency.
+
+## Keyboard And Focus
+
+- `ArrowDown` and `ArrowUp` move the selected result and wrap around.
+- `Enter` navigates to the selected result.
+- `Escape` closes the palette.
+- Backdrop click closes the palette.
+- Focus is trapped while the palette is open and returns to the header trigger on
+  close.
+
+## Motion
+
+The open surface uses the shared motion duration token and disables transitions
+when `prefers-reduced-motion: reduce` is active.

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,359 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import { Search, X } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import FocusTrap from "focus-trap-react";
+import { listVaults } from "../services/vaultService";
+import type { Vault } from "../types/vault";
+import { fuzzyMatch } from "../utils/commandPalette";
+import { duration } from "../utils/motion";
+import { usePrefersReducedMotion } from "../utils/usePrefersReducedMotion";
+
+interface CommandPaletteProps {
+  loadVaults?: () => Promise<Vault[]>;
+}
+
+type CommandItem = {
+  id: string;
+  label: string;
+  description: string;
+  to: string;
+  kind: "action" | "vault";
+};
+
+const QUICK_ACTIONS: CommandItem[] = [
+  {
+    id: "action-create-vault",
+    label: "Create Vault",
+    description: "Start a new vault",
+    to: "/vaults/create",
+    kind: "action",
+  },
+  {
+    id: "action-verifier-queue",
+    label: "Verifier Queue",
+    description: "Review pending validations",
+    to: "/verifier/queue",
+    kind: "action",
+  },
+  {
+    id: "action-analytics",
+    label: "Analytics",
+    description: "Open vault analytics",
+    to: "/analytics",
+    kind: "action",
+  },
+];
+
+function useCommandPalette() {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    window.setTimeout(() => triggerRef.current?.focus(), 0);
+  }, []);
+
+  const open = useCallback(() => {
+    triggerRef.current?.focus();
+    setIsOpen(true);
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key.toLowerCase() !== "k" ||
+        (!event.metaKey && !event.ctrlKey)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      open();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
+
+  return { close, isOpen, open, triggerRef };
+}
+
+function vaultToCommand(vault: Vault): CommandItem {
+  return {
+    id: `vault-${vault.id}`,
+    label: vault.name,
+    description: `Vault ${vault.id} · ${vault.amount.toLocaleString()} ${vault.currency}`,
+    to: `/vaults/${vault.id}`,
+    kind: "vault",
+  };
+}
+
+export default function CommandPalette({
+  loadVaults = listVaults,
+}: CommandPaletteProps) {
+  const navigate = useNavigate();
+  const { close, isOpen, open, triggerRef } = useCommandPalette();
+  const [query, setQuery] = useState("");
+  const [vaults, setVaults] = useState<Vault[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let cancelled = false;
+    loadVaults()
+      .then((nextVaults) => {
+        if (!cancelled) setVaults(nextVaults);
+      })
+      .catch(() => {
+        if (!cancelled) setVaults([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, loadVaults]);
+
+  useEffect(() => {
+    if (!isOpen) setQuery("");
+  }, [isOpen]);
+
+  const items = useMemo(() => {
+    const vaultCommands = vaults.map(vaultToCommand);
+    const allItems = [...QUICK_ACTIONS, ...vaultCommands];
+    const trimmedQuery = query.trim();
+
+    if (!trimmedQuery) return allItems;
+
+    return allItems.filter((item) => {
+      const haystack =
+        item.kind === "vault" ? `${item.label} ${item.id}` : item.label;
+      return fuzzyMatch(trimmedQuery, haystack);
+    });
+  }, [query, vaults]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [items.length, query]);
+
+  const runItem = useCallback(
+    (item: CommandItem) => {
+      navigate(item.to);
+      close();
+    },
+    [close, navigate],
+  );
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      close();
+      return;
+    }
+
+    if (items.length === 0) return;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((current) => (current + 1) % items.length);
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((current) => (current - 1 + items.length) % items.length);
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      runItem(items[activeIndex]);
+    }
+  };
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="Open command palette"
+        className="header-link"
+        onClick={open}
+        style={{ border: "none", background: "transparent", cursor: "pointer" }}
+      >
+        <Search size={18} aria-hidden="true" />
+      </button>
+
+      {isOpen && (
+        <FocusTrap
+          focusTrapOptions={{
+            allowOutsideClick: true,
+            clickOutsideDeactivates: false,
+            escapeDeactivates: false,
+            fallbackFocus: () => dialogRef.current ?? document.body,
+            initialFocus: "#command-palette-input",
+            returnFocusOnDeactivate: false,
+          }}
+        >
+          <div
+            role="presentation"
+            onClick={close}
+            style={{
+              position: "fixed",
+              inset: 0,
+              zIndex: "var(--z-index-modal, 1000)",
+              background: "rgba(0, 0, 0, 0.48)",
+              display: "flex",
+              alignItems: "flex-start",
+              justifyContent: "center",
+              padding: "12vh 1rem 1rem",
+              transition: prefersReducedMotion
+                ? "none"
+                : `opacity ${duration.normal}s ease`,
+            }}
+          >
+            <div
+              ref={dialogRef}
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="command-palette-title"
+              onClick={(event) => event.stopPropagation()}
+              onKeyDown={handleKeyDown}
+              style={{
+                width: "min(640px, 100%)",
+                maxHeight: "min(70vh, 640px)",
+                overflow: "hidden",
+                borderRadius: "var(--radius)",
+                border: "1px solid var(--border)",
+                background: "var(--surface)",
+                boxShadow: "var(--shadow-lg)",
+                transform: "translateY(0)",
+                transition: prefersReducedMotion
+                  ? "none"
+                  : `transform ${duration.normal}s ease`,
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "0.75rem",
+                  padding: "0.875rem 1rem",
+                  borderBottom: "1px solid var(--border)",
+                }}
+              >
+                <Search size={18} aria-hidden="true" />
+                <label
+                  id="command-palette-title"
+                  htmlFor="command-palette-input"
+                >
+                  Search vaults and actions
+                </label>
+                <button
+                  type="button"
+                  aria-label="Close command palette"
+                  onClick={close}
+                  style={{
+                    marginLeft: "auto",
+                    border: "none",
+                    background: "transparent",
+                    color: "var(--muted)",
+                    cursor: "pointer",
+                    minHeight: "var(--touch-target)",
+                    minWidth: "var(--touch-target)",
+                  }}
+                >
+                  <X size={18} aria-hidden="true" />
+                </button>
+              </div>
+
+              <input
+                id="command-palette-input"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Type a vault name, id, or action"
+                aria-controls="command-palette-results"
+                style={{
+                  width: "100%",
+                  border: "none",
+                  borderBottom: "1px solid var(--border)",
+                  background: "transparent",
+                  color: "var(--text)",
+                  padding: "0.875rem 1rem",
+                  font: "inherit",
+                  outline: "none",
+                }}
+              />
+
+              <div
+                id="command-palette-results"
+                role="listbox"
+                aria-label="Command palette results"
+                style={{
+                  maxHeight: "420px",
+                  overflowY: "auto",
+                  padding: "0.5rem",
+                }}
+              >
+                {items.length === 0 ? (
+                  <p
+                    role="status"
+                    style={{
+                      margin: 0,
+                      padding: "1rem",
+                      color: "var(--muted)",
+                    }}
+                  >
+                    No matching vaults or actions.
+                  </p>
+                ) : (
+                  items.map((item, index) => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      role="option"
+                      aria-selected={index === activeIndex}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      onClick={() => runItem(item)}
+                      style={{
+                        width: "100%",
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "flex-start",
+                        gap: "0.25rem",
+                        border: "none",
+                        borderRadius: "var(--radius)",
+                        background:
+                          index === activeIndex
+                            ? "color-mix(in srgb, var(--accent) 12%, transparent)"
+                            : "transparent",
+                        color: "var(--text)",
+                        cursor: "pointer",
+                        padding: "0.75rem",
+                        textAlign: "left",
+                      }}
+                    >
+                      <span style={{ fontWeight: 700 }}>{item.label}</span>
+                      <span style={{ color: "var(--muted)", fontSize: 13 }}>
+                        {item.description}
+                      </span>
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+          </div>
+        </FocusTrap>
+      )}
+    </>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,6 +9,7 @@ import { Text } from "./Text";
 import { TrustlineBanner } from "./TrustlineBanner";
 import NotificationBell from "./Notification/NotificationBell";
 import { ShortcutsHelp } from "./ShortcutsHelp";
+import CommandPalette from "./CommandPalette";
 import "./Layout.css";
 
 interface LayoutProps {
@@ -17,10 +18,12 @@ interface LayoutProps {
 
 export default function Layout({ children }: LayoutProps) {
   const [isDrawerOpen, setDrawerOpen] = useState(false);
-  const toggleDrawer = () => setDrawerOpen(prev => !prev);
+  const toggleDrawer = () => setDrawerOpen((prev) => !prev);
   const location = useLocation();
   const backgroundA11yProps = isDrawerOpen
-    ? ({ "aria-hidden": true, inert: "" } as HTMLAttributes<HTMLElement> & { inert: "" })
+    ? ({ "aria-hidden": true, inert: "" } as HTMLAttributes<HTMLElement> & {
+        inert: "";
+      })
     : {};
 
   return (
@@ -50,7 +53,11 @@ export default function Layout({ children }: LayoutProps) {
           </NavLink>
         </div>
 
-        <nav className="desktop-nav" aria-label="Main navigation" {...backgroundA11yProps}>
+        <nav
+          className="desktop-nav"
+          aria-label="Main navigation"
+          {...backgroundA11yProps}
+        >
           <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
             <NavLink
               to="/"
@@ -62,10 +69,7 @@ export default function Layout({ children }: LayoutProps) {
               </Text>
             </NavLink>
 
-            <NavLink
-              to="/verifier"
-              className="header-link"
-            >
+            <NavLink to="/verifier" className="header-link">
               <Text role="caption" as="span">
                 Verifier
               </Text>
@@ -74,7 +78,9 @@ export default function Layout({ children }: LayoutProps) {
             <NavLink
               to="/analytics"
               className="header-link"
-              aria-current={location.pathname === "/analytics" ? "page" : undefined}
+              aria-current={
+                location.pathname === "/analytics" ? "page" : undefined
+              }
             >
               <Text role="caption" as="span">
                 Analytics
@@ -84,7 +90,9 @@ export default function Layout({ children }: LayoutProps) {
             <Link
               to="/vaults/create"
               className="header-link header-cta"
-              aria-current={location.pathname === "/vaults/create" ? "page" : undefined}
+              aria-current={
+                location.pathname === "/vaults/create" ? "page" : undefined
+              }
             >
               Create Vault
             </Link>
@@ -93,6 +101,9 @@ export default function Layout({ children }: LayoutProps) {
             <WalletConnectButton />
           </div>
         </nav>
+        <div {...backgroundA11yProps}>
+          <CommandPalette />
+        </div>
         <div className="mobile-bell-wrapper" {...backgroundA11yProps}>
           <NotificationBell />
         </div>
@@ -106,7 +117,10 @@ export default function Layout({ children }: LayoutProps) {
         >
           <Menu size={24} aria-hidden="true" />
         </button>
-        <MobileDrawer isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)} />
+        <MobileDrawer
+          isOpen={isDrawerOpen}
+          onClose={() => setDrawerOpen(false)}
+        />
       </header>
       <TrustlineBanner />
 

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import CommandPalette from "../CommandPalette";
+import type { Vault } from "../../types/vault";
+import { fuzzyMatch } from "../../utils/commandPalette";
+
+const vaults: Vault[] = [
+  {
+    id: "alpha-1",
+    name: "Alpha Vault",
+    status: "active",
+    amount: 12500,
+    currency: "USDC",
+    createdAt: "2024-01-01T00:00:00Z",
+    deadline: "2024-07-01T00:00:00Z",
+    creatorAddress: "GCREATOR",
+    successAddress: "GSUCCESS",
+    failureAddress: "GFAILURE",
+    contractAddress: "CCONTRACT",
+    milestones: [],
+    transactions: [],
+  },
+  {
+    id: "beta-2",
+    name: "Beta Reserve",
+    status: "completed",
+    amount: 4200,
+    currency: "USDC",
+    createdAt: "2024-01-01T00:00:00Z",
+    deadline: "2024-07-01T00:00:00Z",
+    creatorAddress: "GCREATOR",
+    successAddress: "GSUCCESS",
+    failureAddress: "GFAILURE",
+    contractAddress: "CCONTRACT",
+    milestones: [],
+    transactions: [],
+  },
+];
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="current-path">{location.pathname}</div>;
+}
+
+function renderPalette(options?: {
+  loadVaults?: () => Promise<Vault[]>;
+  initialPath?: string;
+}) {
+  const loadVaults = options?.loadVaults ?? vi.fn().mockResolvedValue(vaults);
+
+  render(
+    <MemoryRouter initialEntries={[options?.initialPath ?? "/"]}>
+      <CommandPalette loadVaults={loadVaults} />
+      <Routes>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+  return { loadVaults };
+}
+
+async function openPalette() {
+  const user = userEvent.setup();
+  await user.click(
+    screen.getByRole("button", { name: /open command palette/i }),
+  );
+  return user;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fuzzyMatch", () => {
+  it("matches subsequence queries without requiring contiguous letters", () => {
+    expect(fuzzyMatch("av", "Alpha Vault")).toBe(true);
+    expect(fuzzyMatch("b2", "beta-2")).toBe(true);
+    expect(fuzzyMatch("zz", "Alpha Vault")).toBe(false);
+  });
+});
+
+describe("CommandPalette", () => {
+  it("opens from the trigger and shows quick actions plus vaults for an empty query", async () => {
+    const { loadVaults } = renderPalette();
+
+    await openPalette();
+
+    expect(
+      await screen.findByRole("dialog", { name: /search vaults and actions/i }),
+    ).toBeInTheDocument();
+    expect(loadVaults).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole("option", { name: /Create Vault/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /Verifier Queue/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /Analytics/i }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: /Alpha Vault/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens from Cmd+K and filters vaults by fuzzy name or id", async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    await user.keyboard("{Meta>}k{/Meta}");
+
+    const input = await screen.findByRole("textbox", {
+      name: /search vaults and actions/i,
+    });
+    await user.type(input, "alp");
+
+    expect(
+      screen.getByRole("option", { name: /Alpha Vault/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: /Beta Reserve/i }),
+    ).not.toBeInTheDocument();
+
+    await user.clear(input);
+    await user.type(input, "beta-2");
+
+    expect(
+      screen.getByRole("option", { name: /Beta Reserve/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an empty state when no vaults or actions match", async () => {
+    const user = await openPaletteAfterRender();
+
+    await user.type(
+      screen.getByRole("textbox", { name: /search vaults and actions/i }),
+      "zzzz",
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "No matching vaults or actions.",
+    );
+  });
+
+  it("wraps arrow-key selection and navigates with Enter", async () => {
+    const user = await openPaletteAfterRender();
+    const input = screen.getByRole("textbox", {
+      name: /search vaults and actions/i,
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("option", { name: /Beta Reserve/i }),
+      ).toBeInTheDocument(),
+    );
+
+    await user.keyboard("{ArrowUp}{Enter}");
+
+    expect(screen.getByTestId("current-path")).toHaveTextContent(
+      "/vaults/beta-2",
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(input).not.toBeInTheDocument();
+  });
+
+  it("closes with Escape, backdrop click, and restores focus to the trigger", async () => {
+    renderPalette();
+    const user = userEvent.setup();
+    const trigger = screen.getByRole("button", {
+      name: /open command palette/i,
+    });
+
+    trigger.focus();
+    await user.click(trigger);
+    const dialog = await screen.findByRole("dialog", {
+      name: /search vaults and actions/i,
+    });
+
+    await user.keyboard("{Escape}");
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    await waitFor(() => expect(trigger).toHaveFocus());
+
+    await user.click(trigger);
+    const reopenedDialog = await screen.findByRole("dialog", {
+      name: /search vaults and actions/i,
+    });
+    await user.click(reopenedDialog.parentElement!);
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    expect(dialog).not.toBeInTheDocument();
+  });
+
+  it("disables dialog transition when reduced motion is preferred", async () => {
+    vi.spyOn(window, "matchMedia").mockImplementation(
+      (query: string) =>
+        ({
+          matches: query === "(prefers-reduced-motion: reduce)",
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as unknown as MediaQueryList,
+    );
+
+    renderPalette();
+    await openPalette();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("dialog", { name: /search vaults and actions/i }),
+      ).toHaveStyle({
+        transition: "none",
+      }),
+    );
+  });
+});
+
+async function openPaletteAfterRender() {
+  renderPalette();
+  return openPalette();
+}

--- a/src/utils/commandPalette.ts
+++ b/src/utils/commandPalette.ts
@@ -1,0 +1,16 @@
+export function fuzzyMatch(query: string, value: string): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  let queryIndex = 0;
+  const normalizedValue = value.toLowerCase();
+
+  for (const char of normalizedValue) {
+    if (char === normalizedQuery[queryIndex]) {
+      queryIndex += 1;
+      if (queryIndex === normalizedQuery.length) return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- add a global Cmd/Ctrl+K command palette mounted from Layout
- include quick actions for Create Vault, Verifier Queue, and Analytics plus fuzzy vault name/id search
- support Escape/backdrop close, arrow-key wrap-around, Enter navigation, focus trapping/restoration, and reduced-motion transitions
- document the command palette behavior and add focused RTL coverage

Closes #451

## Validation
- npx vitest run src/components/__tests__/CommandPalette.test.tsx src/components/__tests__/Layout.test.tsx
- npx eslint src/components/CommandPalette.tsx src/components/Layout.tsx src/components/__tests__/CommandPalette.test.tsx src/utils/commandPalette.ts
- npx prettier --check src/components/CommandPalette.tsx src/components/Layout.tsx src/components/__tests__/CommandPalette.test.tsx src/utils/commandPalette.ts design-system/documentation/command-palette.md
- git diff --check