### PR TITLE
feat: refresh WalletContext on Freighter network/account change

### DIFF
--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -30,6 +30,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const [isConnecting, setIsConnecting] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const abortControllerRef = useRef<AbortController | null>(null);
+    const lastKnownAddressRef = useRef<string | null>(null);
+    const lastKnownNetworkRef = useRef<WalletNetwork | null>(null);
 
     const normalizeNetwork = (networkName: string): WalletNetwork => {
         return networkName === 'PUBLIC' ? 'PUBLIC' : 'TESTNET';
@@ -89,6 +91,34 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         };
     }, []);
 
+    // Watch for Freighter network/account changes and refresh state accordingly.
+    // Only runs while connected; stops when disconnected.
+    useEffect(() => {
+        if (!address) return;
+
+        const intervalId = setInterval(async () => {
+            try {
+                const { address: currentAddress, error: addrError } = await getAddress();
+                if (addrError || !currentAddress) return;
+
+                const netDetails = await getNetworkDetails();
+                const currentNetwork = normalizeNetwork(netDetails.network);
+
+                // Detect changes in address or network
+                if (currentAddress !== lastKnownAddressRef.current || currentNetwork !== lastKnownNetworkRef.current) {
+                    lastKnownAddressRef.current = currentAddress;
+                    lastKnownNetworkRef.current = currentNetwork;
+                    setAddress(currentAddress);
+                    await fetchNetworkAndBalance(currentAddress);
+                }
+            } catch (err) {
+                logger.error('Network/address change check failed', err);
+            }
+        }, 2000);
+
+        return () => clearInterval(intervalId);
+    }, [address]);
+
     const connect = async () => {
         setIsConnecting(true);
         setError(null);
@@ -125,6 +155,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         setBalance(null);
         setBalanceStatus('idle');
         setBalanceError(null);
+        lastKnownAddressRef.current = null;
+        lastKnownNetworkRef.current = null;
     };
 
     return (

--- a/src/context/__tests__/WalletContext.test.tsx
+++ b/src/context/__tests__/WalletContext.test.tsx
@@ -101,7 +101,7 @@ describe('WalletContext Horizon USDC balance path', () => {
         expect(screen.getByTestId('address')).toHaveTextContent('GCONNECTED');
         expect(screen.getByTestId('network')).toHaveTextContent('TESTNET');
         expect(screen.getByTestId('balance')).toHaveTextContent('42.2500000');
-        expect(globalThis.fetch).toHaveBeenCalledWith('https://horizon-testnet.stellar.org/accounts/GCONNECTED');
+        expect(globalThis.fetch).toHaveBeenCalledWith('https://horizon-testnet.stellar.org/accounts/GCONNECTED', expect.any(Object));
     });
 
     test('marks no-trustline when a connected public account has no Circle USDC balance line', async () => {
@@ -326,5 +326,171 @@ describe('WalletContext mount-time auto-restore (checkConnection)', () => {
         expect(screen.getByTestId('balanceStatus')).toHaveTextContent('idle');
 
         consoleSpy.mockRestore();
+    });
+});
+
+describe('WalletContext network/address change listener', () => {
+    const originalFetch = globalThis.fetch;
+    const originalSetInterval = globalThis.setInterval;
+    const originalClearInterval = globalThis.clearInterval;
+    const clearIntervalMock = vi.fn();
+    let intervalCallback: (() => void) | null = null;
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        intervalCallback = null;
+        freighterMocks.isAllowed.mockResolvedValue(true);
+        freighterMocks.getAddress.mockResolvedValue({ address: 'G123456', error: null });
+        freighterMocks.getNetworkDetails.mockResolvedValue({ network: 'TESTNET' });
+        globalThis.fetch = vi.fn();
+
+        // Store the callback to invoke it manually in tests
+        globalThis.setInterval = vi.fn((callback: () => void) => {
+            intervalCallback = callback;
+            const id = originalSetInterval(() => {}, 100000);
+            return id;
+        }) as unknown as typeof setInterval;
+        globalThis.clearInterval = clearIntervalMock;
+    });
+
+    afterAll(() => {
+        globalThis.fetch = originalFetch;
+        globalThis.setInterval = originalSetInterval;
+        globalThis.clearInterval = originalClearInterval;
+    });
+
+    test('refreshes state when Freighter network changes', async () => {
+        vi.mocked(globalThis.fetch).mockResolvedValue(
+            mockResponse(200, {
+                balances: [
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: USDC_ISSUERS.TESTNET,
+                        balance: '100.0000000',
+                    },
+                ],
+            }),
+        );
+
+        renderWallet();
+
+        await waitFor(() => expect(screen.getByTestId('network')).toHaveTextContent('TESTNET'));
+        expect(screen.getByTestId('balance')).toHaveTextContent('100.0000000');
+
+        // Simulate network switch
+        freighterMocks.getNetworkDetails.mockResolvedValue({ network: 'PUBLIC' });
+        vi.mocked(globalThis.fetch).mockResolvedValue(
+            mockResponse(200, {
+                balances: [
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: USDC_ISSUERS.PUBLIC,
+                        balance: '200.0000000',
+                    },
+                ],
+            }),
+        );
+
+        // Trigger the interval callback to check for changes
+        intervalCallback?.();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('network')).toHaveTextContent('PUBLIC');
+            expect(screen.getByTestId('balance')).toHaveTextContent('200.0000000');
+        });
+    });
+
+    test('refreshes state when Freighter address changes', async () => {
+        vi.mocked(globalThis.fetch).mockResolvedValue(
+            mockResponse(200, {
+                balances: [
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: USDC_ISSUERS.TESTNET,
+                        balance: '50.0000000',
+                    },
+                ],
+            }),
+        );
+
+        renderWallet();
+
+        await waitFor(() => expect(screen.getByTestId('address')).toHaveTextContent('G123456'));
+
+        // Simulate address switch
+        freighterMocks.getAddress.mockResolvedValue({ address: 'GNEWADDR', error: null });
+        vi.mocked(globalThis.fetch).mockResolvedValue(
+            mockResponse(200, {
+                balances: [
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: USDC_ISSUERS.TESTNET,
+                        balance: '75.0000000',
+                    },
+                ],
+            }),
+        );
+
+        // Trigger the interval callback to check for changes
+        intervalCallback?.();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('address')).toHaveTextContent('GNEWADDR');
+            expect(screen.getByTestId('balance')).toHaveTextContent('75.0000000');
+        });
+    });
+
+    test('disconnect stops the watcher and clears refs', async () => {
+        vi.mocked(globalThis.fetch).mockResolvedValue(
+            mockResponse(200, {
+                balances: [{ asset_type: 'native', balance: '10.0000000' }],
+            }),
+        );
+
+        renderWallet();
+
+        await waitFor(() => expect(screen.getByTestId('address')).toHaveTextContent('G123456'));
+
+        fireEvent.click(screen.getByRole('button', { name: /disconnect/i }));
+
+        expect(screen.getByTestId('address')).toHaveTextContent('');
+        expect(screen.getByTestId('balanceStatus')).toHaveTextContent('idle');
+
+        // Verify clearInterval was called to stop the polling
+        await waitFor(() => expect(clearIntervalMock).toHaveBeenCalled());
+    });
+
+    test('refresh error sets balanceStatus to error', async () => {
+        vi.mocked(globalThis.fetch).mockResolvedValue(
+            mockResponse(200, {
+                balances: [
+                    {
+                        asset_type: 'credit_alphanum4',
+                        asset_code: 'USDC',
+                        asset_issuer: USDC_ISSUERS.TESTNET,
+                        balance: '100.0000000',
+                    },
+                ],
+            }),
+        );
+
+        renderWallet();
+
+        await waitFor(() => expect(screen.getByTestId('balanceStatus')).toHaveTextContent('success'));
+
+        // Simulate network change with fetch error
+        freighterMocks.getNetworkDetails.mockResolvedValue({ network: 'PUBLIC' });
+        vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse(500, {}));
+
+        // Trigger the interval callback to check for changes
+        intervalCallback?.();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('balanceStatus')).toHaveTextContent('error');
+        });
     });
 });

--- a/src/utils/horizon.ts
+++ b/src/utils/horizon.ts
@@ -87,23 +87,10 @@ export async function fetchUsdcBalance(
             throw new HorizonBalanceError('INVALID_RESPONSE', 'Horizon account response did not include balances.');
         }
 
-    if (account.balances.length > MAX_HORIZON_BALANCES) {
-        throw new HorizonBalanceError('INVALID_RESPONSE', 'Horizon account response included too many balances.');
-    }
+        if (account.balances.length > MAX_HORIZON_BALANCES) {
+            throw new HorizonBalanceError('INVALID_RESPONSE', 'Horizon account response included too many balances.');
+        }
 
-    const usdcBalance = account.balances.find(
-        (balanceLine) =>
-            balanceLine.asset_type !== 'native' &&
-            balanceLine.asset_code === 'USDC' &&
-            balanceLine.asset_issuer === issuer,
-    );
-
-    return {
-        balance: usdcBalance?.balance ?? '0.00',
-        hasTrustline: Boolean(usdcBalance),
-        issuer,
-        network,
-    };
         const usdcBalance = account.balances.find(
             (balanceLine) =>
                 balanceLine.asset_type !== 'native' &&


### PR DESCRIPTION
- Add polling listener (2s interval) that detects Freighter network/address changes and refreshes state via fetchNetworkAndBalance
- Only runs while connected; cleared on unmount and disconnect
- Add refs to track last known address/network for change detection
- Add 4 new tests: network switch, address switch, disconnect cleanup, refresh error handling
- Fix pre-existing duplicate code bug in horizon.ts
closes #272