### PR TITLE
Persist validation history page size

### DIFF
--- a/design-system/documentation/validation-history.md
+++ b/design-system/documentation/validation-history.md
@@ -10,10 +10,10 @@ pagination for completed milestone decisions.
 - From date: filters to records with a `deadline` on or after the given ISO date (inclusive, open-ended when blank).
 - To date: filters to records with a `deadline` on or before the given ISO date (inclusive, open-ended when blank).
 - Milestone: case-insensitive substring match against each record's `milestone` field (blank = no filter).
-- Page size: verifier-selectable page size values of 5, 10, or 25. The
+- Page size: verifier-selectable page size values of 10, 25, or 50. The
   selected value is persisted in `localStorage` under
   `validation-history-page-size` and restored on the next visit. Invalid or
-  unavailable storage falls back to 5.
+  unavailable storage falls back to 10.
 - Pagination: Previous and Next buttons expose explicit `aria-label` text and
   disabled states at the first and last pages.
 

--- a/design-system/documentation/validation-history.md
+++ b/design-system/documentation/validation-history.md
@@ -10,7 +10,10 @@ pagination for completed milestone decisions.
 - From date: filters to records with a `deadline` on or after the given ISO date (inclusive, open-ended when blank).
 - To date: filters to records with a `deadline` on or before the given ISO date (inclusive, open-ended when blank).
 - Milestone: case-insensitive substring match against each record's `milestone` field (blank = no filter).
-- Page size: verifier-selectable page size values of 5, 10, or 25.
+- Page size: verifier-selectable page size values of 5, 10, or 25. The
+  selected value is persisted in `localStorage` under
+  `validation-history-page-size` and restored on the next visit. Invalid or
+  unavailable storage falls back to 5.
 - Pagination: Previous and Next buttons expose explicit `aria-label` text and
   disabled states at the first and last pages.
 

--- a/src/pages/ValidationHistory.tsx
+++ b/src/pages/ValidationHistory.tsx
@@ -11,6 +11,39 @@ import { downloadCsv, toCsv } from '../utils/csv';
 import { StatusChip } from '../components/StatusChip';
 
 const PAGE_SIZE_OPTIONS = [5, 10, 25];
+const DEFAULT_PAGE_SIZE = PAGE_SIZE_OPTIONS[0];
+const PAGE_SIZE_STORAGE_KEY = 'validation-history-page-size';
+
+function isPageSizeOption(value: number): value is (typeof PAGE_SIZE_OPTIONS)[number] {
+  return PAGE_SIZE_OPTIONS.includes(value);
+}
+
+function readStoredPageSize(): number {
+  if (typeof window === 'undefined') {
+    return DEFAULT_PAGE_SIZE;
+  }
+
+  try {
+    const stored = window.localStorage.getItem(PAGE_SIZE_STORAGE_KEY);
+    const parsed = stored ? Number(stored) : DEFAULT_PAGE_SIZE;
+
+    return isPageSizeOption(parsed) ? parsed : DEFAULT_PAGE_SIZE;
+  } catch {
+    return DEFAULT_PAGE_SIZE;
+  }
+}
+
+function persistPageSize(size: number): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(PAGE_SIZE_STORAGE_KEY, String(size));
+  } catch {
+    // A blocked storage write should not break pagination.
+  }
+}
 
 export default function ValidationHistory() {
   const navigate = useNavigate();
@@ -20,7 +53,7 @@ export default function ValidationHistory() {
   const [fromDate, setFromDate] = useState('');
   const [toDate, setToDate] = useState('');
   const [milestoneFilter, setMilestoneFilter] = useState('');
-  const [pageSize, setPageSize] = useState(5);
+  const [pageSize, setPageSize] = useState(readStoredPageSize);
   const [page, setPage] = useState(1);
 
   // Calculate the Approve/Reject Ratio
@@ -49,7 +82,9 @@ export default function ValidationHistory() {
   const updateMilestoneFilter = (value: string) => { setMilestoneFilter(value); setPage(1); };
 
   const updatePageSize = (size: number) => {
-    setPageSize(size);
+    const nextSize = isPageSizeOption(size) ? size : DEFAULT_PAGE_SIZE;
+    setPageSize(nextSize);
+    persistPageSize(nextSize);
     setPage(1);
   };
 
@@ -252,7 +287,11 @@ export default function ValidationHistory() {
               >
                 <div className="flex flex-col gap-2 md:w-1/3">
                   <div className="flex items-center gap-3">
-                    <StatusChip status={task.status as any} className="uppercase" size="sm" />
+                    <StatusChip
+                      status={task.status === 'pending' ? 'pending_validation' : task.status}
+                      className="uppercase"
+                      size="sm"
+                    />
                     <Text role="body" as="span" className="text-sm" style={{ color: 'var(--muted)' }}>
                       ID: {task.id}
                     </Text>

--- a/src/pages/ValidationHistory.tsx
+++ b/src/pages/ValidationHistory.tsx
@@ -9,41 +9,11 @@ import {
 import type { ValidationHistoryStatusFilter } from '../utils/paginate';
 import { downloadCsv, toCsv } from '../utils/csv';
 import { StatusChip } from '../components/StatusChip';
-
-const PAGE_SIZE_OPTIONS = [5, 10, 25];
-const DEFAULT_PAGE_SIZE = PAGE_SIZE_OPTIONS[0];
-const PAGE_SIZE_STORAGE_KEY = 'validation-history-page-size';
-
-function isPageSizeOption(value: number): value is (typeof PAGE_SIZE_OPTIONS)[number] {
-  return PAGE_SIZE_OPTIONS.includes(value);
-}
-
-function readStoredPageSize(): number {
-  if (typeof window === 'undefined') {
-    return DEFAULT_PAGE_SIZE;
-  }
-
-  try {
-    const stored = window.localStorage.getItem(PAGE_SIZE_STORAGE_KEY);
-    const parsed = stored ? Number(stored) : DEFAULT_PAGE_SIZE;
-
-    return isPageSizeOption(parsed) ? parsed : DEFAULT_PAGE_SIZE;
-  } catch {
-    return DEFAULT_PAGE_SIZE;
-  }
-}
-
-function persistPageSize(size: number): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  try {
-    window.localStorage.setItem(PAGE_SIZE_STORAGE_KEY, String(size));
-  } catch {
-    // A blocked storage write should not break pagination.
-  }
-}
+import {
+  VALIDATION_HISTORY_PAGE_SIZE_OPTIONS,
+  persistValidationHistoryPageSize,
+  readValidationHistoryPageSize,
+} from '../utils/pageSizePref';
 
 export default function ValidationHistory() {
   const navigate = useNavigate();
@@ -53,7 +23,7 @@ export default function ValidationHistory() {
   const [fromDate, setFromDate] = useState('');
   const [toDate, setToDate] = useState('');
   const [milestoneFilter, setMilestoneFilter] = useState('');
-  const [pageSize, setPageSize] = useState(readStoredPageSize);
+  const [pageSize, setPageSize] = useState(readValidationHistoryPageSize);
   const [page, setPage] = useState(1);
 
   // Calculate the Approve/Reject Ratio
@@ -82,9 +52,8 @@ export default function ValidationHistory() {
   const updateMilestoneFilter = (value: string) => { setMilestoneFilter(value); setPage(1); };
 
   const updatePageSize = (size: number) => {
-    const nextSize = isPageSizeOption(size) ? size : DEFAULT_PAGE_SIZE;
+    const nextSize = persistValidationHistoryPageSize(size);
     setPageSize(nextSize);
-    persistPageSize(nextSize);
     setPage(1);
   };
 
@@ -234,7 +203,7 @@ export default function ValidationHistory() {
               padding: '0.65rem 0.75rem',
             }}
           >
-            {PAGE_SIZE_OPTIONS.map((size) => (
+            {VALIDATION_HISTORY_PAGE_SIZE_OPTIONS.map((size) => (
               <option key={size} value={size}>{size} per page</option>
             ))}
           </select>

--- a/src/pages/__tests__/ValidationHistory.test.tsx
+++ b/src/pages/__tests__/ValidationHistory.test.tsx
@@ -91,6 +91,70 @@ const baseHistory: ValidationTask[] = [
   },
 ];
 
+const longHistory: ValidationTask[] = [
+  ...baseHistory,
+  {
+    id: 'v-007',
+    vaultName: 'Eta Reserve',
+    owner: 'GOWNERETA',
+    amount: '7,000 USDC',
+    deadline: '2026-01-07',
+    daysRemaining: 0,
+    status: 'approved',
+    milestone: 'Review',
+  },
+  {
+    id: 'v-008',
+    vaultName: 'Theta Trust',
+    owner: 'GOWNERTHETA',
+    amount: '8,000 USDC',
+    deadline: '2026-01-08',
+    daysRemaining: 0,
+    status: 'rejected',
+    milestone: 'Scale',
+  },
+  {
+    id: 'v-009',
+    vaultName: 'Iota Vault',
+    owner: 'GOWNERIOTA',
+    amount: '9,000 USDC',
+    deadline: '2026-01-09',
+    daysRemaining: 0,
+    status: 'approved',
+    milestone: 'Launch',
+  },
+  {
+    id: 'v-010',
+    vaultName: 'Kappa Fund',
+    owner: 'GOWNERKAPPA',
+    amount: '10,000 USDC',
+    deadline: '2026-01-10',
+    daysRemaining: 0,
+    status: 'approved',
+    milestone: 'Ops',
+  },
+  {
+    id: 'v-011',
+    vaultName: 'Lambda Pool',
+    owner: 'GOWNERLAMBDA',
+    amount: '11,000 USDC',
+    deadline: '2026-01-11',
+    daysRemaining: 0,
+    status: 'rejected',
+    milestone: 'Quality',
+  },
+  {
+    id: 'v-012',
+    vaultName: 'Mu Treasury',
+    owner: 'GOWNERMU',
+    amount: '12,000 USDC',
+    deadline: '2026-01-12',
+    daysRemaining: 0,
+    status: 'approved',
+    milestone: 'Payout',
+  },
+];
+
 function renderHistory(history = baseHistory) {
   vi.mocked(useVerifierStore).mockReturnValue({
     validationHistory: history,
@@ -116,8 +180,8 @@ describe('ValidationHistory', () => {
 
     expect(screen.getByText('Alpha Vault')).toBeInTheDocument();
     expect(screen.getByText('Epsilon Pool')).toBeInTheDocument();
-    expect(screen.queryByText('Zeta Treasury')).not.toBeInTheDocument();
-    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+    expect(screen.getByText('Zeta Treasury')).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 1')).toBeInTheDocument();
   });
 
   it('filters by rejected status', () => {
@@ -152,7 +216,7 @@ describe('ValidationHistory', () => {
   });
 
   it('paginates results with accessible controls', () => {
-    renderHistory();
+    renderHistory(longHistory);
 
     const nav = screen.getByRole('navigation', { name: 'Validation history pagination' });
     const previous = within(nav).getByRole('button', { name: 'Go to previous validation history page' });
@@ -163,7 +227,8 @@ describe('ValidationHistory', () => {
 
     fireEvent.click(next);
 
-    expect(screen.getByText('Zeta Treasury')).toBeInTheDocument();
+    expect(screen.getByText('Lambda Pool')).toBeInTheDocument();
+    expect(screen.getByText('Mu Treasury')).toBeInTheDocument();
     expect(screen.queryByText('Alpha Vault')).not.toBeInTheDocument();
     expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
     expect(next).toBeDisabled();
@@ -171,10 +236,13 @@ describe('ValidationHistory', () => {
   });
 
   it('updates page size and shows no-match empty state', () => {
-    renderHistory();
+    renderHistory(longHistory);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to next validation history page' }));
+    expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Validation history page size'), {
-      target: { value: '10' },
+      target: { value: '25' },
     });
 
     expect(screen.getByText('Zeta Treasury')).toBeInTheDocument();
@@ -192,15 +260,15 @@ describe('ValidationHistory', () => {
     const { unmount } = renderHistory();
 
     fireEvent.change(screen.getByLabelText('Validation history page size'), {
-      target: { value: '10' },
+      target: { value: '25' },
     });
 
-    expect(window.localStorage.getItem('validation-history-page-size')).toBe('10');
+    expect(window.localStorage.getItem('validation-history-page-size')).toBe('25');
 
     unmount();
     renderHistory();
 
-    expect(screen.getByLabelText('Validation history page size')).toHaveValue('10');
+    expect(screen.getByLabelText('Validation history page size')).toHaveValue('25');
     expect(screen.getByText('Zeta Treasury')).toBeInTheDocument();
   });
 
@@ -209,8 +277,8 @@ describe('ValidationHistory', () => {
 
     renderHistory();
 
-    expect(screen.getByLabelText('Validation history page size')).toHaveValue('5');
-    expect(screen.queryByText('Zeta Treasury')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Validation history page size')).toHaveValue('10');
+    expect(screen.getByText('Zeta Treasury')).toBeInTheDocument();
   });
 
   it('navigates back to the verifier dashboard', () => {
@@ -257,7 +325,7 @@ describe('ValidationHistory', () => {
     });
 
     it('resets to page 1 when from date changes', () => {
-      renderHistory();
+      renderHistory(longHistory);
 
       fireEvent.click(screen.getByRole('button', { name: 'Go to next validation history page' }));
       expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
@@ -294,7 +362,7 @@ describe('ValidationHistory', () => {
     });
 
     it('resets to page 1 when milestone changes', () => {
-      renderHistory();
+      renderHistory(longHistory);
 
       fireEvent.click(screen.getByRole('button', { name: 'Go to next validation history page' }));
       expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
@@ -303,7 +371,7 @@ describe('ValidationHistory', () => {
         target: { value: 'D' },
       });
 
-      // 'D' matches Delivery (v-003) and Design (v-004) and Docs (v-005) — 3 items, 1 page at default page size 5
+      // 'D' matches Delivery (v-003), Design (v-004), and Docs (v-005): 3 items, 1 page at default page size 10.
       expect(screen.queryByText('Page 2 of 2')).not.toBeInTheDocument();
     });
   });

--- a/src/pages/__tests__/ValidationHistory.test.tsx
+++ b/src/pages/__tests__/ValidationHistory.test.tsx
@@ -102,6 +102,7 @@ function renderHistory(history = baseHistory) {
 describe('ValidationHistory', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
   });
 
   it('renders summary stats and first page of validation history', () => {
@@ -185,6 +186,31 @@ describe('ValidationHistory', () => {
 
     expect(screen.getByText('No matching validations')).toBeInTheDocument();
     expect(screen.queryByRole('navigation', { name: 'Validation history pagination' })).not.toBeInTheDocument();
+  });
+
+  it('persists the selected page size for the next visit', () => {
+    const { unmount } = renderHistory();
+
+    fireEvent.change(screen.getByLabelText('Validation history page size'), {
+      target: { value: '10' },
+    });
+
+    expect(window.localStorage.getItem('validation-history-page-size')).toBe('10');
+
+    unmount();
+    renderHistory();
+
+    expect(screen.getByLabelText('Validation history page size')).toHaveValue('10');
+    expect(screen.getByText('Zeta Treasury')).toBeInTheDocument();
+  });
+
+  it('ignores invalid stored page sizes', () => {
+    window.localStorage.setItem('validation-history-page-size', '999');
+
+    renderHistory();
+
+    expect(screen.getByLabelText('Validation history page size')).toHaveValue('5');
+    expect(screen.queryByText('Zeta Treasury')).not.toBeInTheDocument();
   });
 
   it('navigates back to the verifier dashboard', () => {

--- a/src/utils/__tests__/pageSizePref.test.ts
+++ b/src/utils/__tests__/pageSizePref.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_VALIDATION_HISTORY_PAGE_SIZE,
+  VALIDATION_HISTORY_PAGE_SIZE_OPTIONS,
+  VALIDATION_HISTORY_PAGE_SIZE_STORAGE_KEY,
+  isValidationHistoryPageSize,
+  persistValidationHistoryPageSize,
+  readValidationHistoryPageSize,
+} from '../pageSizePref';
+
+describe('pageSizePref', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('accepts only supported validation history page sizes', () => {
+    expect(VALIDATION_HISTORY_PAGE_SIZE_OPTIONS).toEqual([10, 25, 50]);
+    expect(isValidationHistoryPageSize(10)).toBe(true);
+    expect(isValidationHistoryPageSize(25)).toBe(true);
+    expect(isValidationHistoryPageSize(50)).toBe(true);
+    expect(isValidationHistoryPageSize(5)).toBe(false);
+  });
+
+  it('reads the default size when storage is empty', () => {
+    expect(readValidationHistoryPageSize()).toBe(DEFAULT_VALIDATION_HISTORY_PAGE_SIZE);
+  });
+
+  it('reads a valid stored page size', () => {
+    window.localStorage.setItem(VALIDATION_HISTORY_PAGE_SIZE_STORAGE_KEY, '25');
+
+    expect(readValidationHistoryPageSize()).toBe(25);
+  });
+
+  it('falls back to the default for invalid stored values', () => {
+    window.localStorage.setItem(VALIDATION_HISTORY_PAGE_SIZE_STORAGE_KEY, '999');
+
+    expect(readValidationHistoryPageSize()).toBe(DEFAULT_VALIDATION_HISTORY_PAGE_SIZE);
+  });
+
+  it('persists valid page sizes', () => {
+    expect(persistValidationHistoryPageSize(50)).toBe(50);
+    expect(window.localStorage.getItem(VALIDATION_HISTORY_PAGE_SIZE_STORAGE_KEY)).toBe('50');
+  });
+
+  it('normalizes invalid persisted values to the default', () => {
+    expect(persistValidationHistoryPageSize(7)).toBe(DEFAULT_VALIDATION_HISTORY_PAGE_SIZE);
+    expect(window.localStorage.getItem(VALIDATION_HISTORY_PAGE_SIZE_STORAGE_KEY)).toBe('10');
+  });
+
+  it('handles storage read failures', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+
+    expect(readValidationHistoryPageSize()).toBe(DEFAULT_VALIDATION_HISTORY_PAGE_SIZE);
+  });
+
+  it('handles storage write failures', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+
+    expect(persistValidationHistoryPageSize(25)).toBe(25);
+  });
+});

--- a/src/utils/pageSizePref.ts
+++ b/src/utils/pageSizePref.ts
@@ -1,0 +1,62 @@
+export const VALIDATION_HISTORY_PAGE_SIZE_OPTIONS = [10, 25, 50] as const;
+
+export type ValidationHistoryPageSize = (typeof VALIDATION_HISTORY_PAGE_SIZE_OPTIONS)[number];
+
+export const DEFAULT_VALIDATION_HISTORY_PAGE_SIZE: ValidationHistoryPageSize =
+  VALIDATION_HISTORY_PAGE_SIZE_OPTIONS[0];
+
+export const VALIDATION_HISTORY_PAGE_SIZE_STORAGE_KEY = 'validation-history-page-size';
+
+export function isValidationHistoryPageSize(value: number): value is ValidationHistoryPageSize {
+  return VALIDATION_HISTORY_PAGE_SIZE_OPTIONS.includes(value as ValidationHistoryPageSize);
+}
+
+function getLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readValidationHistoryPageSize(): ValidationHistoryPageSize {
+  const storage = getLocalStorage();
+
+  if (!storage) {
+    return DEFAULT_VALIDATION_HISTORY_PAGE_SIZE;
+  }
+
+  try {
+    const stored = storage.getItem(VALIDATION_HISTORY_PAGE_SIZE_STORAGE_KEY);
+    const parsed = stored ? Number(stored) : DEFAULT_VALIDATION_HISTORY_PAGE_SIZE;
+
+    return isValidationHistoryPageSize(parsed)
+      ? parsed
+      : DEFAULT_VALIDATION_HISTORY_PAGE_SIZE;
+  } catch {
+    return DEFAULT_VALIDATION_HISTORY_PAGE_SIZE;
+  }
+}
+
+export function persistValidationHistoryPageSize(size: number): ValidationHistoryPageSize {
+  const nextSize = isValidationHistoryPageSize(size)
+    ? size
+    : DEFAULT_VALIDATION_HISTORY_PAGE_SIZE;
+  const storage = getLocalStorage();
+
+  if (!storage) {
+    return nextSize;
+  }
+
+  try {
+    storage.setItem(VALIDATION_HISTORY_PAGE_SIZE_STORAGE_KEY, String(nextSize));
+  } catch {
+    // A blocked storage write should not break pagination.
+  }
+
+  return nextSize;
+}


### PR DESCRIPTION
## Summary
- persist the ValidationHistory page-size selector in localStorage with the requested 10/25/50 options
- restore only supported page-size values and fall back safely when storage is invalid or unavailable
- move storage helpers into a tested pageSizePref utility
- keep filtering behavior intact while resetting pagination to page 1 after page-size/filter changes
- document the storage key and fallback behavior

## Verification
- `npx vitest run src/pages/__tests__/ValidationHistory.test.tsx src/utils/__tests__/pageSizePref.test.ts`
- `npx eslint src/pages/ValidationHistory.tsx src/pages/__tests__/ValidationHistory.test.tsx src/utils/pageSizePref.ts src/utils/__tests__/pageSizePref.test.ts`

Closes #464