### PR TITLE
feat: add system theme mode and tri-state ThemeToggle

### DIFF
--- a/design-system/documentation/getting-started.md
+++ b/design-system/documentation/getting-started.md
@@ -56,6 +56,59 @@ git diff --check
 For documentation-only changes, verify every referenced file, CSS variable, and
 component path exists before opening the PR.
 
+## Theme System
+
+The app uses a tri-state theme system exposed by `src/context/ThemeContext.tsx`
+and controlled through `src/components/ThemeToggle.tsx`.
+
+### Modes
+
+| Preference | Resolved `data-theme` | Behavior |
+| ---------- | --------------------- | -------- |
+| `light`    | `light`               | Manual light mode; ignores OS preference. |
+| `dark`     | `dark`                | Manual dark mode; ignores OS preference. |
+| `system`   | Follows OS            | Tracks `prefers-color-scheme` live; the default when no stored preference exists. |
+
+The `data-theme` attribute on `<html>` is always concrete (`light` or
+`dark`), ensuring CSS selectors such as `:root[data-theme="dark"]` and
+`:root[data-theme="light"]` in `src/index.css` resolve predictably.
+
+### ThemeContext API
+
+```tsx
+import { useTheme } from '../context/ThemeContext';
+
+const { theme, preference, toggleTheme, setTheme } = useTheme();
+```
+
+- `theme` — the resolved concrete value (`'light'` | `'dark'`) applied to
+  `data-theme`. Use this when you only care about the current visual mode.
+- `preference` — the user's stored choice (`'light'` | `'dark'` | `'system'`).
+  Use this to inspect or display the tri-state selection.
+- `toggleTheme()` — cycles through the three states in order:
+  `light` → `dark` → `system` → `light`.
+- `setTheme(pref)` — sets the preference directly, e.g.
+  `setTheme('system')`.
+
+### ThemeToggle Component
+
+The `ThemeToggle` button in `src/components/ThemeToggle.tsx` renders an
+icon for the current preference:
+
+- ☀️ Sun — light mode is active.
+- 🌙 Moon — dark mode is active.
+- 🖥️ Monitor — system mode is active (following OS).
+
+Clicking the button cycles to the next state. The `aria-label` announces the
+next state (e.g., "Switch to dark mode"). For `system` preference,
+`aria-pressed` is set to `"mixed"` since the resolved theme depends on the OS.
+
+### Persistence
+
+The user preference is persisted in `localStorage` under the key
+`disciplr-theme`. When `localStorage` is unavailable (e.g., privacy mode
+blocking), an in-memory fallback preserves the preference for the session.
+
 ## Navigation Structure
 
 The site-wide navigation is defined in `src/components/Layout.tsx` for desktop headers and `src/components/MobileDrawer.tsx` for mobile viewports.

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,8 +2,95 @@ import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useTheme } from '../context/ThemeContext';
 import './Layout.css';
 
+function SunIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+function MonitorIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+      <line x1="12" y1="17" x2="12" y2="21" />
+    </svg>
+  );
+}
+
+function getNextLabel(preference: string): string {
+  switch (preference) {
+    case 'light':
+      return 'Switch to dark mode';
+    case 'dark':
+      return 'Switch to system mode';
+    case 'system':
+      return 'Switch to light mode';
+    default:
+      return 'Switch theme';
+  }
+}
+
+function getIcon(preference: string) {
+  switch (preference) {
+    case 'light':
+      return <SunIcon />;
+    case 'dark':
+      return <MoonIcon />;
+    case 'system':
+      return <MonitorIcon />;
+    default:
+      return <SunIcon />;
+  }
+}
+
 export default function ThemeToggle() {
-  const { theme, toggleTheme } = useTheme();
+  const { preference, toggleTheme } = useTheme();
 
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
     if (event.key === 'Enter' || event.key === ' ') {
@@ -18,8 +105,8 @@ export default function ThemeToggle() {
       className="theme-toggle"
       onClick={toggleTheme}
       onKeyDown={handleKeyDown}
-      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
-      aria-pressed={theme === 'dark'}
+      aria-label={getNextLabel(preference)}
+      aria-pressed={preference === 'dark' ? true : preference === 'system' ? 'mixed' as const : false}
       style={{
         background: 'transparent',
         border: 'var(--border-width-1) solid var(--border)',
@@ -34,43 +121,7 @@ export default function ThemeToggle() {
         transition: 'all var(--duration-normal) var(--ease-in-out)',
       }}
     >
-      {theme === 'light' ? (
-        // Moon icon for dark mode
-        <svg
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-        </svg>
-      ) : (
-        // Sun icon for light mode
-        <svg
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <circle cx="12" cy="12" r="5" />
-          <line x1="12" y1="1" x2="12" y2="3" />
-          <line x1="12" y1="21" x2="12" y2="23" />
-          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-          <line x1="1" y1="12" x2="3" y2="12" />
-          <line x1="21" y1="12" x2="23" y2="12" />
-          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-        </svg>
-      )}
+      {getIcon(preference)}
     </button>
   );
 }

--- a/src/components/__tests__/ThemeToggle.test.tsx
+++ b/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '../../context/ThemeContext';
 import ThemeToggle from '../ThemeToggle';
@@ -32,99 +32,154 @@ describe('ThemeToggle', () => {
     vi.restoreAllMocks();
   });
 
-  test('renders light theme by default', () => {
-    renderToggle();
+  describe('default (system) mode', () => {
+    test('renders in system mode by default', () => {
+      renderToggle();
 
-    const button = screen.getByRole('button', { name: /switch to dark mode/i });
-    expect(button).toBeInTheDocument();
-    expect(button).toHaveAttribute('aria-pressed', 'false');
+      const button = screen.getByRole('button', { name: /switch to light mode/i });
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveAttribute('aria-pressed', 'mixed');
+    });
+
+    test('shows monitor icon in system mode', () => {
+      renderToggle();
+
+      const button = screen.getByRole('button', { name: /switch to light mode/i });
+      const svg = button.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+      // Monitor icon has a <rect> element (the screen)
+      expect(svg?.querySelector('rect')).toBeInTheDocument();
+    });
+
+    test('data-theme is concrete (light) when OS is light and preference is system', () => {
+      renderToggle();
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    });
   });
 
-  test('renders dark theme from localStorage', () => {
-    localStorage.setItem(THEME_KEY, 'dark');
-    renderToggle();
+  describe('light mode', () => {
+    test('renders light theme with sun icon', () => {
+      localStorage.setItem(THEME_KEY, 'light');
+      renderToggle();
 
-    const button = screen.getByRole('button', { name: /switch to light mode/i });
-    expect(button).toBeInTheDocument();
-    expect(button).toHaveAttribute('aria-pressed', 'true');
+      const button = screen.getByRole('button', { name: /switch to dark mode/i });
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveAttribute('aria-pressed', 'false');
+      // Sun icon has circle and lines, no rect
+      const svg = button.querySelector('svg');
+      expect(svg?.querySelector('circle')).toBeInTheDocument();
+    });
   });
 
-  test('click toggles theme', async () => {
-    const user = userEvent.setup();
-    renderToggle();
+  describe('dark mode', () => {
+    test('renders dark theme with moon icon', () => {
+      localStorage.setItem(THEME_KEY, 'dark');
+      renderToggle();
 
-    const button = screen.getByRole('button', { name: /switch to dark mode/i });
-    await user.click(button);
+      const button = screen.getByRole('button', { name: /switch to system mode/i });
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveAttribute('aria-pressed', 'true');
+    });
 
-    expect(button).toHaveAttribute('aria-label', 'Switch to light mode');
-    expect(button).toHaveAttribute('aria-pressed', 'true');
-    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    test('data-theme is dark', () => {
+      localStorage.setItem(THEME_KEY, 'dark');
+      renderToggle();
+
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    });
   });
 
-  test('double click returns original theme', async () => {
-    const user = userEvent.setup();
-    renderToggle();
+  describe('tri-state cycling', () => {
+    test('cycles system → light → dark → system', async () => {
+      const user = userEvent.setup();
+      renderToggle();
 
-    const button = screen.getByRole('button', { name: /switch to dark mode/i });
-    await user.click(button);
-    await user.click(button);
+      const button = screen.getByRole('button', { name: /switch to light mode/i });
+      expect(button).toHaveAttribute('aria-pressed', 'mixed');
 
-    expect(button).toHaveAttribute('aria-label', 'Switch to dark mode');
-    expect(button).toHaveAttribute('aria-pressed', 'false');
-    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+      // system → light
+      await user.click(button);
+      expect(button).toHaveAttribute('aria-label', 'Switch to dark mode');
+      expect(button).toHaveAttribute('aria-pressed', 'false');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+
+      // light → dark
+      await user.click(button);
+      expect(button).toHaveAttribute('aria-label', 'Switch to system mode');
+      expect(button).toHaveAttribute('aria-pressed', 'true');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+      // dark → system
+      await user.click(button);
+      expect(button).toHaveAttribute('aria-label', 'Switch to light mode');
+      expect(button).toHaveAttribute('aria-pressed', 'mixed');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    });
+
+    test('persists preference through full cycle', async () => {
+      const user = userEvent.setup();
+      renderToggle();
+
+      const button = screen.getByRole('button', { name: /switch to light mode/i });
+
+      await user.click(button); // system → light
+      expect(localStorage.getItem(THEME_KEY)).toBe('light');
+
+      await user.click(button); // light → dark
+      expect(localStorage.getItem(THEME_KEY)).toBe('dark');
+
+      await user.click(button); // dark → system
+      expect(localStorage.getItem(THEME_KEY)).toBe('system');
+    });
   });
 
-  test('persists to localStorage', async () => {
-    const user = userEvent.setup();
-    renderToggle();
+  describe('keyboard interaction', () => {
+    test('keyboard activation with Enter cycles theme', async () => {
+      const user = userEvent.setup();
+      renderToggle();
 
-    const button = screen.getByRole('button', { name: /switch to dark mode/i });
-    await user.click(button);
+      const button = screen.getByRole('button', { name: /switch to light mode/i });
+      button.focus();
+      await user.keyboard('{Enter}');
 
-    expect(localStorage.getItem(THEME_KEY)).toBe('dark');
+      expect(button).toHaveAttribute('aria-label', 'Switch to dark mode');
+    });
+
+    test('keyboard activation with Space cycles theme', async () => {
+      const user = userEvent.setup();
+      renderToggle();
+
+      const button = screen.getByRole('button', { name: /switch to light mode/i });
+      button.focus();
+      await user.keyboard(' ');
+
+      expect(button).toHaveAttribute('aria-label', 'Switch to dark mode');
+    });
   });
 
-  test('updates data-theme attribute on document root', async () => {
-    const user = userEvent.setup();
-    renderToggle();
+  describe('data-theme attribute', () => {
+    test('updates data-theme when cycling through preferences', async () => {
+      const user = userEvent.setup();
+      renderToggle();
 
-    const button = screen.getByRole('button', { name: /switch to dark mode/i });
-    await user.click(button);
+      // system → light
+      await user.click(screen.getByRole('button'));
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
 
-    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      // light → dark
+      await user.click(screen.getByRole('button'));
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+      // dark → system (resolves to light since OS is light)
+      await user.click(screen.getByRole('button'));
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    });
   });
 
-  test('keyboard activation with Enter toggles theme', async () => {
-    const user = userEvent.setup();
-    renderToggle();
-
-    const button = screen.getByRole('button', { name: /switch to dark mode/i });
-    button.focus();
-    await user.keyboard('{Enter}');
-
-    expect(button).toHaveAttribute('aria-label', 'Switch to light mode');
-  });
-
-  test('keyboard activation with Space toggles theme', async () => {
-    const user = userEvent.setup();
-    renderToggle();
-
-    const button = screen.getByRole('button', { name: /switch to dark mode/i });
-    button.focus();
-    await user.keyboard(' ');
-
-    expect(button).toHaveAttribute('aria-label', 'Switch to light mode');
-  });
-
-  test('renders a theme icon (SVG)', () => {
-    renderToggle();
-
-    const button = screen.getByRole('button', { name: /switch to dark mode/i });
-    expect(button.querySelector('svg')).toBeInTheDocument();
-  });
-
-  test('unmount does not throw and cleans listeners', () => {
-    const { unmount } = renderToggle();
-    expect(() => unmount()).not.toThrow();
+  describe('unmount', () => {
+    test('unmount does not throw and cleans listeners', () => {
+      const { unmount } = renderToggle();
+      expect(() => unmount()).not.toThrow();
+    });
   });
 });

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,13 +1,14 @@
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState, useCallback, ReactNode } from 'react';
 
 // In‑memory fallback when localStorage fails
-let memoryTheme: Theme | null = null;
+let memoryPreference: UserPreference | null = null;
 
 function safeGetItem(key: string): string | null {
   try {
-    return localStorage.getItem(key);
+    return localStorage.getItem(key) ?? null;
   } catch (_) {
-    return null;
+    // fallback to in-memory preference when storage is unavailable
+    return memoryPreference;
   }
 }
 
@@ -15,73 +16,101 @@ function safeSetItem(key: string, value: string): void {
   try {
     localStorage.setItem(key, value);
   } catch (_) {
-    // ignore storage errors
+    // persist in-memory when storage is unavailable
+    memoryPreference = value as UserPreference;
   }
-  memoryTheme = value as Theme;
 }
 
 
 type Theme = 'light' | 'dark';
+type UserPreference = Theme | 'system';
 
 interface ThemeContextType {
+  /** The resolved concrete theme applied to data-theme ('light' | 'dark') */
   theme: Theme;
+  /** The user's stored preference ('light' | 'dark' | 'system') */
+  preference: UserPreference;
+  /** Cycle through light → dark → system → light */
   toggleTheme: () => void;
-  setTheme: (theme: Theme) => void;
+  /** Set a specific user preference */
+  setTheme: (preference: UserPreference) => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 const THEME_STORAGE_KEY = 'disciplr-theme';
 
+const NEXT_PREFERENCE: Record<UserPreference, UserPreference> = {
+  light: 'dark',
+  dark: 'system',
+  system: 'light',
+};
+
 function getSystemTheme(): Theme {
   if (typeof window === 'undefined') return 'light';
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
-function getStoredTheme(): Theme | null {
+function isValidPreference(value: string | null | undefined): value is UserPreference {
+  return value === 'light' || value === 'dark' || value === 'system';
+}
+
+function getStoredPreference(): UserPreference | null {
   if (typeof window === 'undefined') return null;
   const stored = safeGetItem(THEME_STORAGE_KEY);
-  if (stored === 'light' || stored === 'dark') return stored as Theme;
-  // fallback to in-memory theme if storage unavailable
-  return memoryTheme;
+  if (isValidPreference(stored)) return stored;
+  return null;
+}
+
+function resolveTheme(preference: UserPreference): Theme {
+  if (preference === 'system') return getSystemTheme();
+  return preference;
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>(() => {
-    const stored = getStoredTheme();
+  const [preference, setPreferenceState] = useState<UserPreference>(() => {
+    const stored = getStoredPreference();
     if (stored) return stored;
-    return getSystemTheme();
+    // Default to system when no stored preference exists
+    return 'system';
   });
 
-  useEffect(() => {
-  const root = document.documentElement;
-  root.setAttribute('data-theme', theme);
-  safeSetItem(THEME_STORAGE_KEY, theme);
-}, [theme]);
+  // Counter bumped on every OS change to force re-computation of resolved theme
+  const [osTick, setOsTick] = useState(0);
 
+  const theme = useMemo(() => resolveTheme(preference), [preference, osTick]);
+
+  // Apply data-theme and persist preference whenever it changes
+  useEffect(() => {
+    const root = document.documentElement;
+    root.setAttribute('data-theme', theme);
+    safeSetItem(THEME_STORAGE_KEY, preference);
+  }, [theme, preference]);
+
+  // Listen for OS preference changes when in system mode
   useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    const handleChange = (e: MediaQueryListEvent) => {
-      // Only auto‑switch if user hasn't manually selected a theme
-      if (!getStoredTheme()) {
-        setThemeState(e.matches ? 'dark' : 'light');
+    const handleChange = () => {
+      if (preference === 'system') {
+        // Bump osTick to force re-computation of resolved theme
+        setOsTick((t) => t + 1);
       }
     };
     mediaQuery.addEventListener('change', handleChange);
     return () => mediaQuery.removeEventListener('change', handleChange);
+  }, [preference]);
+
+  const toggleTheme = useCallback(() => {
+    setPreferenceState((prev) => NEXT_PREFERENCE[prev]);
   }, []);
 
-  const toggleTheme = () => {
-    setThemeState((prev) => (prev === 'light' ? 'dark' : 'light'));
-  };
-
-  const setTheme = (newTheme: Theme) => {
-  setThemeState(newTheme);
-  safeSetItem(THEME_STORAGE_KEY, newTheme);
-};
+  const setTheme = useCallback((newPreference: UserPreference) => {
+    setPreferenceState(newPreference);
+    safeSetItem(THEME_STORAGE_KEY, newPreference);
+  }, []);
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
+    <ThemeContext.Provider value={{ theme, preference, toggleTheme, setTheme }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/src/context/__tests__/ThemeContext.test.tsx
+++ b/src/context/__tests__/ThemeContext.test.tsx
@@ -1,43 +1,41 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ThemeProvider, useTheme } from '../ThemeContext';
-import { vi, type Mock } from 'vitest';
+import { vi } from 'vitest';
 
 function TestComponent() {
-  const { theme, toggleTheme, setTheme } = useTheme();
+  const { theme, preference, toggleTheme, setTheme } = useTheme();
   return (
     <div>
       <span data-testid="theme">{theme}</span>
+      <span data-testid="preference">{preference}</span>
       <button onClick={toggleTheme}>Toggle</button>
       <button onClick={() => setTheme('dark')}>Set Dark</button>
+      <button onClick={() => setTheme('system')}>Set System</button>
+      <button onClick={() => setTheme('light')}>Set Light</button>
     </div>
   );
 }
 
 describe('ThemeContext safe storage', () => {
-  const originalMatchMedia = window.matchMedia;
-  const originalGetItem = window.localStorage.getItem;
-  const originalSetItem = window.localStorage.setItem;
-
   beforeEach(() => {
-    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    // Mock matchMedia to simulate a light OS preference
+    vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
       matches: false,
       media: query,
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
     } as unknown as MediaQueryList));
-    window.localStorage.getItem = vi.fn();
-    window.localStorage.setItem = vi.fn();
+    vi.spyOn(Storage.prototype, 'getItem');
+    vi.spyOn(Storage.prototype, 'setItem');
   });
 
   afterEach(() => {
-    window.matchMedia = originalMatchMedia;
-    window.localStorage.getItem = originalGetItem;
-    window.localStorage.setItem = originalSetItem;
+    vi.restoreAllMocks();
   });
 
-  test('falls back to system theme when getItem throws', () => {
-    (window.localStorage.getItem as Mock).mockImplementation(() => {
+  test('falls back to system preference when getItem throws', () => {
+    vi.mocked(window.localStorage.getItem).mockImplementation(() => {
       throw new Error('storage blocked');
     });
     render(
@@ -46,12 +44,14 @@ describe('ThemeContext safe storage', () => {
       </ThemeProvider>
     );
     const themeSpan = screen.getByTestId('theme');
+    const preferenceSpan = screen.getByTestId('preference');
     expect(themeSpan).toHaveTextContent('light');
+    expect(preferenceSpan).toHaveTextContent('system');
     expect(document.documentElement).toHaveAttribute('data-theme', 'light');
   });
 
   test('toggles theme even when setItem throws', () => {
-    (window.localStorage.setItem as Mock).mockImplementation(() => {
+    vi.mocked(window.localStorage.setItem).mockImplementation(() => {
       throw new Error('quota exceeded');
     });
     render(
@@ -59,9 +59,257 @@ describe('ThemeContext safe storage', () => {
         <TestComponent />
       </ThemeProvider>
     );
-    fireEvent.click(screen.getByText('Toggle'));
+    // Default is system; cycle: system → light → dark
+    fireEvent.click(screen.getByText('Toggle')); // system → light
+    fireEvent.click(screen.getByText('Toggle')); // light → dark
     const themeSpan = screen.getByTestId('theme');
+    const preferenceSpan = screen.getByTestId('preference');
     expect(themeSpan).toHaveTextContent('dark');
+    expect(preferenceSpan).toHaveTextContent('dark');
     expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
+  });
+
+  test('defaults to system preference when no stored value', () => {
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('preference')).toHaveTextContent('system');
+    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+  });
+});
+
+describe('ThemeContext tri-state preference', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList));
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('cycles preference: light → dark → system → light', () => {
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+
+    // Default is system
+    expect(screen.getByTestId('preference')).toHaveTextContent('system');
+
+    // system → light
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(screen.getByTestId('preference')).toHaveTextContent('light');
+
+    // light → dark
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(screen.getByTestId('preference')).toHaveTextContent('dark');
+
+    // dark → system
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(screen.getByTestId('preference')).toHaveTextContent('system');
+  });
+
+  test('data-theme is always concrete light or dark', () => {
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+
+    // system mode with light OS
+    expect(document.documentElement).toHaveAttribute('data-theme', 'light');
+
+    // switch to dark
+    fireEvent.click(screen.getByText('Toggle')); // system → light
+    fireEvent.click(screen.getByText('Toggle')); // light → dark
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
+
+    // switch to system with light OS
+    fireEvent.click(screen.getByText('Toggle')); // dark → system
+    expect(document.documentElement).toHaveAttribute('data-theme', 'light');
+  });
+
+  test('persists preference to localStorage', () => {
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+
+    fireEvent.click(screen.getByText('Set Dark'));
+    expect(localStorage.getItem('disciplr-theme')).toBe('dark');
+
+    fireEvent.click(screen.getByText('Set System'));
+    expect(localStorage.getItem('disciplr-theme')).toBe('system');
+
+    fireEvent.click(screen.getByText('Set Light'));
+    expect(localStorage.getItem('disciplr-theme')).toBe('light');
+  });
+
+  test('setTheme accepts system preference', () => {
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+
+    fireEvent.click(screen.getByText('Set Dark'));
+    fireEvent.click(screen.getByText('Set System'));
+    expect(screen.getByTestId('preference')).toHaveTextContent('system');
+  });
+
+  test('restores stored system preference', () => {
+    localStorage.setItem('disciplr-theme', 'system');
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('preference')).toHaveTextContent('system');
+  });
+
+  test('restores stored dark preference', () => {
+    localStorage.setItem('disciplr-theme', 'dark');
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('preference')).toHaveTextContent('dark');
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+  });
+
+  test('restores stored light preference', () => {
+    localStorage.setItem('disciplr-theme', 'light');
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('preference')).toHaveTextContent('light');
+    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+  });
+});
+
+describe('ThemeContext OS preference following', () => {
+  let mediaEventHandlers: Map<string, (e: MediaQueryListEvent) => void>;
+  let darkModeMatches: boolean;
+
+  beforeEach(() => {
+    mediaEventHandlers = new Map();
+    darkModeMatches = false;
+    vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+      get matches() { return query === '(prefers-color-scheme: dark)' ? darkModeMatches : false; },
+      media: query,
+      addEventListener: vi.fn((event: string, handler: EventListener) => {
+        if (event === 'change') {
+          mediaEventHandlers.set(query, handler as (e: MediaQueryListEvent) => void);
+        }
+      }),
+      removeEventListener: vi.fn((event: string) => {
+        if (event === 'change') {
+          mediaEventHandlers.delete(query);
+        }
+      }),
+    } as unknown as MediaQueryList));
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    mediaEventHandlers.clear();
+    vi.restoreAllMocks();
+  });
+
+  function fireOsDarkChange(matches: boolean) {
+    darkModeMatches = matches;
+    const handler = mediaEventHandlers.get('(prefers-color-scheme: dark)');
+    if (handler) {
+      act(() => {
+        handler({ matches } as MediaQueryListEvent);
+      });
+    }
+  }
+
+  test('follows OS changes when preference is system', () => {
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId('preference')).toHaveTextContent('system');
+    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+    expect(document.documentElement).toHaveAttribute('data-theme', 'light');
+
+    // Simulate OS switching to dark
+    fireOsDarkChange(true);
+
+    expect(screen.getByTestId('preference')).toHaveTextContent('system');
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
+
+    // Simulate OS switching back to light
+    fireOsDarkChange(false);
+
+    expect(screen.getByTestId('preference')).toHaveTextContent('system');
+    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+    expect(document.documentElement).toHaveAttribute('data-theme', 'light');
+  });
+
+  test('stops following OS changes after switching to manual preference', () => {
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+
+    // Start in system mode
+    expect(screen.getByTestId('preference')).toHaveTextContent('system');
+
+    // Switch to dark manually
+    fireEvent.click(screen.getByText('Toggle')); // system → light
+    fireEvent.click(screen.getByText('Toggle')); // light → dark
+    expect(screen.getByTestId('preference')).toHaveTextContent('dark');
+
+    // OS changes should not affect the resolved theme
+    fireOsDarkChange(false); // OS switches to light
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
+  });
+
+  test('resumes following OS changes after switching back to system', () => {
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+
+    // Switch to dark manually
+    fireEvent.click(screen.getByText('Toggle')); // system → light
+    fireEvent.click(screen.getByText('Toggle')); // light → dark
+    expect(screen.getByTestId('preference')).toHaveTextContent('dark');
+
+    // Switch back to system
+    fireEvent.click(screen.getByText('Toggle')); // dark → system
+    expect(screen.getByTestId('preference')).toHaveTextContent('system');
+
+    // OS change to dark
+    fireOsDarkChange(true);
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+
+    // OS change back to light
+    fireOsDarkChange(false);
+    expect(screen.getByTestId('theme')).toHaveTextContent('light');
   });
 });


### PR DESCRIPTION
Close #300 

Extend ThemeContext to support a 'system' UserPreference distinct from the resolved 'light'|'dark' applied to data-theme. The provider now exposes both  (resolved concrete value) and
(user's stored choice of light/dark/system).

- Default preference is now 'system' (follows OS) instead of defaulting to an implicit manual choice
- In 'system' mode, OS preference changes are tracked live via an osTick counter forcing useMemo re-computation
- data-theme on <html> remains always concrete ('light'|'dark')
- toggleTheme() cycles light → dark → system → light
- setTheme() accepts 'system' directly
- memoryPreference now only acts as error fallback, preventing cross-test state leakage

ThemeToggle updated to render three icons:
- Sun (light mode) / Moon (dark mode) / Monitor (system mode)
- aria-pressed is 'mixed' for system mode per ARIA spec

Tests: 13 ThemeContext + 12 ThemeToggle tests covering safe storage, tri-state cycling, persistence, OS-following, keyboard activation, and manual-override behavior (25 total, all passing).

Documentation added to design-system/documentation/getting-started.md under a new 'Theme System' section.

Close #300