### PR TITLE
Add pending validation sort controls

### DIFF
--- a/design-system/documentation/pending-sort.md
+++ b/design-system/documentation/pending-sort.md
@@ -1,0 +1,15 @@
+# Pending Validation Sorting
+
+`PendingValidations` uses `sortPending(tasks, key, dir)` after filtering the
+queue. Filtering stays responsible for narrowing the result set; sorting only
+orders the visible tasks.
+
+Supported keys:
+
+- `deadline`: earliest or latest deadline first
+- `amount`: numeric amount parsed from strings such as `20,000 USDC`
+- `vaultName`: case-insensitive vault-name ordering
+
+The comparator is stable, so tasks with equal sort keys keep their original
+relative order. This keeps queue movement predictable when several validations
+share a deadline or an unavailable amount.

--- a/src/pages/PendingValidations.tsx
+++ b/src/pages/PendingValidations.tsx
@@ -8,6 +8,7 @@ import { computeVerifierMetrics } from '../utils/verifierMetrics';
 import { useVerifierStore } from '../Zustand/Store';
 import { StatusChip } from '../components/StatusChip';
 import { filterPending } from '../utils/filterPending';
+import { sortPending, type PendingSortKey, type SortDirection } from '../utils/sortPending';
 
 export default function PendingValidations() {
   const navigate = useNavigate();
@@ -22,7 +23,8 @@ export default function PendingValidations() {
   // Filter and sort state
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedMilestone, setSelectedMilestone] = useState('');
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+  const [sortKey, setSortKey] = useState<PendingSortKey>('deadline');
+  const [sortDir, setSortDir] = useState<SortDirection>('asc');
 
   // Multi-select state for batch actions.
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -45,13 +47,8 @@ export default function PendingValidations() {
   }, [pendingValidations, searchQuery, selectedMilestone]);
 
   const sortedValidations = useMemo(
-    () =>
-      [...filteredValidations].sort((a, b) =>
-        sortOrder === 'asc'
-          ? a.daysRemaining - b.daysRemaining
-          : b.daysRemaining - a.daysRemaining,
-      ),
-    [filteredValidations, sortOrder],
+    () => sortPending(filteredValidations, sortKey, sortDir),
+    [filteredValidations, sortDir, sortKey],
   );
 
   // Keep selection in sync with the queue and reset it when the active filters change.
@@ -122,16 +119,64 @@ export default function PendingValidations() {
           </Text>
         </div>
 
-        <button
-          onClick={() => setSortOrder(prev => prev === 'asc' ? 'desc' : 'asc')}
-          className="px-4 py-2 border rounded text-sm font-medium transition"
-          style={{ borderColor: 'var(--border)', color: 'var(--text)', background: 'var(--bg)' }}
-        >
-          Sort by Urgency: {sortOrder === 'asc' ? 'High to Low' : 'Low to High'}
-        </button>
+        <div className="flex flex-col sm:flex-row gap-3">
+          <label className="flex flex-col gap-1 text-sm font-medium" style={{ color: 'var(--text)' }}>
+            Sort by
+            <select
+              value={sortKey}
+              onChange={(event) => setSortKey(event.target.value as PendingSortKey)}
+              className="px-3 py-2 border rounded text-sm"
+              style={{ borderColor: 'var(--border)', background: 'var(--bg)', color: 'var(--text)' }}
+            >
+              <option value="deadline">Deadline</option>
+              <option value="amount">Amount at stake</option>
+              <option value="vaultName">Vault name</option>
+            </select>
+          </label>
+          <button
+            onClick={() => setSortDir((prev) => (prev === 'asc' ? 'desc' : 'asc'))}
+            className="self-end px-4 py-2 border rounded text-sm font-medium transition"
+            style={{ borderColor: 'var(--border)', color: 'var(--text)', background: 'var(--bg)' }}
+          >
+            Sort direction: {sortDir === 'asc' ? 'Ascending' : 'Descending'}
+          </button>
+        </div>
       </header>
 
       <VerifierMetricsBar metrics={metrics} />
+
+      <section
+        aria-label="Pending validation filters"
+        className="grid gap-4 md:grid-cols-2"
+      >
+        <label className="flex flex-col gap-1 text-sm font-medium" style={{ color: 'var(--text)' }}>
+          Search by Vault Name or Owner
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            className="px-3 py-2 border rounded"
+            placeholder="Search vaults or owners"
+            style={{ borderColor: 'var(--border)', background: 'var(--bg)', color: 'var(--text)' }}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm font-medium" style={{ color: 'var(--text)' }}>
+          Filter by Milestone
+          <select
+            value={selectedMilestone}
+            onChange={(event) => setSelectedMilestone(event.target.value)}
+            className="px-3 py-2 border rounded"
+            style={{ borderColor: 'var(--border)', background: 'var(--bg)', color: 'var(--text)' }}
+          >
+            <option value="">All Milestones</option>
+            {availableMilestones.map((milestone) => (
+              <option key={milestone} value={milestone}>
+                {milestone}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
 
       <section className="border rounded-lg shadow-sm overflow-x-auto" style={{ background: 'var(--bg)', borderColor: 'var(--border)' }}>
         {sortedValidations.length === 0 ? (
@@ -164,10 +209,31 @@ export default function PendingValidations() {
                     className="h-4 w-4 cursor-pointer accent-[var(--accent)]"
                   />
                 </th>
-                <th scope="col" className="p-4 font-medium text-sm" style={{ color: 'var(--muted)' }}>Vault & Milestone</th>
+                <th
+                  scope="col"
+                  className="p-4 font-medium text-sm"
+                  style={{ color: 'var(--muted)' }}
+                  aria-sort={sortKey === 'vaultName' ? (sortDir === 'asc' ? 'ascending' : 'descending') : undefined}
+                >
+                  Vault & Milestone
+                </th>
                 <th scope="col" className="p-4 font-medium text-sm" style={{ color: 'var(--muted)' }}>Owner</th>
-                <th scope="col" className="p-4 font-medium text-sm" style={{ color: 'var(--muted)' }}>Amount at Stake</th>
-                <th scope="col" className="p-4 font-medium text-sm" style={{ color: 'var(--muted)' }} aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>Deadline</th>
+                <th
+                  scope="col"
+                  className="p-4 font-medium text-sm"
+                  style={{ color: 'var(--muted)' }}
+                  aria-sort={sortKey === 'amount' ? (sortDir === 'asc' ? 'ascending' : 'descending') : undefined}
+                >
+                  Amount at Stake
+                </th>
+                <th
+                  scope="col"
+                  className="p-4 font-medium text-sm"
+                  style={{ color: 'var(--muted)' }}
+                  aria-sort={sortKey === 'deadline' ? (sortDir === 'asc' ? 'ascending' : 'descending') : undefined}
+                >
+                  Deadline
+                </th>
                 <th scope="col" className="p-4 font-medium text-sm text-right" style={{ color: 'var(--muted)' }}>Actions</th>
               </tr>
             </thead>

--- a/src/pages/__tests__/PendingValidations.test.tsx
+++ b/src/pages/__tests__/PendingValidations.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import PendingValidations from '../PendingValidations';
 import { useVerifierStore } from '../../Zustand/Store';
@@ -50,6 +51,8 @@ const makeTasks = () => [
   },
 ];
 
+const mockedUseVerifierStore = useVerifierStore as unknown as Mock;
+
 function renderPage() {
   return render(
     <MemoryRouter>
@@ -63,7 +66,7 @@ describe('PendingValidations', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-21T00:00:00Z'));
     vi.clearAllMocks();
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: makeTasks() });
+    mockedUseVerifierStore.mockReturnValue({ pendingValidations: makeTasks() });
   });
 
   afterEach(() => {
@@ -76,14 +79,14 @@ describe('PendingValidations', () => {
   });
 
   it('shows "All caught up!" when there are no pending validations', () => {
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+    mockedUseVerifierStore.mockReturnValue({ pendingValidations: [] });
     renderPage();
     expect(screen.getByText('All caught up!')).toBeInTheDocument();
     expect(screen.getByText(/no pending validations/i)).toBeInTheDocument();
   });
 
   it('does not render the table when queue is empty', () => {
-    (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+    mockedUseVerifierStore.mockReturnValue({ pendingValidations: [] });
     renderPage();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
@@ -95,9 +98,10 @@ describe('PendingValidations', () => {
     expect(screen.getByText('Gamma Vault')).toBeInTheDocument();
   });
 
-  it('default sort is ascending (most urgent first) and button shows "High to Low"', () => {
+  it('default sort is deadline ascending and direction shows ascending', () => {
     renderPage();
-    expect(screen.getByRole('button', { name: /High to Low/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Sort by/i)).toHaveValue('deadline');
+    expect(screen.getByRole('button', { name: /Ascending/i })).toBeInTheDocument();
 
     // ascending: v-2 (2 days) → v-1 (10 days) → v-3 (20 days)
     const vaultCells = screen.getAllByText(/Vault$/);
@@ -106,11 +110,11 @@ describe('PendingValidations', () => {
     expect(vaultCells[2].textContent).toBe('Gamma Vault');
   });
 
-  it('toggling sort reverses the order and button shows "Low to High"', () => {
+  it('toggling sort direction reverses the order and shows descending', () => {
     renderPage();
-    fireEvent.click(screen.getByRole('button', { name: /High to Low/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Ascending/i }));
 
-    expect(screen.getByRole('button', { name: /Low to High/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Descending/i })).toBeInTheDocument();
 
     // descending: v-3 (20 days) → v-1 (10 days) → v-2 (2 days)
     const vaultCells = screen.getAllByText(/Vault$/);
@@ -119,12 +123,12 @@ describe('PendingValidations', () => {
     expect(vaultCells[2].textContent).toBe('Beta Vault');
   });
 
-  it('toggling twice returns to original ascending order', () => {
+  it('toggling direction twice returns to original ascending order', () => {
     renderPage();
-    fireEvent.click(screen.getByRole('button', { name: /High to Low/i }));
-    fireEvent.click(screen.getByRole('button', { name: /Low to High/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Ascending/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Descending/i }));
 
-    expect(screen.getByRole('button', { name: /High to Low/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Ascending/i })).toBeInTheDocument();
 
     // back to ascending: v-2 → v-1 → v-3
     const vaultCells = screen.getAllByText(/Vault$/);
@@ -133,10 +137,35 @@ describe('PendingValidations', () => {
     expect(vaultCells[2].textContent).toBe('Gamma Vault');
   });
 
+  it('sorts by amount when the sort selector changes', () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/Sort by/i), {
+      target: { value: 'amount' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Ascending/i }));
+
+    const vaultCells = screen.getAllByText(/Vault$/);
+    expect(vaultCells[0].textContent).toBe('Gamma Vault');
+    expect(vaultCells[1].textContent).toBe('Alpha Vault');
+    expect(vaultCells[2].textContent).toBe('Beta Vault');
+  });
+
+  it('sorts by vault name from the sort selector', () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/Sort by/i), {
+      target: { value: 'vaultName' },
+    });
+
+    const vaultCells = screen.getAllByText(/Vault$/);
+    expect(vaultCells[0].textContent).toBe('Alpha Vault');
+    expect(vaultCells[1].textContent).toBe('Beta Vault');
+    expect(vaultCells[2].textContent).toBe('Gamma Vault');
+  });
+
   it('clicking Review navigates to the correct ValidationDetail route', () => {
     renderPage();
     const reviewButtons = screen.getAllByRole('button', { name: /Review/i });
-    // first row after asc sort is v-2 (daysRemaining: 2)
+    // first row after deadline ascending sort is v-2.
     fireEvent.click(reviewButtons[0]);
     expect(mockNavigate).toHaveBeenCalledWith('/verifier/queue/v-2');
   });
@@ -148,7 +177,7 @@ describe('PendingValidations', () => {
   });
 
   it('renders a single task without crashing', () => {
-    (useVerifierStore as any).mockReturnValue({
+    mockedUseVerifierStore.mockReturnValue({
       pendingValidations: [makeTasks()[0]],
     });
     renderPage();
@@ -157,7 +186,7 @@ describe('PendingValidations', () => {
   });
 
   it('handles ties in daysRemaining (stable relative order preserved)', () => {
-    (useVerifierStore as any).mockReturnValue({
+    mockedUseVerifierStore.mockReturnValue({
       pendingValidations: [
         { ...makeTasks()[0], id: 'v-a', daysRemaining: 5 },
         { ...makeTasks()[1], id: 'v-b', daysRemaining: 5 },
@@ -201,19 +230,29 @@ describe('PendingValidations', () => {
       expect(deadlineHeader).toHaveAttribute('aria-sort', 'ascending');
     });
 
-    it('aria-sort becomes "descending" after toggling sort to Low to High', () => {
+    it('aria-sort becomes "descending" after toggling sort direction', () => {
       renderPage();
-      fireEvent.click(screen.getByRole('button', { name: /High to Low/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Ascending/i }));
       const deadlineHeader = screen.getByRole('columnheader', { name: /Deadline/i });
       expect(deadlineHeader).toHaveAttribute('aria-sort', 'descending');
     });
 
     it('toggling sort twice restores aria-sort to "ascending"', () => {
       renderPage();
-      fireEvent.click(screen.getByRole('button', { name: /High to Low/i }));
-      fireEvent.click(screen.getByRole('button', { name: /Low to High/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Ascending/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Descending/i }));
       const deadlineHeader = screen.getByRole('columnheader', { name: /Deadline/i });
       expect(deadlineHeader).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('moves aria-sort to the active sort column', () => {
+      renderPage();
+      fireEvent.change(screen.getByLabelText(/Sort by/i), {
+        target: { value: 'amount' },
+      });
+
+      expect(screen.getByRole('columnheader', { name: /Deadline/i })).not.toHaveAttribute('aria-sort');
+      expect(screen.getByRole('columnheader', { name: /Amount at Stake/i })).toHaveAttribute('aria-sort', 'ascending');
     });
 
     it('urgent rows (≤3 days) include a non-color sr-only urgency cue', () => {
@@ -231,7 +270,7 @@ describe('PendingValidations', () => {
     });
 
     it('empty table state renders no table role', () => {
-      (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+      mockedUseVerifierStore.mockReturnValue({ pendingValidations: [] });
       renderPage();
       expect(screen.queryByRole('table')).not.toBeInTheDocument();
     });
@@ -473,7 +512,7 @@ describe('PendingValidations', () => {
 
   describe('empty state messaging', () => {
     it('shows "All caught up!" when there are no pending validations', () => {
-      (useVerifierStore as any).mockReturnValue({ pendingValidations: [] });
+      mockedUseVerifierStore.mockReturnValue({ pendingValidations: [] });
       renderPage();
 
       expect(screen.getByText('All caught up!')).toBeInTheDocument();

--- a/src/utils/__tests__/sortPending.test.ts
+++ b/src/utils/__tests__/sortPending.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { ValidationTask } from '../../Zustand/Store';
+import { sortPending } from '../sortPending';
+
+const task = (
+  id: string,
+  overrides: Partial<ValidationTask> = {},
+): ValidationTask => ({
+  id,
+  vaultName: `Vault ${id}`,
+  owner: '0xowner',
+  amount: '1,000 USDC',
+  deadline: '2026-07-01',
+  daysRemaining: 10,
+  status: 'pending',
+  milestone: 'Milestone',
+  ...overrides,
+});
+
+describe('sortPending', () => {
+  it('sorts deadlines ascending and descending', () => {
+    const tasks = [
+      task('later', { deadline: '2026-08-01', daysRemaining: 40 }),
+      task('soon', { deadline: '2026-06-20', daysRemaining: 2 }),
+      task('middle', { deadline: '2026-07-01', daysRemaining: 10 }),
+    ];
+
+    expect(sortPending(tasks, 'deadline', 'asc').map((t) => t.id)).toEqual([
+      'soon',
+      'middle',
+      'later',
+    ]);
+    expect(sortPending(tasks, 'deadline', 'desc').map((t) => t.id)).toEqual([
+      'later',
+      'middle',
+      'soon',
+    ]);
+  });
+
+  it('parses numeric amounts with separators', () => {
+    const tasks = [
+      task('small', { amount: '500 USDC' }),
+      task('large', { amount: '20,000 USDC' }),
+      task('middle', { amount: '$1,250.50' }),
+    ];
+
+    expect(sortPending(tasks, 'amount', 'desc').map((t) => t.id)).toEqual([
+      'large',
+      'middle',
+      'small',
+    ]);
+  });
+
+  it('sorts vault names case-insensitively', () => {
+    const tasks = [
+      task('c', { vaultName: 'zeta Vault' }),
+      task('a', { vaultName: 'Alpha Vault' }),
+      task('b', { vaultName: 'beta Vault' }),
+    ];
+
+    expect(sortPending(tasks, 'vaultName', 'asc').map((t) => t.id)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  it('preserves relative order for equal keys', () => {
+    const tasks = [
+      task('first', { amount: 'not available' }),
+      task('second', { amount: 'pending' }),
+      task('third', { amount: 'unknown' }),
+    ];
+
+    expect(sortPending(tasks, 'amount', 'asc').map((t) => t.id)).toEqual([
+      'first',
+      'second',
+      'third',
+    ]);
+  });
+
+  it('handles empty lists', () => {
+    expect(sortPending([], 'deadline', 'asc')).toEqual([]);
+  });
+});

--- a/src/utils/sortPending.ts
+++ b/src/utils/sortPending.ts
@@ -1,0 +1,49 @@
+import type { ValidationTask } from '../Zustand/Store';
+
+export type PendingSortKey = 'deadline' | 'amount' | 'vaultName';
+export type SortDirection = 'asc' | 'desc';
+
+const parseAmount = (amount: string): number => {
+  const match = amount.replace(/,/g, '').match(/-?\d+(\.\d+)?/);
+  return match ? Number(match[0]) : 0;
+};
+
+const parseDeadline = (task: ValidationTask): number => {
+  const timestamp = Date.parse(task.deadline);
+  return Number.isNaN(timestamp) ? task.daysRemaining : timestamp;
+};
+
+const compareTasks = (
+  a: ValidationTask,
+  b: ValidationTask,
+  key: PendingSortKey,
+): number => {
+  switch (key) {
+    case 'amount':
+      return parseAmount(a.amount) - parseAmount(b.amount);
+    case 'vaultName':
+      return a.vaultName.localeCompare(b.vaultName, undefined, {
+        sensitivity: 'base',
+        numeric: true,
+      });
+    case 'deadline':
+    default:
+      return parseDeadline(a) - parseDeadline(b);
+  }
+};
+
+export function sortPending(
+  tasks: ValidationTask[],
+  key: PendingSortKey,
+  dir: SortDirection,
+): ValidationTask[] {
+  const direction = dir === 'desc' ? -1 : 1;
+
+  return tasks
+    .map((task, index) => ({ task, index }))
+    .sort((a, b) => {
+      const compared = compareTasks(a.task, b.task, key);
+      return compared === 0 ? a.index - b.index : compared * direction;
+    })
+    .map(({ task }) => task);
+}


### PR DESCRIPTION
## Summary
- Add a pure `sortPending(tasks, key, dir)` comparator for deadline, amount, and vault-name sorting
- Replace the urgency-only toggle on `PendingValidations` with a sort selector plus direction toggle
- Add the missing search and milestone filter controls so sorting composes with `filterPending`
- Add focused utility/page tests and design-system documentation

Closes #458

## Verification
- `npm exec vitest -- run src/utils/__tests__/sortPending.test.ts src/pages/__tests__/PendingValidations.test.tsx src/pages/__tests__/PendingValidations.batch.test.tsx`
- `npm exec eslint -- src/utils/sortPending.ts src/utils/__tests__/sortPending.test.ts src/pages/PendingValidations.tsx src/pages/__tests__/PendingValidations.test.tsx src/pages/__tests__/PendingValidations.batch.test.tsx`

## Notes
- `npm run build` is currently blocked by unrelated baseline syntax errors in `src/utils/__tests__/csv.analytics.test.ts` and `src/utils/__tests__/verifierMetrics.test.ts`.