### PR TITLE
Add multi-milestone CreateVault repeater

### DIFF
--- a/design-system/documentation/create-vault-milestones.md
+++ b/design-system/documentation/create-vault-milestones.md
@@ -1,0 +1,27 @@
+# Create Vault Milestones
+
+The Create Vault form accepts one or more milestone rows. Each row contains:
+
+- `title`: a short label shown in the review step and later milestone surfaces.
+- `criteria`: the validation requirement the verifier should check.
+
+## Validation
+
+At least one milestone is required. Every row must have a non-empty title and
+non-empty criteria. Titles are compared case-insensitively after trimming, so
+duplicate titles are blocked before review.
+
+When validation fails, the form summary lists all milestone errors and focus
+moves to the first invalid milestone field after the core vault fields pass.
+
+## Editing
+
+Creators can add rows, remove rows, and reorder rows with the row controls.
+Removing the final row is allowed so the required-row validation path remains
+visible and testable.
+
+## Review
+
+The review step lists milestones in the submitted order with each title and its
+criteria. The legacy single-milestone review prop still renders as a one-row
+milestone list for compatibility with older callers.

--- a/src/components/CreateVaultReview.tsx
+++ b/src/components/CreateVaultReview.tsx
@@ -1,5 +1,10 @@
 import { Text } from "./Text";
 
+export interface CreateVaultReviewMilestone {
+  title: string;
+  criteria: string;
+}
+
 interface CreateVaultReviewProps {
   amount: string;
   deadline: string;
@@ -7,6 +12,7 @@ interface CreateVaultReviewProps {
   failureAddress: string;
   verifierAddress?: string;
   milestone?: string;
+  milestones?: CreateVaultReviewMilestone[];
   onBack?: () => void;
   onConfirm?: () => void;
 }
@@ -42,9 +48,17 @@ export function CreateVaultReview({
   failureAddress,
   verifierAddress,
   milestone,
+  milestones,
   onBack,
   onConfirm,
 }: CreateVaultReviewProps) {
+  const reviewMilestones =
+    milestones && milestones.length > 0
+      ? milestones
+      : milestone
+        ? [{ title: milestone, criteria: "" }]
+        : [];
+
   return (
     <div
       style={{
@@ -105,16 +119,39 @@ export function CreateVaultReview({
           </div>
         ) : null}
 
-        {milestone ? (
+        {reviewMilestones.length > 0 ? (
           <div
-            style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}
+            style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
           >
             <Text role="caption" as="span" style={{ color: "var(--muted)" }}>
-              Milestone
+              Milestones
             </Text>
-            <Text role="body" as="p">
-              {milestone}
-            </Text>
+            <ol
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.5rem",
+                margin: 0,
+                paddingLeft: "1.25rem",
+              }}
+            >
+              {reviewMilestones.map((item, index) => (
+                <li key={`${item.title}-${index}`}>
+                  <Text role="body" as="p" style={{ fontWeight: 700 }}>
+                    {item.title}
+                  </Text>
+                  {item.criteria ? (
+                    <Text
+                      role="caption"
+                      as="p"
+                      style={{ color: "var(--muted)" }}
+                    >
+                      {item.criteria}
+                    </Text>
+                  ) : null}
+                </li>
+              ))}
+            </ol>
           </div>
         ) : null}
       </div>

--- a/src/components/__tests__/CreateVaultReview.test.tsx
+++ b/src/components/__tests__/CreateVaultReview.test.tsx
@@ -15,7 +15,16 @@ describe("CreateVaultReview", () => {
         successAddress={successAddress}
         failureAddress={failureAddress}
         verifierAddress={verifierAddress}
-        milestone="Deliverables approved"
+        milestones={[
+          {
+            title: "Design approved",
+            criteria: "Verifier signs the design handoff",
+          },
+          {
+            title: "Launch ready",
+            criteria: "Deployment checklist is complete",
+          },
+        ]}
       />,
     );
 
@@ -27,6 +36,29 @@ describe("CreateVaultReview", () => {
     expect(screen.getByText(successAddress)).toBeInTheDocument();
     expect(screen.getByText(failureAddress)).toBeInTheDocument();
     expect(screen.getByText("Verifier address")).toBeInTheDocument();
-    expect(screen.getByText("Milestone")).toBeInTheDocument();
+    expect(screen.getByText("Milestones")).toBeInTheDocument();
+    expect(screen.getByText("Design approved")).toBeInTheDocument();
+    expect(
+      screen.getByText("Verifier signs the design handoff"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Launch ready")).toBeInTheDocument();
+    expect(
+      screen.getByText("Deployment checklist is complete"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the legacy single milestone prop rendering", () => {
+    render(
+      <CreateVaultReview
+        amount="100"
+        deadline="2030-01-01T00:00"
+        successAddress={`G${"A".repeat(55)}`}
+        failureAddress={`G${"B".repeat(55)}`}
+        milestone="Deliverables approved"
+      />,
+    );
+
+    expect(screen.getByText("Milestones")).toBeInTheDocument();
+    expect(screen.getByText("Deliverables approved")).toBeInTheDocument();
   });
 });

--- a/src/pages/CreateVault.tsx
+++ b/src/pages/CreateVault.tsx
@@ -1,7 +1,10 @@
 import { useRef, useState } from "react";
 import { Text } from "../components/Text";
 import { Field } from "../components/Field";
-import type { CreateVaultErrors } from "../utils/vaultValidation";
+import type {
+  CreateVaultErrors,
+  CreateVaultMilestoneInput,
+} from "../utils/vaultValidation";
 import {
   exceedsBalance,
   hasCreateVaultErrors,
@@ -12,7 +15,23 @@ import { CreateVaultReview } from "../components/CreateVaultReview";
 import { formatUsdcInput, parseUsdcInput } from "../utils/usdcInput";
 import { logger } from "../utils/logger";
 import { useWallet } from "../context/WalletContext";
-import { DEADLINE_PRESETS, computeFutureDeadline, getPresetLabel } from "../utils/deadlinePresets";
+import {
+  DEADLINE_PRESETS,
+  computeFutureDeadline,
+  getPresetLabel,
+} from "../utils/deadlinePresets";
+
+interface MilestoneFormRow extends CreateVaultMilestoneInput {
+  id: string;
+}
+
+function createMilestoneRow(index: number): MilestoneFormRow {
+  return {
+    id: `milestone-${Date.now()}-${index}`,
+    title: "",
+    criteria: "",
+  };
+}
 
 export default function CreateVault() {
   const { balance, balanceStatus } = useWallet();
@@ -20,10 +39,19 @@ export default function CreateVault() {
   const deadlineRef = useRef<HTMLInputElement>(null);
   const successAddressRef = useRef<HTMLInputElement>(null);
   const failureAddressRef = useRef<HTMLInputElement>(null);
+  const milestoneTitleRefs = useRef<Record<string, HTMLInputElement | null>>(
+    {},
+  );
+  const milestoneCriteriaRefs = useRef<Record<string, HTMLInputElement | null>>(
+    {},
+  );
   const [amount, setAmount] = useState("");
   const [deadline, setDeadline] = useState("");
   const [successAddress, setSuccessAddress] = useState("");
   const [failureAddress, setFailureAddress] = useState("");
+  const [milestones, setMilestones] = useState<MilestoneFormRow[]>([
+    createMilestoneRow(0),
+  ]);
   const [errors, setErrors] = useState<CreateVaultErrors>({});
   const [evidenceUrl, setEvidenceUrl] = useState<string | undefined>();
   const [showReview, setShowReview] = useState(false);
@@ -43,8 +71,90 @@ export default function CreateVault() {
   };
 
   const errorEntries = errorFieldOrder.flatMap((field) =>
-    errors[field] ? [{ field, message: errors[field] as string }] : [],
+    errors[field] ? [{ key: field, message: errors[field] as string }] : [],
   );
+  const milestoneErrorEntries = [
+    ...(errors.milestones?.form
+      ? [{ key: "milestones-form", message: errors.milestones.form }]
+      : []),
+    ...(errors.milestones?.rows ?? []).flatMap((row, rowIndex) =>
+      row
+        ? Object.values(row).map((message, errorIndex) => ({
+            key: `milestone-${rowIndex}-${errorIndex}`,
+            message,
+          }))
+        : [],
+    ),
+  ];
+  const allErrorEntries = [...errorEntries, ...milestoneErrorEntries];
+
+  const clearMilestoneErrors = () => {
+    setErrors((current) => ({ ...current, milestones: undefined }));
+  };
+
+  const updateMilestone = (
+    id: string,
+    field: keyof CreateVaultMilestoneInput,
+    value: string,
+  ) => {
+    setMilestones((current) =>
+      current.map((milestone) =>
+        milestone.id === id ? { ...milestone, [field]: value } : milestone,
+      ),
+    );
+    clearMilestoneErrors();
+  };
+
+  const addMilestone = () => {
+    setMilestones((current) => [
+      ...current,
+      createMilestoneRow(current.length),
+    ]);
+    clearMilestoneErrors();
+  };
+
+  const removeMilestone = (id: string) => {
+    setMilestones((current) =>
+      current.filter((milestone) => milestone.id !== id),
+    );
+    clearMilestoneErrors();
+  };
+
+  const moveMilestone = (id: string, direction: "up" | "down") => {
+    setMilestones((current) => {
+      const index = current.findIndex((milestone) => milestone.id === id);
+      const targetIndex = direction === "up" ? index - 1 : index + 1;
+      if (index === -1 || targetIndex < 0 || targetIndex >= current.length) {
+        return current;
+      }
+
+      const next = [...current];
+      [next[index], next[targetIndex]] = [next[targetIndex], next[index]];
+      return next;
+    });
+    clearMilestoneErrors();
+  };
+
+  const focusFirstMilestoneError = (nextErrors: CreateVaultErrors) => {
+    const rowIndex = nextErrors.milestones?.rows?.findIndex(Boolean) ?? -1;
+    if (rowIndex < 0) return false;
+
+    const row = nextErrors.milestones?.rows?.[rowIndex];
+    const milestone = milestones[rowIndex];
+    if (!row || !milestone) return false;
+
+    if (row.title) {
+      milestoneTitleRefs.current[milestone.id]?.focus();
+      return true;
+    }
+
+    if (row.criteria) {
+      milestoneCriteriaRefs.current[milestone.id]?.focus();
+      return true;
+    }
+
+    return false;
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -53,13 +163,18 @@ export default function CreateVault() {
       deadline,
       successAddress,
       failureAddress,
+      milestones,
     });
     setErrors(nextErrors);
 
     if (hasCreateVaultErrors(nextErrors)) {
-      const firstInvalidField = errorFieldOrder.find((field) => nextErrors[field]);
+      const firstInvalidField = errorFieldOrder.find(
+        (field) => nextErrors[field],
+      );
       if (firstInvalidField) {
         fieldRefs[firstInvalidField].current?.focus();
+      } else {
+        focusFirstMilestoneError(nextErrors);
       }
       return;
     }
@@ -73,6 +188,10 @@ export default function CreateVault() {
       deadline,
       successAddress,
       failureAddress,
+      milestones: milestones.map(({ title, criteria }) => ({
+        title,
+        criteria,
+      })),
       evidenceUrl,
     });
   };
@@ -101,12 +220,13 @@ export default function CreateVault() {
           deadline={deadline}
           successAddress={successAddress}
           failureAddress={failureAddress}
+          milestones={milestones}
           onBack={handleBackToEdit}
           onConfirm={handleConfirm}
         />
       ) : (
         <>
-          {errorEntries.length > 0 && (
+          {allErrorEntries.length > 0 && (
             <div
               role="alert"
               aria-live="assertive"
@@ -114,7 +234,8 @@ export default function CreateVault() {
                 border: "1px solid var(--danger)",
                 borderRadius: "var(--radius)",
                 padding: "0.75rem",
-                background: "color-mix(in srgb, var(--danger) 10%, var(--surface))",
+                background:
+                  "color-mix(in srgb, var(--danger) 10%, var(--surface))",
                 marginBottom: "1rem",
                 maxWidth: 400,
               }}
@@ -126,9 +247,15 @@ export default function CreateVault() {
               >
                 Please fix the highlighted fields before creating the vault.
               </Text>
-              <ul style={{ margin: 0, paddingLeft: "1.25rem", color: "var(--danger)" }}>
-                {errorEntries.map(({ field, message }, index) => (
-                  <li key={`${field}-${index}`}>{message}</li>
+              <ul
+                style={{
+                  margin: 0,
+                  paddingLeft: "1.25rem",
+                  color: "var(--danger)",
+                }}
+              >
+                {allErrorEntries.map(({ key, message }, index) => (
+                  <li key={`${key}-${index}`}>{message}</li>
                 ))}
               </ul>
             </div>
@@ -162,7 +289,11 @@ export default function CreateVault() {
             {balanceStatus === "success" && exceedsBalance(amount, balance) && (
               <p
                 role="status"
-                style={{ color: "var(--warning)", margin: 0, fontSize: "0.875rem" }}
+                style={{
+                  color: "var(--warning)",
+                  margin: 0,
+                  fontSize: "0.875rem",
+                }}
               >
                 Amount exceeds your available USDC balance ({balance}).
               </p>
@@ -175,7 +306,10 @@ export default function CreateVault() {
                   onClick={() => {
                     const days = parseInt(preset, 10);
                     setDeadline(computeFutureDeadline(days));
-                    setErrors((current) => ({ ...current, deadline: undefined }));
+                    setErrors((current) => ({
+                      ...current,
+                      deadline: undefined,
+                    }));
                   }}
                   style={{
                     padding: "0.4rem 0.875rem",
@@ -239,6 +373,183 @@ export default function CreateVault() {
               error={errors.failureAddress}
               required
             />
+            <section
+              aria-labelledby="create-vault-milestones-heading"
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.75rem",
+              }}
+            >
+              <div>
+                <Text
+                  role="body"
+                  as="h2"
+                  id="create-vault-milestones-heading"
+                  style={{ marginBottom: "0.25rem" }}
+                >
+                  Milestones
+                </Text>
+                <Text role="caption" as="p" style={{ color: "var(--muted)" }}>
+                  Add each delivery checkpoint with clear validation criteria.
+                </Text>
+              </div>
+
+              {errors.milestones?.form ? (
+                <Text
+                  role="caption"
+                  as="p"
+                  id="create-vault-milestones-error"
+                  style={{ color: "var(--danger)" }}
+                >
+                  {errors.milestones.form}
+                </Text>
+              ) : null}
+
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "0.875rem",
+                }}
+              >
+                {milestones.map((milestone, index) => {
+                  const rowErrors = errors.milestones?.rows?.[index];
+                  const canMoveUp = index > 0;
+                  const canMoveDown = index < milestones.length - 1;
+
+                  return (
+                    <fieldset
+                      key={milestone.id}
+                      style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "0.75rem",
+                        margin: 0,
+                        padding: "0.875rem",
+                        border: "1px solid var(--border)",
+                        borderRadius: "var(--radius)",
+                        background: "var(--bg)",
+                      }}
+                    >
+                      <legend>
+                        <Text role="caption" as="span">
+                          Milestone {index + 1}
+                        </Text>
+                      </legend>
+                      <Field
+                        ref={(node) => {
+                          milestoneTitleRefs.current[milestone.id] = node;
+                        }}
+                        id={`create-vault-milestone-${index}-title`}
+                        label={`Milestone ${index + 1} title`}
+                        type="text"
+                        value={milestone.title}
+                        onChange={(e) =>
+                          updateMilestone(milestone.id, "title", e.target.value)
+                        }
+                        placeholder="Design approved"
+                        error={rowErrors?.title}
+                        required
+                      />
+                      <Field
+                        ref={(node) => {
+                          milestoneCriteriaRefs.current[milestone.id] = node;
+                        }}
+                        id={`create-vault-milestone-${index}-criteria`}
+                        label={`Milestone ${index + 1} criteria`}
+                        type="text"
+                        value={milestone.criteria}
+                        onChange={(e) =>
+                          updateMilestone(
+                            milestone.id,
+                            "criteria",
+                            e.target.value,
+                          )
+                        }
+                        placeholder="Signed approval from the verifier"
+                        error={rowErrors?.criteria}
+                        required
+                      />
+                      <div
+                        style={{
+                          display: "flex",
+                          gap: "0.5rem",
+                          flexWrap: "wrap",
+                        }}
+                      >
+                        <button
+                          type="button"
+                          onClick={() => moveMilestone(milestone.id, "up")}
+                          disabled={!canMoveUp}
+                          aria-label={`Move milestone ${index + 1} up`}
+                          style={{
+                            padding: "0.4rem 0.75rem",
+                            border: "1px solid var(--border)",
+                            borderRadius: "var(--radius)",
+                            background: "var(--surface)",
+                            color: "var(--text)",
+                            cursor: canMoveUp ? "pointer" : "not-allowed",
+                            opacity: canMoveUp ? 1 : 0.5,
+                          }}
+                        >
+                          Move up
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => moveMilestone(milestone.id, "down")}
+                          disabled={!canMoveDown}
+                          aria-label={`Move milestone ${index + 1} down`}
+                          style={{
+                            padding: "0.4rem 0.75rem",
+                            border: "1px solid var(--border)",
+                            borderRadius: "var(--radius)",
+                            background: "var(--surface)",
+                            color: "var(--text)",
+                            cursor: canMoveDown ? "pointer" : "not-allowed",
+                            opacity: canMoveDown ? 1 : 0.5,
+                          }}
+                        >
+                          Move down
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => removeMilestone(milestone.id)}
+                          aria-label={`Remove milestone ${index + 1}`}
+                          style={{
+                            padding: "0.4rem 0.75rem",
+                            border: "1px solid var(--danger)",
+                            borderRadius: "var(--radius)",
+                            background: "transparent",
+                            color: "var(--danger)",
+                            cursor: "pointer",
+                          }}
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </fieldset>
+                  );
+                })}
+              </div>
+
+              <button
+                type="button"
+                onClick={addMilestone}
+                style={{
+                  alignSelf: "flex-start",
+                  padding: "0.55rem 0.875rem",
+                  border: "1px solid var(--accent)",
+                  borderRadius: "var(--radius)",
+                  background: "transparent",
+                  color: "var(--accent)",
+                  cursor: "pointer",
+                  fontWeight: 600,
+                }}
+              >
+                Add milestone
+              </button>
+            </section>
             <EvidenceUpload onChange={setEvidenceUrl} />
             <button
               type="submit"

--- a/src/pages/__tests__/CreateVault.test.tsx
+++ b/src/pages/__tests__/CreateVault.test.tsx
@@ -16,6 +16,14 @@ function fillField(label: RegExp, value: string) {
   fireEvent.change(screen.getByLabelText(label), { target: { value } });
 }
 
+function fillFirstMilestone(
+  title = "Design approved",
+  criteria = "Verifier signs off",
+) {
+  fillField(/milestone 1 title/i, title);
+  fillField(/milestone 1 criteria/i, criteria);
+}
+
 describe("CreateVault", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -45,6 +53,8 @@ describe("CreateVault", () => {
     expect(
       screen.getAllByText("Enter a valid Stellar public key starting with G."),
     ).toHaveLength(4);
+    expect(screen.getAllByText("Enter a milestone title.")).toHaveLength(2);
+    expect(screen.getAllByText("Enter milestone criteria.")).toHaveLength(2);
 
     const amount = screen.getByLabelText(/amount/i);
     expect(amount).toHaveAttribute("aria-invalid", "true");
@@ -81,6 +91,7 @@ describe("CreateVault", () => {
     fillField(/deadline/i, "2030-01-01T00:00");
     fillField(/success destination/i, successAddress);
     fillField(/failure destination/i, successAddress);
+    fillFirstMilestone();
     fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
 
     expect(
@@ -104,6 +115,7 @@ describe("CreateVault", () => {
     fillField(/deadline/i, "2030-01-01T00:00");
     fillField(/success destination/i, successAddress);
     fillField(/failure destination/i, failureAddress);
+    fillFirstMilestone("Prototype", "Prototype approved by verifier");
     fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
 
     expect(
@@ -112,6 +124,10 @@ describe("CreateVault", () => {
     expect(
       screen.queryByText(/Enter a positive USDC amount/),
     ).not.toBeInTheDocument();
+    expect(screen.getByText("Prototype")).toBeInTheDocument();
+    expect(
+      screen.getByText("Prototype approved by verifier"),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /confirm vault/i }));
 
@@ -120,6 +136,12 @@ describe("CreateVault", () => {
       deadline: "2030-01-01T00:00",
       successAddress,
       failureAddress,
+      milestones: [
+        {
+          title: "Prototype",
+          criteria: "Prototype approved by verifier",
+        },
+      ],
       evidenceUrl: undefined,
     });
     expect(consoleDebug).toHaveBeenCalledTimes(1);
@@ -132,6 +154,7 @@ describe("CreateVault", () => {
     fillField(/deadline/i, "2030-02-02T00:00");
     fillField(/success destination/i, successAddress);
     fillField(/failure destination/i, failureAddress);
+    fillFirstMilestone("Launch", "Launch evidence uploaded");
     fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
 
     fireEvent.click(screen.getByRole("button", { name: /back to edit/i }));
@@ -143,6 +166,10 @@ describe("CreateVault", () => {
     );
     expect(screen.getByLabelText(/failure destination/i)).toHaveValue(
       failureAddress,
+    );
+    expect(screen.getByLabelText(/milestone 1 title/i)).toHaveValue("Launch");
+    expect(screen.getByLabelText(/milestone 1 criteria/i)).toHaveValue(
+      "Launch evidence uploaded",
     );
   });
 
@@ -210,6 +237,7 @@ describe("CreateVault", () => {
     fireEvent.change(screen.getByLabelText(/failure destination/i), {
       target: { value: failureAddress },
     });
+    fillFirstMilestone();
 
     fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
     fireEvent.click(screen.getByRole("button", { name: /confirm vault/i }));
@@ -276,31 +304,88 @@ describe("CreateVault", () => {
   });
 
   it("selecting preset clears deadline error", () => {
-    const consoleDebug = vi
-      .spyOn(console, "debug")
-      .mockImplementation(() => undefined);
+    vi.spyOn(console, "debug").mockImplementation(() => undefined);
     render(<CreateVault />);
 
     fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
-    expect(screen.getByText("Choose a future deadline.")).toBeInTheDocument();
+    expect(screen.getAllByText("Choose a future deadline.")).toHaveLength(2);
 
     fireEvent.click(screen.getByRole("button", { name: "30 days" }));
-    expect(screen.queryByText("Choose a future deadline.")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Choose a future deadline."),
+    ).not.toBeInTheDocument();
   });
 
   it("computed deadline satisfies isFutureDeadline validation", () => {
-    const consoleDebug = vi
-      .spyOn(console, "debug")
-      .mockImplementation(() => undefined);
+    vi.spyOn(console, "debug").mockImplementation(() => undefined);
     render(<CreateVault />);
 
     fillField(/amount/i, "100");
     fillField(/success destination/i, successAddress);
     fillField(/failure destination/i, failureAddress);
+    fillFirstMilestone();
 
     fireEvent.click(screen.getByRole("button", { name: "90 days" }));
     fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
 
-    expect(screen.queryByText("Choose a future deadline.")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Choose a future deadline."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("adds, reorders, and removes milestone rows before review", () => {
+    render(<CreateVault />);
+
+    fillFirstMilestone("First", "First criteria");
+    fireEvent.click(screen.getByRole("button", { name: /add milestone/i }));
+    fillField(/milestone 2 title/i, "Second");
+    fillField(/milestone 2 criteria/i, "Second criteria");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /move milestone 2 up/i }),
+    );
+
+    expect(screen.getByLabelText(/milestone 1 title/i)).toHaveValue("Second");
+    expect(screen.getByLabelText(/milestone 2 title/i)).toHaveValue("First");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /remove milestone 2/i }),
+    );
+
+    expect(screen.getByLabelText(/milestone 1 title/i)).toHaveValue("Second");
+    expect(
+      screen.queryByLabelText(/milestone 2 title/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("blocks duplicate milestone titles", () => {
+    render(<CreateVault />);
+
+    fillField(/amount/i, "100");
+    fillField(/deadline/i, "2030-01-01T00:00");
+    fillField(/success destination/i, successAddress);
+    fillField(/failure destination/i, failureAddress);
+    fillFirstMilestone("Launch", "First criteria");
+    fireEvent.click(screen.getByRole("button", { name: /add milestone/i }));
+    fillField(/milestone 2 title/i, "launch");
+    fillField(/milestone 2 criteria/i, "Second criteria");
+
+    fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
+
+    expect(
+      screen.getAllByText("Milestone titles must be unique."),
+    ).toHaveLength(4);
+    expect(screen.getByLabelText(/milestone 1 title/i)).toHaveFocus();
+  });
+
+  it("requires at least one milestone after removing the last row", () => {
+    render(<CreateVault />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /remove milestone 1/i }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
+
+    expect(screen.getAllByText("Add at least one milestone.")).toHaveLength(2);
   });
 });

--- a/src/utils/__tests__/vaultValidation.test.ts
+++ b/src/utils/__tests__/vaultValidation.test.ts
@@ -1,83 +1,89 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 import {
   exceedsBalance,
   isFutureDeadline,
   isValidStellarAddress,
   isValidUsdcAmount,
+  validateMilestones,
   validateCreateVault,
-} from '../vaultValidation';
+} from "../vaultValidation";
 
-const successAddress = `G${'A'.repeat(55)}`;
-const failureAddress = `G${'B'.repeat(55)}`;
-const now = new Date('2026-06-18T00:00:00Z');
+const successAddress = `G${"A".repeat(55)}`;
+const failureAddress = `G${"B".repeat(55)}`;
+const now = new Date("2026-06-18T00:00:00Z");
 
-describe('vaultValidation', () => {
-  it('validates positive USDC amounts with up to 7 decimals', () => {
-    expect(isValidUsdcAmount('1')).toBe(true);
-    expect(isValidUsdcAmount('0.0000001')).toBe(true);
-    expect(isValidUsdcAmount('0')).toBe(false);
-    expect(isValidUsdcAmount('-1')).toBe(false);
-    expect(isValidUsdcAmount('1.12345678')).toBe(false);
-    expect(isValidUsdcAmount('1e3')).toBe(false);
+describe("vaultValidation", () => {
+  it("validates positive USDC amounts with up to 7 decimals", () => {
+    expect(isValidUsdcAmount("1")).toBe(true);
+    expect(isValidUsdcAmount("0.0000001")).toBe(true);
+    expect(isValidUsdcAmount("0")).toBe(false);
+    expect(isValidUsdcAmount("-1")).toBe(false);
+    expect(isValidUsdcAmount("1.12345678")).toBe(false);
+    expect(isValidUsdcAmount("1e3")).toBe(false);
   });
 
-  it('validates Stellar public key shape', () => {
+  it("validates Stellar public key shape", () => {
     expect(isValidStellarAddress(successAddress)).toBe(true);
     expect(isValidStellarAddress(` ${successAddress} `)).toBe(true);
-    expect(isValidStellarAddress(`M${'A'.repeat(55)}`)).toBe(false);
-    expect(isValidStellarAddress(`G${'A'.repeat(54)}`)).toBe(false);
-    expect(isValidStellarAddress(`G${'0'.repeat(55)}`)).toBe(false);
+    expect(isValidStellarAddress(`M${"A".repeat(55)}`)).toBe(false);
+    expect(isValidStellarAddress(`G${"A".repeat(54)}`)).toBe(false);
+    expect(isValidStellarAddress(`G${"0".repeat(55)}`)).toBe(false);
   });
 
-  it('requires a valid future deadline', () => {
-    expect(isFutureDeadline('2026-06-18T00:00:01Z', now)).toBe(true);
-    expect(isFutureDeadline('2026-06-18T00:00:00Z', now)).toBe(false);
-    expect(isFutureDeadline('not-a-date', now)).toBe(false);
+  it("requires a valid future deadline", () => {
+    expect(isFutureDeadline("2026-06-18T00:00:01Z", now)).toBe(true);
+    expect(isFutureDeadline("2026-06-18T00:00:00Z", now)).toBe(false);
+    expect(isFutureDeadline("not-a-date", now)).toBe(false);
   });
 
-  it('returns field-specific errors for invalid create-vault values', () => {
+  it("returns field-specific errors for invalid create-vault values", () => {
     const errors = validateCreateVault(
       {
-        amount: '1.12345678',
-        deadline: '2020-01-01T00:00:00Z',
-        successAddress: 'bad',
-        failureAddress: 'bad',
+        amount: "1.12345678",
+        deadline: "2020-01-01T00:00:00Z",
+        successAddress: "bad",
+        failureAddress: "bad",
+        milestones: [],
       },
       now,
     );
 
     expect(errors).toEqual({
-      amount: 'Enter a positive USDC amount with up to 7 decimal places.',
-      deadline: 'Choose a future deadline.',
-      successAddress: 'Enter a valid Stellar public key starting with G.',
-      failureAddress: 'Enter a valid Stellar public key starting with G.',
+      amount: "Enter a positive USDC amount with up to 7 decimal places.",
+      deadline: "Choose a future deadline.",
+      successAddress: "Enter a valid Stellar public key starting with G.",
+      failureAddress: "Enter a valid Stellar public key starting with G.",
+      milestones: { form: "Add at least one milestone." },
     });
   });
 
-  it('rejects identical success and failure destinations', () => {
+  it("rejects identical success and failure destinations", () => {
     const errors = validateCreateVault(
       {
-        amount: '100',
-        deadline: '2026-06-19T00:00:00Z',
+        amount: "100",
+        deadline: "2026-06-19T00:00:00Z",
         successAddress,
         failureAddress: successAddress,
+        milestones: [{ title: "Launch", criteria: "Verifier approval" }],
       },
       now,
     );
 
     expect(errors).toEqual({
-      failureAddress: 'Failure destination must be different from success destination.',
+      failureAddress:
+        "Failure destination must be different from success destination.",
     });
   });
 
-  it('returns no errors for valid create-vault values', () => {
+  it("returns no errors for valid create-vault values", () => {
     expect(
       validateCreateVault(
         {
-          amount: '100.1234567',
-          deadline: '2026-06-19T00:00:00Z',
+          amount: "100.1234567",
+          deadline: "2026-06-19T00:00:00Z",
           successAddress,
           failureAddress,
+          milestones: [{ title: "Launch", criteria: "Verifier approval" }],
         },
         now,
       ),
@@ -85,33 +91,77 @@ describe('vaultValidation', () => {
   });
 });
 
-describe('exceedsBalance', () => {
-  it('returns true when amount is greater than balance', () => {
-    expect(exceedsBalance('200', '100')).toBe(true);
+describe("validateMilestones", () => {
+  it("requires at least one milestone", () => {
+    expect(validateMilestones([])).toEqual({
+      form: "Add at least one milestone.",
+    });
   });
 
-  it('returns false when amount equals balance', () => {
-    expect(exceedsBalance('100', '100')).toBe(false);
+  it("requires title and criteria for each row", () => {
+    expect(validateMilestones([{ title: "", criteria: "  " }])).toEqual({
+      rows: [
+        {
+          title: "Enter a milestone title.",
+          criteria: "Enter milestone criteria.",
+        },
+      ],
+    });
   });
 
-  it('returns false when amount is less than balance', () => {
-    expect(exceedsBalance('50', '100')).toBe(false);
+  it("rejects duplicate titles case-insensitively", () => {
+    expect(
+      validateMilestones([
+        { title: "Launch", criteria: "First approval" },
+        { title: " launch ", criteria: "Second approval" },
+      ]),
+    ).toEqual({
+      rows: [
+        { title: "Milestone titles must be unique." },
+        { title: "Milestone titles must be unique." },
+      ],
+    });
   });
 
-  it('returns false when balance is null (unknown)', () => {
-    expect(exceedsBalance('100', null)).toBe(false);
+  it("accepts long criteria text without truncation", () => {
+    expect(
+      validateMilestones([
+        {
+          title: "Final delivery",
+          criteria: "A".repeat(1000),
+        },
+      ]),
+    ).toBeUndefined();
+  });
+});
+
+describe("exceedsBalance", () => {
+  it("returns true when amount is greater than balance", () => {
+    expect(exceedsBalance("200", "100")).toBe(true);
   });
 
-  it('returns false when amount is not a finite number', () => {
-    expect(exceedsBalance('abc', '100')).toBe(false);
+  it("returns false when amount equals balance", () => {
+    expect(exceedsBalance("100", "100")).toBe(false);
   });
 
-  it('returns false when balance is not a finite number', () => {
-    expect(exceedsBalance('100', 'abc')).toBe(false);
+  it("returns false when amount is less than balance", () => {
+    expect(exceedsBalance("50", "100")).toBe(false);
   });
 
-  it('handles decimal amounts correctly', () => {
-    expect(exceedsBalance('100.01', '100')).toBe(true);
-    expect(exceedsBalance('99.99', '100')).toBe(false);
+  it("returns false when balance is null (unknown)", () => {
+    expect(exceedsBalance("100", null)).toBe(false);
+  });
+
+  it("returns false when amount is not a finite number", () => {
+    expect(exceedsBalance("abc", "100")).toBe(false);
+  });
+
+  it("returns false when balance is not a finite number", () => {
+    expect(exceedsBalance("100", "abc")).toBe(false);
+  });
+
+  it("handles decimal amounts correctly", () => {
+    expect(exceedsBalance("100.01", "100")).toBe(true);
+    expect(exceedsBalance("99.99", "100")).toBe(false);
   });
 });

--- a/src/utils/vaultValidation.ts
+++ b/src/utils/vaultValidation.ts
@@ -3,9 +3,31 @@ export interface CreateVaultFormValues {
   deadline: string;
   successAddress: string;
   failureAddress: string;
+  milestones?: CreateVaultMilestoneInput[];
 }
 
-export type CreateVaultErrors = Partial<Record<keyof CreateVaultFormValues, string>>;
+export interface CreateVaultMilestoneInput {
+  title: string;
+  criteria: string;
+}
+
+export interface CreateVaultMilestoneRowErrors {
+  title?: string;
+  criteria?: string;
+}
+
+export interface CreateVaultMilestoneErrors {
+  form?: string;
+  rows?: CreateVaultMilestoneRowErrors[];
+}
+
+type CreateVaultFieldName = Exclude<keyof CreateVaultFormValues, "milestones">;
+
+export type CreateVaultErrors = Partial<
+  Record<CreateVaultFieldName, string>
+> & {
+  milestones?: CreateVaultMilestoneErrors;
+};
 
 const STELLAR_PUBLIC_KEY = /^G[A-Z2-7]{55}$/;
 const USDC_AMOUNT = /^(?:0|[1-9]\d*)(?:\.\d{1,7})?$/;
@@ -34,21 +56,27 @@ export function validateCreateVault(
   const failureAddress = values.failureAddress.trim();
 
   if (!isValidUsdcAmount(values.amount)) {
-    errors.amount = 'Enter a positive USDC amount with up to 7 decimal places.';
+    errors.amount = "Enter a positive USDC amount with up to 7 decimal places.";
   }
 
   if (!isFutureDeadline(values.deadline, now)) {
-    errors.deadline = 'Choose a future deadline.';
+    errors.deadline = "Choose a future deadline.";
   }
 
   if (!isValidStellarAddress(successAddress)) {
-    errors.successAddress = 'Enter a valid Stellar public key starting with G.';
+    errors.successAddress = "Enter a valid Stellar public key starting with G.";
   }
 
   if (!isValidStellarAddress(failureAddress)) {
-    errors.failureAddress = 'Enter a valid Stellar public key starting with G.';
+    errors.failureAddress = "Enter a valid Stellar public key starting with G.";
   } else if (successAddress === failureAddress) {
-    errors.failureAddress = 'Failure destination must be different from success destination.';
+    errors.failureAddress =
+      "Failure destination must be different from success destination.";
+  }
+
+  const milestoneErrors = validateMilestones(values.milestones);
+  if (milestoneErrors) {
+    errors.milestones = milestoneErrors;
   }
 
   return errors;
@@ -58,12 +86,58 @@ export function hasCreateVaultErrors(errors: CreateVaultErrors): boolean {
   return Object.keys(errors).length > 0;
 }
 
+export function validateMilestones(
+  milestones: CreateVaultMilestoneInput[] | undefined,
+): CreateVaultMilestoneErrors | undefined {
+  if (!milestones || milestones.length === 0) {
+    return { form: "Add at least one milestone." };
+  }
+
+  const rows: CreateVaultMilestoneRowErrors[] = [];
+  const titleCounts = new Map<string, number>();
+
+  milestones.forEach((milestone) => {
+    const normalizedTitle = milestone.title.trim().toLowerCase();
+    if (normalizedTitle) {
+      titleCounts.set(
+        normalizedTitle,
+        (titleCounts.get(normalizedTitle) ?? 0) + 1,
+      );
+    }
+  });
+
+  milestones.forEach((milestone, index) => {
+    const row: CreateVaultMilestoneRowErrors = {};
+    const title = milestone.title.trim();
+    const criteria = milestone.criteria.trim();
+
+    if (!title) {
+      row.title = "Enter a milestone title.";
+    } else if ((titleCounts.get(title.toLowerCase()) ?? 0) > 1) {
+      row.title = "Milestone titles must be unique.";
+    }
+
+    if (!criteria) {
+      row.criteria = "Enter milestone criteria.";
+    }
+
+    if (row.title || row.criteria) {
+      rows[index] = row;
+    }
+  });
+
+  return rows.length > 0 ? { rows } : undefined;
+}
+
 /**
  * Returns true when amount is a valid positive number that strictly exceeds the
  * available balance. Returns false when either value is not a finite number so
  * the caller can treat an unknown balance as non-blocking.
  */
-export function exceedsBalance(amount: string, balance: string | null): boolean {
+export function exceedsBalance(
+  amount: string,
+  balance: string | null,
+): boolean {
   if (balance === null) return false;
   const a = Number(amount);
   const b = Number(balance);


### PR DESCRIPTION
## Summary
- add a multi-milestone repeater to CreateVault with add/remove/reorder controls
- validate at least one milestone plus per-row title/criteria and duplicate titles
- list all milestones in the review step while keeping the legacy single-milestone prop compatible
- document the milestone editing, validation, and review contract

Closes #453

## Validation
- npx vitest run src/utils/__tests__/vaultValidation.test.ts src/pages/__tests__/CreateVault.test.tsx src/components/__tests__/CreateVaultReview.test.tsx
- npx eslint src/pages/CreateVault.tsx src/components/CreateVaultReview.tsx src/utils/vaultValidation.ts src/utils/__tests__/vaultValidation.test.ts src/pages/__tests__/CreateVault.test.tsx src/components/__tests__/CreateVaultReview.test.tsx
- npx prettier --check src/pages/CreateVault.tsx src/components/CreateVaultReview.tsx src/utils/vaultValidation.ts src/utils/__tests__/vaultValidation.test.ts src/pages/__tests__/CreateVault.test.tsx src/components/__tests__/CreateVaultReview.test.tsx design-system/documentation/create-vault-milestones.md
- git diff --check

## Notes
- npm run build is currently blocked by existing unrelated syntax errors in src/utils/__tests__/csv.analytics.test.ts and src/utils/__tests__/verifierMetrics.test.ts.