### PR TITLE
[codex] Add network mismatch guard banner

### DIFF
--- a/design-system/documentation/network-mismatch.md
+++ b/design-system/documentation/network-mismatch.md
@@ -1,0 +1,17 @@
+# Network Mismatch Banner
+
+`NetworkMismatchBanner` warns connected-wallet users when the Freighter network
+differs from the network expected by the Disciplr deployment.
+
+- Expected network comes from `VITE_DISCIPLR_NETWORK`.
+- Valid values are `TESTNET` and `PUBLIC`; missing or unsupported values fall
+  back to `TESTNET`.
+- The banner only renders when a wallet address is connected and the connected
+  wallet network differs from the expected network.
+- Disconnected wallets and wallets with a matching network never show the banner.
+- The banner can be dismissed for the current mismatch and reappears after the
+  mismatch clears and returns.
+- Styling uses danger tokens so the warning is consistent with the design system.
+
+The pure `isNetworkMismatch(walletNetwork, expectedNetwork)` helper lives in
+`src/utils/networkMismatch.ts` and is covered separately from the React banner.

--- a/docs/NETWORK_CONFIG.md
+++ b/docs/NETWORK_CONFIG.md
@@ -7,6 +7,7 @@ in Disciplr-Frontend. It covers:
   and Stellar Expert URLs.
 - USDC issuer addresses per network.
 - The `WalletNetwork` type and normalization logic.
+- The expected wallet network used by the global mismatch warning.
 - The Testnet fallback behaviour used by the explorer utilities.
 - A step-by-step checklist for adding or changing a network.
 
@@ -189,7 +190,31 @@ and is `null` until the wallet connects.
 
 ---
 
-## 6. Checklist — Adding or Changing a Network
+## 6. Expected Wallet Network
+
+`src/utils/networkMismatch.ts` defines the deployment network expected by the
+global network mismatch warning:
+
+```ts
+export const APP_EXPECTED_NETWORK = resolveExpectedNetwork(
+  import.meta.env.VITE_DISCIPLR_NETWORK,
+);
+```
+
+`VITE_DISCIPLR_NETWORK` accepts the same supported identifiers as
+`WalletNetwork`: `TESTNET` and `PUBLIC`. Missing or unsupported values fall back
+to `TESTNET`, matching the development-safe fallback used elsewhere in this
+document.
+
+`isNetworkMismatch(walletNetwork, expectedNetwork)` returns `false` while the
+wallet is disconnected or still loading network state, and returns `true` when a
+connected wallet reports a different or unsupported network. `Layout` mounts
+`NetworkMismatchBanner` globally so users see the warning before creating or
+validating vaults.
+
+---
+
+## 7. Checklist — Adding or Changing a Network
 
 Follow these steps when adding a third network or updating an existing URL or
 issuer address.
@@ -209,6 +234,8 @@ issuer address.
   the new identifier (or confirm the Testnet fallback is acceptable).
 - [ ] Update `networkLabel` in `src/utils/explorer.ts` to return a
   human-readable label for the new identifier.
+- [ ] Update `resolveExpectedNetwork` in `src/utils/networkMismatch.ts` if the
+  new network should be a valid expected deployment network.
 - [ ] Update `getExplorerTxUrl` and `getExplorerAccountUrl` if their current
   binary `network === 'PUBLIC'` ternary needs to distinguish more than two
   networks.
@@ -234,11 +261,13 @@ issuer address.
 
 ---
 
-## 7. Related Files
+## 8. Related Files
 
 | File | Role |
 |---|---|
 | [`src/utils/horizon.ts`](../src/utils/horizon.ts) | `HORIZON_URLS`, `USDC_ISSUERS`, `fetchUsdcBalance`, `HorizonBalanceError` |
 | [`src/utils/explorer.ts`](../src/utils/explorer.ts) | `EXPLORER_BASES`, `getExplorerTxUrl`, `getExplorerAccountUrl`, `contractExplorerUrl`, `networkLabel` |
+| [`src/utils/networkMismatch.ts`](../src/utils/networkMismatch.ts) | `APP_EXPECTED_NETWORK`, `resolveExpectedNetwork`, `isNetworkMismatch` |
+| [`src/components/NetworkMismatchBanner.tsx`](../src/components/NetworkMismatchBanner.tsx) | Global warning for connected wallets on the wrong network |
 | [`src/context/WalletContext.tsx`](../src/context/WalletContext.tsx) | `WalletNetwork` type, `normalizeNetwork`, `fetchNetworkAndBalance` |
 | [`src/utils/stellarAddress.ts`](../src/utils/stellarAddress.ts) | `isValidStellarAddress` — used by explorer helpers to guard empty/invalid addresses |

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import { Menu } from "lucide-react";
 import { WalletConnectButton } from "./Wallet/WalletConnectButton";
 import MobileDrawer from "./MobileDrawer";
 import NavLink from "./NavLink";
+import { NetworkMismatchBanner } from "./NetworkMismatchBanner";
 import { Text } from "./Text";
 import { TrustlineBanner } from "./TrustlineBanner";
 import NotificationBell from "./Notification/NotificationBell";
@@ -106,6 +107,7 @@ export default function Layout({ children }: LayoutProps) {
         <MobileDrawer isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)} />
       </header>
       <TrustlineBanner />
+      <NetworkMismatchBanner />
 
       <main
         {...backgroundA11yProps}

--- a/src/components/NetworkMismatchBanner.tsx
+++ b/src/components/NetworkMismatchBanner.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ExternalLink, X } from 'lucide-react';
+import { useWallet, type WalletNetwork } from '../context/WalletContext';
+import { networkLabel } from '../utils/explorer';
+import { APP_EXPECTED_NETWORK, isNetworkMismatch } from '../utils/networkMismatch';
+
+const FREIGHTER_NETWORK_HELP_URL = 'https://docs.freighter.app/';
+
+interface NetworkMismatchBannerProps {
+  expectedNetwork?: WalletNetwork;
+}
+
+export function NetworkMismatchBanner({
+  expectedNetwork = APP_EXPECTED_NETWORK,
+}: NetworkMismatchBannerProps) {
+  const { address, network } = useWallet();
+  const [dismissedMismatch, setDismissedMismatch] = useState<string | null>(null);
+  const hasMismatch = Boolean(address) && isNetworkMismatch(network, expectedNetwork);
+  const mismatchKey = useMemo(
+    () => `${address ?? 'disconnected'}:${network ?? 'unknown'}:${expectedNetwork}`,
+    [address, network, expectedNetwork],
+  );
+
+  useEffect(() => {
+    if (!hasMismatch) {
+      setDismissedMismatch(null);
+    }
+  }, [hasMismatch]);
+
+  if (!hasMismatch || dismissedMismatch === mismatchKey) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      style={{
+        background: 'var(--danger-transparent)',
+        border: 'var(--border-width-1) solid var(--danger)',
+        color: 'var(--text)',
+        padding: 'var(--spacing-3) var(--spacing-4)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 'var(--spacing-4)',
+        flexWrap: 'wrap',
+      }}
+    >
+      <span>
+        <strong>Wrong wallet network.</strong> Freighter is on{' '}
+        <strong>{networkLabel(network)}</strong>, but Disciplr expects{' '}
+        <strong>{networkLabel(expectedNetwork)}</strong>. Switch Freighter before
+        creating or validating vaults.
+      </span>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--spacing-3)' }}>
+        <a
+          href={FREIGHTER_NETWORK_HELP_URL}
+          target="_blank"
+          rel="noreferrer"
+          aria-label="Switch Freighter network"
+          style={{
+            color: 'var(--danger)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 'var(--spacing-1)',
+            fontWeight: 700,
+          }}
+        >
+          Switch network
+          <ExternalLink size={14} aria-hidden="true" />
+        </a>
+        <button
+          type="button"
+          aria-label="Dismiss network mismatch warning"
+          onClick={() => setDismissedMismatch(mismatchKey)}
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--danger)',
+            cursor: 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: 'var(--touch-target)',
+            minWidth: 'var(--touch-target)',
+            padding: 0,
+          }}
+        >
+          <X size={18} aria-hidden="true" />
+        </button>
+      </span>
+    </div>
+  );
+}

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -11,6 +11,10 @@ vi.mock('../TrustlineBanner', () => ({
   TrustlineBanner: () => null,
 }));
 
+vi.mock('../NetworkMismatchBanner', () => ({
+  NetworkMismatchBanner: () => <div data-testid="network-mismatch-banner" />,
+}));
+
 // MobileDrawer uses FocusTrap only when open; mock it so any accidental open
 // in these tests doesn't break due to missing DOM focus targets.
 vi.mock('focus-trap-react', () => ({
@@ -144,6 +148,11 @@ describe('Layout header landmarks', () => {
   test('page has a main landmark', () => {
     renderLayout('/');
     expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  test('mounts the global network mismatch banner', () => {
+    renderLayout('/');
+    expect(screen.getByTestId('network-mismatch-banner')).toBeInTheDocument();
   });
 });
 

--- a/src/components/__tests__/NetworkMismatchBanner.test.tsx
+++ b/src/components/__tests__/NetworkMismatchBanner.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { NetworkMismatchBanner } from '../NetworkMismatchBanner';
+import type { WalletNetwork } from '../../context/WalletContext';
+
+const walletState = vi.hoisted(() => ({
+  address: null as string | null,
+  network: null as WalletNetwork | null,
+}));
+
+vi.mock('../../context/WalletContext', () => ({
+  useWallet: () => walletState,
+}));
+
+function setWalletState(address: string | null, network: WalletNetwork | null) {
+  walletState.address = address;
+  walletState.network = network;
+}
+
+describe('NetworkMismatchBanner', () => {
+  it('shows a danger alert when a connected wallet is on the wrong network', () => {
+    setWalletState('GABC', 'PUBLIC');
+
+    render(<NetworkMismatchBanner expectedNetwork="TESTNET" />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Wrong wallet network');
+    expect(alert).toHaveTextContent('Mainnet');
+    expect(alert).toHaveTextContent('Testnet');
+    expect(
+      screen.getByRole('link', { name: /switch freighter network/i }),
+    ).toHaveAttribute('href', expect.stringContaining('freighter'));
+  });
+
+  it('stays hidden when networks match or the wallet is disconnected', () => {
+    setWalletState('GABC', 'TESTNET');
+    const { rerender } = render(<NetworkMismatchBanner expectedNetwork="TESTNET" />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    setWalletState(null, 'PUBLIC');
+    rerender(<NetworkMismatchBanner expectedNetwork="TESTNET" />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('can be dismissed for the current mismatch and returns for a new mismatch', () => {
+    setWalletState('GABC', 'PUBLIC');
+    const { rerender } = render(<NetworkMismatchBanner expectedNetwork="TESTNET" />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /dismiss network mismatch warning/i }));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    setWalletState('GABC', 'TESTNET');
+    rerender(<NetworkMismatchBanner expectedNetwork="TESTNET" />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    setWalletState('GABC', 'PUBLIC');
+    rerender(<NetworkMismatchBanner expectedNetwork="TESTNET" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/src/utils/__tests__/networkMismatch.test.ts
+++ b/src/utils/__tests__/networkMismatch.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_EXPECTED_NETWORK,
+  isNetworkMismatch,
+  resolveExpectedNetwork,
+} from '../networkMismatch';
+
+describe('resolveExpectedNetwork', () => {
+  it('keeps supported expected network values', () => {
+    expect(resolveExpectedNetwork('TESTNET')).toBe('TESTNET');
+    expect(resolveExpectedNetwork('PUBLIC')).toBe('PUBLIC');
+  });
+
+  it('falls back to TESTNET for missing or unsupported config values', () => {
+    expect(resolveExpectedNetwork(undefined)).toBe(DEFAULT_EXPECTED_NETWORK);
+    expect(resolveExpectedNetwork(null)).toBe(DEFAULT_EXPECTED_NETWORK);
+    expect(resolveExpectedNetwork('FUTURENET')).toBe(DEFAULT_EXPECTED_NETWORK);
+  });
+});
+
+describe('isNetworkMismatch', () => {
+  it('returns false when the wallet network matches the expected app network', () => {
+    expect(isNetworkMismatch('TESTNET', 'TESTNET')).toBe(false);
+    expect(isNetworkMismatch('PUBLIC', 'PUBLIC')).toBe(false);
+  });
+
+  it('returns true when the wallet network differs from the expected app network', () => {
+    expect(isNetworkMismatch('PUBLIC', 'TESTNET')).toBe(true);
+    expect(isNetworkMismatch('TESTNET', 'PUBLIC')).toBe(true);
+  });
+
+  it('does not warn while the wallet is disconnected or still loading network state', () => {
+    expect(isNetworkMismatch(null, 'TESTNET')).toBe(false);
+    expect(isNetworkMismatch(undefined, 'PUBLIC')).toBe(false);
+  });
+
+  it('treats unsupported connected wallet network values as mismatches', () => {
+    expect(isNetworkMismatch('FUTURENET', 'TESTNET')).toBe(true);
+    expect(isNetworkMismatch('CUSTOM', 'PUBLIC')).toBe(true);
+  });
+});

--- a/src/utils/networkMismatch.ts
+++ b/src/utils/networkMismatch.ts
@@ -1,0 +1,32 @@
+import type { WalletNetwork } from '../context/WalletContext';
+
+type NetworkLike = WalletNetwork | string | null | undefined;
+
+export const DEFAULT_EXPECTED_NETWORK: WalletNetwork = 'TESTNET';
+
+export function resolveExpectedNetwork(value: NetworkLike): WalletNetwork {
+  return value === 'PUBLIC' ? 'PUBLIC' : DEFAULT_EXPECTED_NETWORK;
+}
+
+export const APP_EXPECTED_NETWORK = resolveExpectedNetwork(
+  import.meta.env.VITE_DISCIPLR_NETWORK,
+);
+
+function isKnownNetwork(value: NetworkLike): value is WalletNetwork {
+  return value === 'TESTNET' || value === 'PUBLIC';
+}
+
+export function isNetworkMismatch(
+  walletNetwork: NetworkLike,
+  expectedNetwork: NetworkLike = APP_EXPECTED_NETWORK,
+) {
+  if (walletNetwork == null) {
+    return false;
+  }
+
+  if (!isKnownNetwork(walletNetwork)) {
+    return true;
+  }
+
+  return walletNetwork !== resolveExpectedNetwork(expectedNetwork);
+}


### PR DESCRIPTION
## Summary
- add a pure `isNetworkMismatch(walletNetwork, expectedNetwork)` utility with a safe expected-network resolver backed by `VITE_DISCIPLR_NETWORK`
- add a global `NetworkMismatchBanner` in `Layout` that renders only for connected wallets on the wrong network
- style the warning with danger design tokens, explain the mismatch, link to Freighter network guidance, and allow dismissing the current mismatch
- document the expected network config and banner behavior

Closes #469

## Validation
- `./node_modules/.bin/vitest run src/utils/__tests__/networkMismatch.test.ts src/components/__tests__/NetworkMismatchBanner.test.tsx src/components/__tests__/Layout.test.tsx` - 41 tests passed
- `./node_modules/.bin/eslint src/utils/networkMismatch.ts src/utils/__tests__/networkMismatch.test.ts src/components/NetworkMismatchBanner.tsx src/components/__tests__/NetworkMismatchBanner.test.tsx src/components/Layout.tsx src/components/__tests__/Layout.test.tsx` - passed
- `git diff --check` - passed

## Existing repo-wide failures observed
- `./node_modules/.bin/vitest run --coverage` currently fails in unrelated existing suites such as NotificationIcon, deadlinePresets, explorer, reportWebVitals, and WalletDropdown.
- `./node_modules/.bin/eslint .` currently reports existing unrelated lint errors across the repo.
- `./node_modules/.bin/tsc --noEmit` currently fails on existing syntax errors in `src/utils/__tests__/csv.analytics.test.ts` and `src/utils/__tests__/verifierMetrics.test.ts`.
