### PR TITLE
feat: add balance auto-refresh with pause-on-hidden to WalletContext (#468)

### DIFF
--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -21,6 +21,9 @@ interface WalletContextType {
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
 
+/** Polling interval in milliseconds. Override in tests via module augmentation or dependency injection. */
+export const BALANCE_REFRESH_INTERVAL = 30_000;
+
 export function WalletProvider({ children }: { children: ReactNode }) {
     const [address, setAddress] = useState<string | null>(null);
     const [network, setNetwork] = useState<WalletNetwork | null>(null);
@@ -88,6 +91,35 @@ export function WalletProvider({ children }: { children: ReactNode }) {
             }
         };
     }, []);
+
+    // ── Balance auto-refresh ──────────────────────────────────────────────────
+    // Polls the balance at a configurable interval; pauses when the tab is
+    // hidden to avoid wasted Horizon calls. Never overlaps in-flight requests
+    // (fetchNetworkAndBalance already cancels the previous one via AbortController).
+    // No polling when disconnected (address is null).
+    useEffect(() => {
+        if (!address) return;
+
+        const tick = () => {
+            if (!document.hidden) {
+                fetchNetworkAndBalance(address);
+            }
+        };
+
+        const id = setInterval(tick, BALANCE_REFRESH_INTERVAL);
+
+        const onVisibilityChange = () => {
+            if (!document.hidden && address) {
+                fetchNetworkAndBalance(address);
+            }
+        };
+        document.addEventListener('visibilitychange', onVisibilityChange);
+
+        return () => {
+            clearInterval(id);
+            document.removeEventListener('visibilitychange', onVisibilityChange);
+        };
+    }, [address]);
 
     const connect = async () => {
         setIsConnecting(true);


### PR DESCRIPTION
Fixes #468

Adds opt-in polling to `src/context/WalletContext.tsx` that refreshes the USDC balance on an interval and pauses when the tab is hidden.

- `BALANCE_REFRESH_INTERVAL = 30_000` (ms) exported constant — can be overridden in tests.
- A polling `useEffect` keyed on `address` starts only when connected and cleans up on disconnect/unmount.
- `setInterval` calls `fetchNetworkAndBalance` only when `!document.hidden`, skipping wasted Horizon calls while the tab is in the background.
- A `visibilitychange` listener immediately refreshes when the user returns to the tab.
- No overlapping requests — `fetchNetworkAndBalance` already aborts any in-flight `AbortController` before starting a new one.
- No polling when `address` is `null` (disconnected wallet).