### PR TITLE
Add shared pagination component

### DIFF
--- a/design-system/documentation/pagination.md
+++ b/design-system/documentation/pagination.md
@@ -1,0 +1,25 @@
+# Pagination
+
+Use `Pagination` when a view shows a bounded list and already has a
+`paginate(...)` result from `src/utils/paginate.ts`.
+
+```tsx
+const pagination = paginate(items, currentPage, pageSize);
+
+<Pagination
+  pagination={pagination}
+  onPageChange={setCurrentPage}
+  ariaLabel="Notifications pagination"
+/>
+```
+
+## Accessibility
+
+- The wrapper is a `nav` landmark with a configurable `aria-label`.
+- Previous and next controls expose action-specific labels.
+- Numbered page buttons expose `aria-label="Go to page N"`.
+- The active page uses `aria-current="page"`.
+- Boundary controls are disabled on the first and last pages.
+
+`paginate` clamps empty lists and out-of-range page requests to page `1`, so
+consumers can safely reuse stale page state after filters or deletions.

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,80 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { PaginationResult } from "@/utils/paginate";
+
+interface PaginationProps {
+  pagination: Pick<
+    PaginationResult<unknown>,
+    "currentPage" | "pageCount" | "totalItems"
+  >;
+  onPageChange: (page: number) => void;
+  ariaLabel?: string;
+  className?: string;
+}
+
+export function Pagination({
+  pagination,
+  onPageChange,
+  ariaLabel = "Pagination",
+  className = "",
+}: PaginationProps) {
+  const { currentPage, pageCount, totalItems } = pagination;
+  const isFirstPage = currentPage <= 1;
+  const isLastPage = currentPage >= pageCount;
+  const pages = Array.from({ length: pageCount }, (_, index) => index + 1);
+
+  return (
+    <nav
+      aria-label={ariaLabel}
+      className={`flex flex-col items-center justify-center gap-3 ${className}`}
+    >
+      <p className="text-sm text-gray-600" aria-live="polite">
+        Page {currentPage} of {pageCount}
+      </p>
+
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <button
+          type="button"
+          disabled={isFirstPage}
+          onClick={() => onPageChange(currentPage - 1)}
+          className="inline-flex items-center gap-1 rounded bg-[#121a2a] px-3 py-2 text-sm text-white disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="Go to previous page"
+        >
+          <ChevronLeft aria-hidden="true" size={16} />
+          Previous
+        </button>
+
+        <div className="flex flex-wrap justify-center gap-1">
+          {pages.map((page) => (
+            <button
+              key={page}
+              type="button"
+              onClick={() => onPageChange(page)}
+              aria-label={`Go to page ${page}`}
+              aria-current={page === currentPage ? "page" : undefined}
+              className={`h-9 min-w-9 rounded px-3 text-sm font-medium ${
+                page === currentPage
+                  ? "bg-[#00c389] text-[#121a2a]"
+                  : "bg-white text-[#121a2a] ring-1 ring-gray-300 hover:bg-gray-100"
+              }`}
+            >
+              {page}
+            </button>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          disabled={isLastPage}
+          onClick={() => onPageChange(currentPage + 1)}
+          className="inline-flex items-center gap-1 rounded bg-[#00c389] px-3 py-2 text-sm text-[#121a2a] disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="Go to next page"
+        >
+          Next
+          <ChevronRight aria-hidden="true" size={16} />
+        </button>
+      </div>
+
+      <span className="sr-only">{totalItems} total items</span>
+    </nav>
+  );
+}

--- a/src/components/__tests__/Pagination.test.tsx
+++ b/src/components/__tests__/Pagination.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Pagination } from "../Pagination";
+import { paginate } from "@/utils/paginate";
+
+const items = Array.from({ length: 12 }, (_, index) => index);
+
+describe("Pagination", () => {
+  it("renders page status and numbered controls", () => {
+    render(
+      <Pagination
+        pagination={paginate(items, 2, 5)}
+        onPageChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Page 2 of 3")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Go to page 2" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("button", { name: "Go to page 1" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Go to page 3" })).toBeEnabled();
+  });
+
+  it("calls onPageChange for previous, next, and numbered pages", () => {
+    const onPageChange = vi.fn();
+    render(
+      <Pagination
+        pagination={paginate(items, 2, 5)}
+        onPageChange={onPageChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Go to previous page" }));
+    fireEvent.click(screen.getByRole("button", { name: "Go to next page" }));
+    fireEvent.click(screen.getByRole("button", { name: "Go to page 3" }));
+
+    expect(onPageChange).toHaveBeenNthCalledWith(1, 1);
+    expect(onPageChange).toHaveBeenNthCalledWith(2, 3);
+    expect(onPageChange).toHaveBeenNthCalledWith(3, 3);
+  });
+
+  it("disables previous on the first page and next on the last page", () => {
+    const { rerender } = render(
+      <Pagination
+        pagination={paginate(items, 1, 5)}
+        onPageChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Go to previous page" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Go to next page" })).toBeEnabled();
+
+    rerender(
+      <Pagination
+        pagination={paginate(items, 3, 5)}
+        onPageChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Go to previous page" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Go to next page" })).toBeDisabled();
+  });
+
+  it("keeps controls bounded for empty and single-page results", () => {
+    render(
+      <Pagination
+        pagination={paginate([], 10, 5)}
+        onPageChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Page 1 of 1")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Go to previous page" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Go to next page" })).toBeDisabled();
+    expect(screen.getByText("0 total items")).toBeInTheDocument();
+  });
+});

--- a/src/pages/Notification.tsx
+++ b/src/pages/Notification.tsx
@@ -7,6 +7,8 @@ import { MdOutlineSettingsInputComposite } from "react-icons/md";
 import { Link } from "react-router-dom";
 import { ConfirmationModal } from "@/components/ConfirmationModal";
 import { X } from "lucide-react";
+import { Pagination } from "@/components/Pagination";
+import { paginate } from "@/utils/paginate";
 
 export default function Notification() {
   const notifications = useNotification((state) => state.notification);
@@ -24,12 +26,8 @@ export default function Notification() {
   const [showClearModal, setShowClearModal] = useState(false);
   const itemsPerPage = 5;
 
-  // 1. Calculate the data for the current page
-  const startIndex = (currentPage - 1) * itemsPerPage;
-  const currentData = currentNotification.slice(
-    startIndex,
-    startIndex + itemsPerPage,
-  );
+  const pagination = paginate(currentNotification, currentPage, itemsPerPage);
+  const currentData = pagination.items;
 
   const containerRef = useRef<HTMLDivElement | null>(null); // 1. Create a reference to the container
 
@@ -54,7 +52,7 @@ export default function Notification() {
     };
   }, []);
 
-  const filterNotification = () => {
+  useEffect(() => {
     let filtered = notifications;
 
     if (!filtered) return;
@@ -72,13 +70,7 @@ export default function Notification() {
     }
     setCurrentNotification(filtered);
     setCurrentPage(1);
-  };
-  useEffect(() => {
-    filterNotification();
   }, [currentFilterReadSeletion, currentFilterTypeSeletion, notifications]);
-
-  // 2. Calculate total pages
-  const totalPages = Math.ceil(currentNotification.length / itemsPerPage);
 
   // Reset to page 1 when the underlying notification list changes
   useEffect(() => {
@@ -233,30 +225,12 @@ export default function Notification() {
         )}
       </div>
 
-      {/* Pagination Controls */}
-      <div className="flex flex-col justify-end">
-        <div className="flex justify-center gap-4 mt-8">
-          <button
-            disabled={currentPage === 1}
-            onClick={() => setCurrentPage((prev) => prev - 1)}
-            className="px-4 py-2 bg-[#121a2a] rounded disabled:opacity-50 text-white"
-          >
-            Previous
-          </button>
-
-          <span className="flex items-center">
-            Page {currentPage} of {totalPages}
-          </span>
-
-          <button
-            disabled={currentPage === totalPages}
-            onClick={() => setCurrentPage((prev) => prev + 1)}
-            className="px-4 py-2 bg-[#00c389] rounded disabled:opacity-50"
-          >
-            Next
-          </button>
-        </div>
-      </div>
+      <Pagination
+        pagination={pagination}
+        onPageChange={setCurrentPage}
+        ariaLabel="Notifications pagination"
+        className="mt-8"
+      />
 
       <ConfirmationModal
         isOpen={showClearModal}

--- a/src/pages/__tests__/Notification.test.tsx
+++ b/src/pages/__tests__/Notification.test.tsx
@@ -15,6 +15,7 @@ vi.mock("framer-motion", () => ({
     ),
   },
   AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  useReducedMotion: () => false,
 }));
 
 vi.mock("focus-trap-react", () => ({
@@ -55,11 +56,14 @@ describe("Notification page", () => {
     expect(
       screen.getByText(`Page 1 of ${totalPages}`),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: "Notifications pagination" }),
+    ).toBeInTheDocument();
   });
 
   it("navigates to the next page", () => {
     renderNotification();
-    const nextButton = screen.getByText("Next");
+    const nextButton = screen.getByRole("button", { name: "Go to next page" });
     fireEvent.click(nextButton);
     const totalPages = Math.ceil(initialNotifications.length / 5);
     expect(
@@ -69,8 +73,19 @@ describe("Notification page", () => {
 
   it("disables previous button on first page", () => {
     renderNotification();
-    const prevButton = screen.getByText("Previous");
+    const prevButton = screen.getByRole("button", {
+      name: "Go to previous page",
+    });
     expect(prevButton).toBeDisabled();
+  });
+
+  it("supports numbered page navigation", () => {
+    renderNotification();
+    fireEvent.click(screen.getByRole("button", { name: "Go to page 3" }));
+    const totalPages = Math.ceil(initialNotifications.length / 5);
+    expect(
+      screen.getByText(`Page 3 of ${totalPages}`),
+    ).toBeInTheDocument();
   });
 
   it("filters by unread via the read filter dropdown", () => {
@@ -126,7 +141,7 @@ describe("Notification page", () => {
   it("resets to page 1 when filter changes", () => {
     renderNotification();
 
-    const nextButton = screen.getByText("Next");
+    const nextButton = screen.getByRole("button", { name: "Go to next page" });
     fireEvent.click(nextButton);
     const totalPages = Math.ceil(initialNotifications.length / 5);
     expect(
@@ -146,7 +161,7 @@ describe("Notification page", () => {
   it("resets to page 1 when filter changes", () => {
     renderNotification();
 
-    const nextButton = screen.getByText("Next");
+    const nextButton = screen.getByRole("button", { name: "Go to next page" });
     fireEvent.click(nextButton);
     const totalPages = Math.ceil(initialNotifications.length / 5);
     expect(
@@ -232,7 +247,7 @@ describe("Notification page", () => {
     renderNotification();
 
     // Go to page 2
-    const nextButton = screen.getByText("Next");
+    const nextButton = screen.getByRole("button", { name: "Go to next page" });
     fireEvent.click(nextButton);
     expect(screen.getByText(/Page 2 of 2/)).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary
- Add a shared `Pagination` component powered by `paginate(...)`
- Replace Notification page inline pagination with the reusable control
- Add focused component/page tests and design-system documentation

Closes #455

## Verification
- `npm exec vitest -- run src/components/__tests__/Pagination.test.tsx src/pages/__tests__/Notification.test.tsx`
- `npm exec eslint -- src/components/Pagination.tsx src/components/__tests__/Pagination.test.tsx src/pages/Notification.tsx src/pages/__tests__/Notification.test.tsx`

## Notes
- `npm run build` is currently blocked by unrelated baseline syntax errors in `src/utils/__tests__/csv.analytics.test.ts` and `src/utils/__tests__/verifierMetrics.test.ts`.