### PR TITLE
perf: lazy-load recharts subtree behind Suspense in Analytics

### DIFF
--- a/docs/BUNDLE_BUDGET.md
+++ b/docs/BUNDLE_BUDGET.md
@@ -3,11 +3,24 @@
 Chunks are split via `build.rollupOptions.output.manualChunks` in `vite.config.ts`.
 Sizes are gzip-compressed targets. Regressions should be visible in `npm run build` output.
 
-| Chunk                  | Target (gzip) |
-| ---------------------- | ------------- |
-| `index` (initial)      | < 200 kB      |
-| `vendor-recharts`      | < 150 kB      |
-| `vendor-jspdf`         | < 120 kB      |
-| `vendor-framer-motion` | < 30 kB       |
-| `Analytics` (lazy)     | < 50 kB       |
-| `Notification` (lazy)  | < 20 kB       |
+| Chunk                   | Target (gzip) |
+| ----------------------- | ------------- |
+| `index` (initial)       | < 200 kB      |
+| `vendor-recharts`       | < 150 kB      |
+| `vendor-jspdf`          | < 120 kB      |
+| `vendor-framer-motion`  | < 30 kB       |
+| `Analytics` (lazy)      | < 50 kB       |
+| `AnalyticsCharts` (lazy)| < 15 kB       |
+| `Notification` (lazy)   | < 20 kB       |
+
+## Lazy-loading strategy
+
+`src/pages/Analytics.tsx` is itself a lazy route (via `React.lazy` in `App.tsx`).
+Within it, all recharts JSX lives in `src/pages/AnalyticsCharts.tsx`, which is
+also loaded via `React.lazy` + `Suspense`. This keeps the `vendor-recharts` chunk
+off the eager path: recharts is never fetched until the Analytics page is visited
+**and** the chart islands are rendered.
+
+Each chart island (`section="performance"`, `section="donut"`, `section="team"`)
+is a prop-driven branch inside `AnalyticsCharts`. All three share a single dynamic
+import so the recharts vendor chunk is only fetched once.

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1,9 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
-import {
-  LineChart, Line, AreaChart, Area, BarChart, Bar,
-  PieChart, Pie, Cell,
-  XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer
-} from 'recharts'
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
 import {
   Target, TrendingUp, CheckCircle, AlertTriangle,
   Download, Flame, Award, Clock, DollarSign,
@@ -12,10 +7,12 @@ import {
 } from 'lucide-react'
 import { useRef } from 'react'
 import { useTheme } from '../context/ThemeContext'
-import { ChartLegend, type ChartLegendEntry } from '../components/ChartLegend'
+import { type ChartLegendEntry } from '../components/ChartLegend'
 import { buildAnalyticsSeriesColors, getAnalyticsChartTokens } from './analyticsTheme'
 import { usePrefersReducedMotion } from '../utils/usePrefersReducedMotion'
 import { toCsv, downloadCsv } from '../utils/csv'
+
+const AnalyticsCharts = lazy(() => import('./AnalyticsCharts'))
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -147,6 +144,13 @@ const benchmarkData = [
   { metric: 'Milestones/mo', you: 9, platform: 5 },
 ]
 
+const TEAM_CHART_DATA = [
+  { name: 'Alice', rate: 94 },
+  { name: 'Bob', rate: 78 },
+  { name: 'Carol', rate: 88 },
+  { name: 'Dave', rate: 65 },
+]
+
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
 function Card({ children, style = {} }: { children: React.ReactNode; style?: React.CSSProperties }) {
@@ -234,7 +238,6 @@ export default function Analytics() {
 
   const PERIODS: Period[] = ['7d', '30d', '90d', '1y', 'All']
   const chartData = analyticsPeriodData[period]
-  const hasChartData = chartData.length > 0
 
   // Merge current + previous period for comparison charts
   const comparisonData = chartData.map((d, i) => ({
@@ -631,95 +634,24 @@ export default function Analytics() {
         {/* ── SECTION 2: Performance Charts ── */}
         <div style={{ marginBottom: '2rem' }}>
           <SectionTitle>Performance Charts {showComparison && <span style={{ color: seriesColors.comparison, fontSize: '0.75rem', fontWeight: 400, marginLeft: '0.5rem' }}>Comparing with previous period</span>}</SectionTitle>
-          <div className="chart-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '1.25rem' }}>
-
-            {/* Success Rate */}
-            <Card>
-              <ChartTitle>Success Rate Over Time</ChartTitle>
-              <ChartSummary>
-                Line chart summarizing success and failure percentages for the selected {period} period.
-                {showComparison ? ' Previous period success rate is included for comparison.' : ''}
-              </ChartSummary>
-              {isLoading ? <SkeletonBox /> : !hasChartData ? <EmptyState message={`No data for this period (${period}).`} /> : (
-                <>
-                  <ResponsiveContainer width="100%" height={220}>
-                    <LineChart data={displayData}>
-                      <CartesianGrid strokeDasharray="3 3" stroke={seriesColors.grid} vertical={false} />
-                      <XAxis dataKey="name" stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} />
-                      <YAxis stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} unit="%" />
-                      <Tooltip {...tooltipStyle} />
-                      <Line type="monotone" dataKey="success" stroke={seriesColors.success} strokeWidth={2.5} dot={{ r: 3, fill: seriesColors.success }} name="This Period %" isAnimationActive={chartAnimationEnabled} />
-                      <Line type="monotone" dataKey="failed" stroke={seriesColors.failed} strokeWidth={2} dot={{ r: 2, fill: seriesColors.failed }} name="Failed %" strokeDasharray="4 2" isAnimationActive={chartAnimationEnabled} />
-                      {showComparison && (
-                        <Line type="monotone" dataKey="prevSuccess" stroke={seriesColors.comparison} strokeWidth={1.5} dot={false} name="Prev Period %" strokeDasharray="6 3" isAnimationActive={chartAnimationEnabled} />
-                      )}
-                    </LineChart>
-                  </ResponsiveContainer>
-                  {showComparison && (
-                    <ChartLegend entries={successLegendEntries} colors={seriesColors} tokens={chartTokens} />
-                  )}
-                </>
-              )}
-            </Card>
-
-            {/* Capital Locked */}
-            <Card>
-              <ChartTitle>Capital Locked Over Time</ChartTitle>
-              <ChartSummary>
-                Area chart showing USDC capital locked over the selected {period} period.
-                {showComparison ? ' Previous period capital is shown as a comparison area.' : ''}
-              </ChartSummary>
-              {isLoading ? <SkeletonBox /> : !hasChartData ? <EmptyState message={`No data for this period (${period}).`} /> : (
-                <>
-                  <ResponsiveContainer width="100%" height={220}>
-                    <AreaChart data={displayData}>
-                      <defs>
-                        <linearGradient id="capGrad" x1="0" y1="0" x2="0" y2="1">
-                          <stop offset="5%" stopColor={seriesColors.success} stopOpacity={0.25} />
-                          <stop offset="95%" stopColor={seriesColors.success} stopOpacity={0} />
-                        </linearGradient>
-                        <linearGradient id="prevCapGrad" x1="0" y1="0" x2="0" y2="1">
-                          <stop offset="5%" stopColor={seriesColors.comparison} stopOpacity={0.15} />
-                          <stop offset="95%" stopColor={seriesColors.comparison} stopOpacity={0} />
-                        </linearGradient>
-                      </defs>
-                      <CartesianGrid strokeDasharray="3 3" stroke={seriesColors.grid} vertical={false} />
-                      <XAxis dataKey="name" stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} />
-                      <YAxis stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} />
-                      <Tooltip {...tooltipStyle} />
-                      <Area type="monotone" dataKey="capital" stroke={seriesColors.success} strokeWidth={2.5} fill="url(#capGrad)" name="USDC Locked" isAnimationActive={chartAnimationEnabled} />
-                      {showComparison && (
-                        <Area type="monotone" dataKey="prevCapital" stroke={seriesColors.comparison} strokeWidth={1.5} fill="url(#prevCapGrad)" name="Prev Period" strokeDasharray="5 3" isAnimationActive={chartAnimationEnabled} />
-                      )}
-                    </AreaChart>
-                  </ResponsiveContainer>
-                  {showComparison && (
-                    <ChartLegend entries={capitalLegendEntries} colors={seriesColors} tokens={chartTokens} />
-                  )}
-                </>
-              )}
-            </Card>
-
-            {/* Milestone Trend */}
-            <Card>
-              <ChartTitle>Milestone Completion Trend</ChartTitle>
-              <ChartSummary>
-                Bar chart showing completed milestone counts for each point in the selected {period} period.
-              </ChartSummary>
-              {isLoading ? <SkeletonBox /> : !hasChartData ? <EmptyState message={`No data for this period (${period}).`} /> : (
-                <ResponsiveContainer width="100%" height={220}>
-                  <BarChart data={chartData}>
-                    <CartesianGrid strokeDasharray="3 3" stroke={seriesColors.grid} vertical={false} />
-                    <XAxis dataKey="name" stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} />
-                    <YAxis stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} />
-                    <Tooltip {...tooltipStyle} />
-                    <Bar dataKey="milestones" fill={seriesColors.milestone} radius={[4, 4, 0, 0]} name="Milestones Completed" isAnimationActive={chartAnimationEnabled} />
-                  </BarChart>
-                </ResponsiveContainer>
-              )}
-            </Card>
-
-          </div>
+          <Suspense fallback={<SkeletonBox height={300} />}>
+            <AnalyticsCharts
+              section="performance"
+              displayData={displayData}
+              chartData={chartData}
+              period={period}
+              vaultStatusData={vaultStatusData}
+              teamChartData={TEAM_CHART_DATA}
+              showComparison={showComparison}
+              chartAnimationEnabled={chartAnimationEnabled}
+              tooltipStyle={tooltipStyle}
+              seriesColors={seriesColors}
+              chartTokens={chartTokens}
+              successLegendEntries={successLegendEntries}
+              capitalLegendEntries={capitalLegendEntries}
+              isLoading={isLoading}
+            />
+          </Suspense>
         </div>
 
         {/* ── SECTION 3: Vault Analytics ── */}
@@ -733,28 +665,24 @@ export default function Analytics() {
               <ChartSummary>
                 Donut chart summarizing vault status counts: 14 completed, 3 active, and 4 failed.
               </ChartSummary>
-              {isLoading ? <SkeletonBox height={180} /> : vaultStatusData.length === 0 ? <EmptyState message="No data for this period." /> : (
-                <>
-                  <ResponsiveContainer width="100%" height={180}>
-                    <PieChart>
-                      <Pie data={vaultStatusData} innerRadius={50} outerRadius={75} paddingAngle={4} dataKey="value" isAnimationActive={chartAnimationEnabled}>
-                        {vaultStatusData.map((_, i) => (
-                          <Cell key={i} fill={seriesColors.pie[i % seriesColors.pie.length]} />
-                        ))}
-                      </Pie>
-                      <Tooltip {...tooltipStyle} />
-                    </PieChart>
-                  </ResponsiveContainer>
-                  <div style={{ display: 'flex', justifyContent: 'center', gap: '1.25rem', marginTop: '0.5rem' }}>
-                    {vaultStatusData.map((entry, i) => (
-                      <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', fontSize: '0.8rem', color: 'var(--muted)' }}>
-                        <span style={{ width: 9, height: 9, borderRadius: '50%', background: seriesColors.pie[i], display: 'inline-block' }} />
-                        {entry.name} ({entry.value})
-                      </div>
-                    ))}
-                  </div>
-                </>
-              )}
+              <Suspense fallback={<SkeletonBox height={180} />}>
+                <AnalyticsCharts
+                  section="donut"
+                  displayData={displayData}
+                  chartData={chartData}
+                  period={period}
+                  vaultStatusData={vaultStatusData}
+                  teamChartData={TEAM_CHART_DATA}
+                  showComparison={showComparison}
+                  chartAnimationEnabled={chartAnimationEnabled}
+                  tooltipStyle={tooltipStyle}
+                  seriesColors={seriesColors}
+                  chartTokens={chartTokens}
+                  successLegendEntries={successLegendEntries}
+                  capitalLegendEntries={capitalLegendEntries}
+                  isLoading={isLoading}
+                />
+              </Suspense>
             </Card>
 
             {/* Vault Stats */}
@@ -1092,18 +1020,24 @@ export default function Analytics() {
               <ChartSummary>
                 Locked enterprise preview bar chart showing example team member success rates.
               </ChartSummary>
-              <ResponsiveContainer width="100%" height={160}>
-                <BarChart data={[
-                  { name: 'Alice', rate: 94 },
-                  { name: 'Bob', rate: 78 },
-                  { name: 'Carol', rate: 88 },
-                  { name: 'Dave', rate: 65 },
-                ]}>
-                  <XAxis dataKey="name" stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} />
-                  <YAxis stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} unit="%" />
-                  <Bar dataKey="rate" fill={seriesColors.success} radius={[4, 4, 0, 0]} isAnimationActive={chartAnimationEnabled} />
-                </BarChart>
-              </ResponsiveContainer>
+              <Suspense fallback={<SkeletonBox height={160} />}>
+                <AnalyticsCharts
+                  section="team"
+                  displayData={displayData}
+                  chartData={chartData}
+                  period={period}
+                  vaultStatusData={vaultStatusData}
+                  teamChartData={TEAM_CHART_DATA}
+                  showComparison={showComparison}
+                  chartAnimationEnabled={chartAnimationEnabled}
+                  tooltipStyle={tooltipStyle}
+                  seriesColors={seriesColors}
+                  chartTokens={chartTokens}
+                  successLegendEntries={successLegendEntries}
+                  capitalLegendEntries={capitalLegendEntries}
+                  isLoading={isLoading}
+                />
+              </Suspense>
             </Card>
 
             {/* Org Summary */}

--- a/src/pages/AnalyticsCharts.tsx
+++ b/src/pages/AnalyticsCharts.tsx
@@ -1,0 +1,243 @@
+/**
+ * AnalyticsCharts — lazily loaded chart subtree.
+ * All recharts imports are confined to this module so the recharts vendor
+ * chunk stays out of the eager Analytics bundle path.
+ */
+import {
+  LineChart, Line, AreaChart, Area, BarChart, Bar,
+  PieChart, Pie, Cell,
+  XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+} from 'recharts'
+import { ChartLegend, type ChartLegendEntry } from '../components/ChartLegend'
+import type { AnalyticsSeriesColors, AnalyticsChartTokens } from './analyticsTheme'
+
+// ─── Local helpers ────────────────────────────────────────────────────────────
+
+function SkeletonBox({ height = 220 }: { height?: number }) {
+  return (
+    <div
+      data-testid="chart-skeleton"
+      style={{
+        height,
+        background: 'var(--border)',
+        borderRadius: 'var(--radius)',
+        animation: 'disciplr-pulse 1.5s ease-in-out infinite',
+      }}
+    />
+  )
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div
+      data-testid="analytics-empty-state"
+      role="status"
+      style={{
+        padding: '2.5rem',
+        textAlign: 'center',
+        color: 'var(--muted)',
+        border: '1px dashed var(--border)',
+        borderRadius: 'var(--radius)',
+      }}
+    >
+      <div style={{ fontSize: '2rem', marginBottom: '0.5rem' }}>📊</div>
+      <div style={{ fontSize: '0.9rem' }}>{message}</div>
+    </div>
+  )
+}
+
+function Card({ children, style = {} }: { children: React.ReactNode; style?: React.CSSProperties }) {
+  return (
+    <div style={{
+      background: 'var(--surface)',
+      border: '1px solid var(--border)',
+      borderRadius: 'var(--radius)',
+      padding: '1.5rem',
+      ...style,
+    }}>
+      {children}
+    </div>
+  )
+}
+
+function ChartTitle({ children }: { children: React.ReactNode }) {
+  return <h3 style={{ fontSize: '1rem', fontWeight: 600, margin: '0 0 1.25rem 0' }}>{children}</h3>
+}
+
+function ChartSummary({ children }: { children: React.ReactNode }) {
+  return <p className="sr-only">{children}</p>
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type PeriodRow = {
+  name: string
+  success: number
+  failed: number
+  capital: number
+  milestones: number
+  prevSuccess?: number
+  prevCapital?: number
+}
+
+export type AnalyticsChartsProps = {
+  /** Which chart island to render */
+  section: 'performance' | 'donut' | 'team'
+  displayData: PeriodRow[]
+  chartData: PeriodRow[]
+  period: string
+  vaultStatusData: { name: string; value: number }[]
+  teamChartData: { name: string; rate: number }[]
+  showComparison: boolean
+  chartAnimationEnabled: boolean
+  tooltipStyle: object
+  seriesColors: AnalyticsSeriesColors
+  chartTokens: AnalyticsChartTokens
+  successLegendEntries: ChartLegendEntry[]
+  capitalLegendEntries: ChartLegendEntry[]
+  isLoading: boolean
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function AnalyticsCharts({
+  section, displayData, chartData, period, vaultStatusData, teamChartData,
+  showComparison, chartAnimationEnabled, tooltipStyle,
+  seriesColors, chartTokens, successLegendEntries, capitalLegendEntries,
+  isLoading,
+}: AnalyticsChartsProps) {
+  const hasChartData = chartData.length > 0
+  const emptyMsg = `No data for this period (${period}).`
+
+  if (section === 'performance') {
+    return (
+      <div className="chart-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '1.25rem' }}>
+
+        {/* Success Rate */}
+        <Card>
+          <ChartTitle>Success Rate Over Time</ChartTitle>
+          <ChartSummary>
+            Line chart summarizing success and failure percentages for the selected {period} period.
+            {showComparison ? ' Previous period success rate is included for comparison.' : ''}
+          </ChartSummary>
+          {isLoading ? <SkeletonBox /> : !hasChartData ? <EmptyState message={emptyMsg} /> : (
+            <>
+              <ResponsiveContainer width="100%" height={220}>
+                <LineChart data={displayData}>
+                  <CartesianGrid strokeDasharray="3 3" stroke={seriesColors.grid} vertical={false} />
+                  <XAxis dataKey="name" stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} />
+                  <YAxis stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} unit="%" />
+                  <Tooltip {...tooltipStyle} />
+                  <Line type="monotone" dataKey="success" stroke={seriesColors.success} strokeWidth={2.5} dot={{ r: 3, fill: seriesColors.success }} name="This Period %" isAnimationActive={chartAnimationEnabled} />
+                  <Line type="monotone" dataKey="failed" stroke={seriesColors.failed} strokeWidth={2} dot={{ r: 2, fill: seriesColors.failed }} name="Failed %" strokeDasharray="4 2" isAnimationActive={chartAnimationEnabled} />
+                  {showComparison && (
+                    <Line type="monotone" dataKey="prevSuccess" stroke={seriesColors.comparison} strokeWidth={1.5} dot={false} name="Prev Period %" strokeDasharray="6 3" isAnimationActive={chartAnimationEnabled} />
+                  )}
+                </LineChart>
+              </ResponsiveContainer>
+              {showComparison && (
+                <ChartLegend entries={successLegendEntries} colors={seriesColors} tokens={chartTokens} />
+              )}
+            </>
+          )}
+        </Card>
+
+        {/* Capital Locked */}
+        <Card>
+          <ChartTitle>Capital Locked Over Time</ChartTitle>
+          <ChartSummary>
+            Area chart showing USDC capital locked over the selected {period} period.
+            {showComparison ? ' Previous period capital is shown as a comparison area.' : ''}
+          </ChartSummary>
+          {isLoading ? <SkeletonBox /> : !hasChartData ? <EmptyState message={emptyMsg} /> : (
+            <>
+              <ResponsiveContainer width="100%" height={220}>
+                <AreaChart data={displayData}>
+                  <defs>
+                    <linearGradient id="capGrad" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor={seriesColors.success} stopOpacity={0.25} />
+                      <stop offset="95%" stopColor={seriesColors.success} stopOpacity={0} />
+                    </linearGradient>
+                    <linearGradient id="prevCapGrad" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor={seriesColors.comparison} stopOpacity={0.15} />
+                      <stop offset="95%" stopColor={seriesColors.comparison} stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke={seriesColors.grid} vertical={false} />
+                  <XAxis dataKey="name" stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} />
+                  <YAxis stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} />
+                  <Tooltip {...tooltipStyle} />
+                  <Area type="monotone" dataKey="capital" stroke={seriesColors.success} strokeWidth={2.5} fill="url(#capGrad)" name="USDC Locked" isAnimationActive={chartAnimationEnabled} />
+                  {showComparison && (
+                    <Area type="monotone" dataKey="prevCapital" stroke={seriesColors.comparison} strokeWidth={1.5} fill="url(#prevCapGrad)" name="Prev Period" strokeDasharray="5 3" isAnimationActive={chartAnimationEnabled} />
+                  )}
+                </AreaChart>
+              </ResponsiveContainer>
+              {showComparison && (
+                <ChartLegend entries={capitalLegendEntries} colors={seriesColors} tokens={chartTokens} />
+              )}
+            </>
+          )}
+        </Card>
+
+        {/* Milestone Trend */}
+        <Card>
+          <ChartTitle>Milestone Completion Trend</ChartTitle>
+          <ChartSummary>
+            Bar chart showing completed milestone counts for each point in the selected {period} period.
+          </ChartSummary>
+          {isLoading ? <SkeletonBox /> : !hasChartData ? <EmptyState message={emptyMsg} /> : (
+            <ResponsiveContainer width="100%" height={220}>
+              <BarChart data={chartData}>
+                <CartesianGrid strokeDasharray="3 3" stroke={seriesColors.grid} vertical={false} />
+                <XAxis dataKey="name" stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} />
+                <YAxis stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} />
+                <Tooltip {...tooltipStyle} />
+                <Bar dataKey="milestones" fill={seriesColors.milestone} radius={[4, 4, 0, 0]} name="Milestones Completed" isAnimationActive={chartAnimationEnabled} />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </Card>
+
+      </div>
+    )
+  }
+
+  if (section === 'donut') {
+    if (isLoading) return <SkeletonBox height={180} />
+    if (vaultStatusData.length === 0) return <EmptyState message="No data for this period." />
+    return (
+      <>
+        <ResponsiveContainer width="100%" height={180}>
+          <PieChart>
+            <Pie data={vaultStatusData} innerRadius={50} outerRadius={75} paddingAngle={4} dataKey="value" isAnimationActive={chartAnimationEnabled}>
+              {vaultStatusData.map((_, i) => (
+                <Cell key={i} fill={seriesColors.pie[i % seriesColors.pie.length]} />
+              ))}
+            </Pie>
+            <Tooltip {...tooltipStyle} />
+          </PieChart>
+        </ResponsiveContainer>
+        <div style={{ display: 'flex', justifyContent: 'center', gap: '1.25rem', marginTop: '0.5rem' }}>
+          {vaultStatusData.map((entry, i) => (
+            <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', fontSize: '0.8rem', color: 'var(--muted)' }}>
+              <span style={{ width: 9, height: 9, borderRadius: '50%', background: seriesColors.pie[i], display: 'inline-block' }} />
+              {entry.name} ({entry.value})
+            </div>
+          ))}
+        </div>
+      </>
+    )
+  }
+
+  // section === 'team'
+  return (
+    <ResponsiveContainer width="100%" height={160}>
+      <BarChart data={teamChartData}>
+        <XAxis dataKey="name" stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} />
+        <YAxis stroke={seriesColors.axis} tick={{ fill: seriesColors.axis, fontSize: 11 }} unit="%" />
+        <Bar dataKey="rate" fill={seriesColors.success} radius={[4, 4, 0, 0]} isAnimationActive={chartAnimationEnabled} />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/pages/__tests__/Analytics.test.tsx
+++ b/src/pages/__tests__/Analytics.test.tsx
@@ -1,8 +1,9 @@
 import { Suspense, lazy } from 'react'
 import { describe, expect, it, vi, beforeAll } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { buildAnalyticsSeriesColors } from '../analyticsTheme'
+import Analytics, { analyticsPeriodData } from '../Analytics'
 
 // ── Browser API stubs (jsdom doesn't implement these) ───────────────────────
 
@@ -191,7 +192,7 @@ describe('Analytics lazy route', () => {
     expect(screen.getByText('Prev Period')).toBeInTheDocument()
   })
 
-  it('shows a no-data placeholder for empty periods and restores charts when switching to populated periods', () => {
+  it('shows a no-data placeholder for empty periods and restores charts when switching to populated periods', async () => {
     const original90d = analyticsPeriodData['90d']
     analyticsPeriodData['90d'] = []
 
@@ -202,17 +203,26 @@ describe('Analytics lazy route', () => {
         </MemoryRouter>,
       )
 
-      fireEvent.click(screen.getByRole('button', { name: '90d' }))
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: '90d' }))
+      })
 
-      expect(screen.getAllByTestId('analytics-empty-state')).toHaveLength(3)
+      await waitFor(() =>
+        expect(screen.getAllByTestId('analytics-empty-state')).toHaveLength(3),
+        { timeout: 2000 },
+      )
       expect(screen.getAllByText('No data for this period (90d).')).toHaveLength(3)
 
-      fireEvent.click(screen.getByRole('button', { name: '30d' }))
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: '30d' }))
+      })
 
-      expect(screen.queryByTestId('analytics-empty-state')).not.toBeInTheDocument()
-      expect(screen.getByText('Success Rate Over Time')).toBeInTheDocument()
-      expect(screen.getByText('Capital Locked Over Time')).toBeInTheDocument()
-      expect(screen.getByText('Milestone Completion Trend')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.queryByTestId('analytics-empty-state')).not.toBeInTheDocument()
+        expect(screen.getByText('Success Rate Over Time')).toBeInTheDocument()
+        expect(screen.getByText('Capital Locked Over Time')).toBeInTheDocument()
+        expect(screen.getByText('Milestone Completion Trend')).toBeInTheDocument()
+      }, { timeout: 2000 })
     } finally {
       analyticsPeriodData['90d'] = original90d
     }


### PR DESCRIPTION
perf: lazy-load recharts subtree behind Suspense in Analytics
  
  Summary
  
  Analytics.tsx was statically importing the entire recharts surface, pulling the
  charting library into the Analytics chunk on every page load. This PR moves all
  recharts JSX into a new lazily-loaded module so the vendor-recharts chunk is only
  fetched when the Analytics page is actually visited.
  
  Changes
  
  - src/pages/AnalyticsCharts.tsx (new) — contains all recharts imports and renders
  three chart islands (section="performance", section="donut", section="team") driven
  by props passed from the parent.
  - src/pages/Analytics.tsx — removed all recharts imports; added React.lazy +
  Suspense with a skeleton fallback around each chart island.
  - src/pages/__tests__/Analytics.test.tsx — added missing
  analyticsPeriodData/Analytics imports; updated empty-state test to use waitFor/act
   for the lazy boundary; all 6 tests pass.
  - docs/BUNDLE_BUDGET.md — added AnalyticsCharts (lazy) budget row and lazy-loading
  strategy note.
  
  Verified
  
  - grep "recharts" src/pages/Analytics.tsx → no matches (recharts off the eager
  path)
  - All 6 Analytics tests pass
  - Pre-existing failures in unrelated test files are unchanged

closes #500