### PR TITLE
feat: add notification grouping-by-date util and section headers (#467)

### DIFF
--- a/src/pages/Notification.tsx
+++ b/src/pages/Notification.tsx
@@ -1,4 +1,5 @@
 import Message from "@/components/Notification/Messages";
+import { groupNotificationsByDate } from "../utils/groupNotifications";
 import { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { transitionEnter } from "../utils/motion";
@@ -199,36 +200,47 @@ export default function Notification() {
       </div>
 
       <div className="flex w-full flex-col gap-5 mt-5">
-        {currentData.length > 0 ? (
-          currentData.map((items) => (
-            <div
-              key={items.id}
-              className="w-full px-2 border-[#00c389] border-1 rounded-md "
-            >
-              <div className="flex items-start gap-2">
-                <div className="flex-1">
-                  <Message
-                    id={items.id}
-                    title={items.title}
-                    message={items.message}
-                    timeAgo={items.timeAgo}
-                    type={items.type}
-                    read={items.isRead}
-                    isFullPage={true}
-                    setRead={setRead}
-                  />
-                </div>
-                <button
-                  onClick={() => handleDismiss(items.id)}
-                  className="mt-2 p-1 text-gray-400 hover:text-red-500 transition-colors rounded-full hover:bg-gray-100"
-                  aria-label={`Dismiss notification ${items.id}`}
-                >
-                  <X size={16} />
-                </button>
+        {currentData.length > 0 ? (() => {
+          const groups = groupNotificationsByDate(currentData);
+          return groups.map((group) => (
+            <div key={group.bucket}>
+              <div
+                className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-2 mt-1"
+                style={{ letterSpacing: '0.08em' }}
+              >
+                {group.bucket}
               </div>
+              {group.items.map((items) => (
+                <div
+                  key={items.id}
+                  className="w-full px-2 border-[#00c389] border-1 rounded-md mb-3"
+                >
+                  <div className="flex items-start gap-2">
+                    <div className="flex-1">
+                      <Message
+                        id={items.id}
+                        title={items.title}
+                        message={items.message}
+                        timeAgo={items.timeAgo}
+                        type={items.type}
+                        read={items.isRead}
+                        isFullPage={true}
+                        setRead={setRead}
+                      />
+                    </div>
+                    <button
+                      onClick={() => handleDismiss(items.id)}
+                      className="mt-2 p-1 text-gray-400 hover:text-red-500 transition-colors rounded-full hover:bg-gray-100"
+                      aria-label={`Dismiss notification ${items.id}`}
+                    >
+                      <X size={16} />
+                    </button>
+                  </div>
+                </div>
+              ))}
             </div>
-          ))
-        ) : (
+          ));
+        })() : (
           <p>No notifications found.</p>
         )}
       </div>

--- a/src/utils/groupNotifications.ts
+++ b/src/utils/groupNotifications.ts
@@ -1,0 +1,62 @@
+/**
+ * groupNotifications.ts
+ *
+ * Pure, timezone-stable utility for grouping notification items
+ * under "Today", "Yesterday", and "Earlier" date buckets.
+ */
+
+export type DateBucket = 'Today' | 'Yesterday' | 'Earlier';
+
+export interface NotificationGroup<T> {
+  bucket: DateBucket;
+  items: T[];
+}
+
+/**
+ * Determine the date bucket for a given ISO timestamp relative to `now`.
+ *
+ * Comparison is done in local calendar days (year/month/date) so the
+ * bucketing is stable across midnight boundaries regardless of timezone.
+ */
+export function dateBucket(timestamp: string, now: Date): DateBucket {
+  const itemDate = new Date(timestamp);
+  const itemDay = new Date(itemDate.getFullYear(), itemDate.getMonth(), itemDate.getDate());
+
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+
+  const diffMs = today.getTime() - itemDay.getTime();
+  if (diffMs === 0) return 'Today';
+  if (diffMs === 86400000) return 'Yesterday';
+  return 'Earlier';
+}
+
+const BUCKET_ORDER: DateBucket[] = ['Today', 'Yesterday', 'Earlier'];
+
+/**
+ * Group notification items by date bucket relative to `now`.
+ *
+ * - Items within each group preserve their original order (stable).
+ * - Groups are returned in the canonical order: Today → Yesterday → Earlier.
+ * - Empty groups are omitted.
+ *
+ * @param items  - Array of items that each have a `timestamp` ISO string.
+ * @param now    - Reference time; defaults to `new Date()`.
+ */
+export function groupNotificationsByDate<T extends { timestamp: string }>(
+  items: T[],
+  now: Date = new Date(),
+): NotificationGroup<T>[] {
+  const buckets = new Map<DateBucket, T[]>();
+
+  for (const item of items) {
+    const bucket = dateBucket(item.timestamp, now);
+    if (!buckets.has(bucket)) buckets.set(bucket, []);
+    buckets.get(bucket)!.push(item);
+  }
+
+  return BUCKET_ORDER
+    .filter((b) => buckets.has(b))
+    .map((bucket) => ({ bucket, items: buckets.get(bucket)! }));
+}


### PR DESCRIPTION
Fixes #467

Adds `src/utils/groupNotifications.ts` with a pure `groupNotificationsByDate(items, now)` function and updates `Notification.tsx` to render date section headers.

- `groupNotificationsByDate` buckets items into `Today`, `Yesterday`, or `Earlier` based on local calendar day comparison relative to `now`, making it timezone-stable.
- Groups are returned in canonical order (Today → Yesterday → Earlier); empty buckets are omitted.
- Ordering within each group is stable (preserves original array order).
- `Notification.tsx` groups the paginated `currentData` slice and renders a section header above each bucket without changing existing pagination semantics.