### PR TITLE
a11y: accessible names and non-color urgency cues for VerifierDashboard

### DIFF
--- a/src/pages/VerifierDashboard.tsx
+++ b/src/pages/VerifierDashboard.tsx
@@ -41,14 +41,14 @@ export default function VerifierDashboard() {
       <section className="flex gap-4 mt-4">
         <button
           onClick={() => navigate('/verifier/queue')}
-          className="px-6 py-3 font-medium rounded transition"
+          className="px-6 py-3 font-medium rounded transition focus-visible:outline focus-visible:outline-[var(--focus-ring-width)] focus-visible:outline-offset-[var(--focus-ring-offset)] focus-visible:outline-[var(--focus-ring-color)]"
           style={{ background: 'var(--accent)', color: 'white' }}
         >
           View Pending Queue
         </button>
         <button
           onClick={() => navigate('/verifier/history')}
-          className="px-6 py-3 border font-medium rounded transition"
+          className="px-6 py-3 border font-medium rounded transition focus-visible:outline focus-visible:outline-[var(--focus-ring-width)] focus-visible:outline-offset-[var(--focus-ring-offset)] focus-visible:outline-[var(--focus-ring-color)]"
           style={{ borderColor: 'var(--border)', color: 'var(--text)', background: 'transparent' }}
         >
           View History
@@ -82,11 +82,18 @@ export default function VerifierDashboard() {
                     className="font-bold"
                     style={{ color: task.daysRemaining <= 3 ? 'var(--danger)' : 'var(--text)' }}
                   >
+                    {task.daysRemaining <= 3 && (
+                      <span aria-hidden="true">⚠ </span>
+                    )}
                     {task.daysRemaining} days left
+                    {task.daysRemaining <= 3 && (
+                      <span className="sr-only"> (urgent)</span>
+                    )}
                   </Text>
                   <button
                     onClick={() => navigate(`/verifier/queue/${task.id}`)}
-                    className="font-medium text-sm mt-2 transition"
+                    aria-label={`Review ${task.vaultName}`}
+                    className="font-medium text-sm mt-2 transition focus-visible:outline focus-visible:outline-[var(--focus-ring-width)] focus-visible:outline-offset-[var(--focus-ring-offset)] focus-visible:outline-[var(--focus-ring-color)]"
                     style={{ color: 'var(--accent)' }}
                   >
                     Review Now &rarr;
@@ -127,7 +134,8 @@ export default function VerifierDashboard() {
                   </Text>
                   <button
                     onClick={() => navigate('/verifier/history')}
-                    className="font-medium text-sm mt-2 transition text-left md:text-right"
+                    aria-label={`View ${task.vaultName} in History`}
+                    className="font-medium text-sm mt-2 transition text-left md:text-right focus-visible:outline focus-visible:outline-[var(--focus-ring-width)] focus-visible:outline-offset-[var(--focus-ring-offset)] focus-visible:outline-[var(--focus-ring-color)]"
                     style={{ color: 'var(--accent)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
                   >
                     View in History &rarr;

--- a/src/pages/__tests__/VerifierDashboard.test.tsx
+++ b/src/pages/__tests__/VerifierDashboard.test.tsx
@@ -124,19 +124,19 @@ describe('VerifierDashboard', () => {
 
   it('shows days remaining for each task', () => {
     renderPage();
-    expect(screen.getByText('10 days left')).toBeInTheDocument();
-    expect(screen.getByText('2 days left')).toBeInTheDocument();
+    expect(screen.getByText(/10 days left/)).toBeInTheDocument();
+    expect(screen.getByText(/2 days left/)).toBeInTheDocument();
   });
 
   it('applies danger color for tasks with 3 or fewer days remaining', () => {
     renderPage();
-    const urgentText = screen.getByText('2 days left');
+    const urgentText = screen.getByText(/2 days left/);
     expect(urgentText.getAttribute('style')).toContain('var(--danger)');
   });
 
   it('applies text color for tasks with more than 3 days remaining', () => {
     renderPage();
-    const normalText = screen.getByText('10 days left');
+    const normalText = screen.getByText(/10 days left/);
     expect(normalText.getAttribute('style')).toContain('var(--text)');
   });
 
@@ -145,6 +145,36 @@ describe('VerifierDashboard', () => {
     const reviewButtons = screen.getAllByText('Review Now →');
     fireEvent.click(reviewButtons[0]);
     expect(mockNavigate).toHaveBeenCalledWith('/verifier/queue/v-1');
+  });
+
+  it('gives each Review Now button an accessible name including the vault name', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: 'Review Alpha Vault' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Review Beta Vault' })).toBeInTheDocument();
+  });
+
+  it('shows urgency text (not just color) for tasks with 3 or fewer days remaining', () => {
+    renderPage();
+    const urgentContainer = screen.getByText(/2 days left/) as HTMLElement;
+    expect(urgentContainer.textContent).toContain('(urgent)');
+  });
+
+  it('does not show urgency text for tasks with more than 3 days remaining', () => {
+    renderPage();
+    const normalContainer = screen.getByText(/10 days left/) as HTMLElement;
+    expect(normalContainer.textContent).not.toContain('(urgent)');
+  });
+
+  it('Review Now buttons have focus-visible outline class', () => {
+    renderPage();
+    const btn = screen.getByRole('button', { name: 'Review Alpha Vault' });
+    expect(btn.className).toContain('focus-visible:outline');
+  });
+
+  it('nav buttons have focus-visible outline class', () => {
+    renderPage();
+    expect(screen.getByText('View Pending Queue').className).toContain('focus-visible:outline');
+    expect(screen.getByText('View History').className).toContain('focus-visible:outline');
   });
 
   it('uses design tokens for stat cards', () => {
@@ -195,9 +225,20 @@ describe('VerifierDashboard', () => {
 
     it('navigates to history page when View in History is clicked', () => {
       renderPage();
-      const viewHistoryBtn = screen.getByRole('button', { name: 'View in History →' });
+      const viewHistoryBtn = screen.getByRole('button', { name: 'View Gamma Vault in History' });
       fireEvent.click(viewHistoryBtn);
       expect(mockNavigate).toHaveBeenCalledWith('/verifier/history');
+    });
+
+    it('gives each View in History button an accessible name including the vault name', () => {
+      renderPage();
+      expect(screen.getByRole('button', { name: 'View Gamma Vault in History' })).toBeInTheDocument();
+    });
+
+    it('View in History buttons have focus-visible outline class', () => {
+      renderPage();
+      const btn = screen.getByRole('button', { name: 'View Gamma Vault in History' });
+      expect(btn.className).toContain('focus-visible:outline');
     });
 
     it('renders a maximum of 5 recent decisions', () => {


### PR DESCRIPTION
- Add aria-label to Review Now buttons: 'Review <VaultName>'
- Add aria-label to View in History buttons: 'View <VaultName> in History'
- Add ⚠ icon + sr-only '(urgent)' text for tasks with ≤3 days remaining
- Add focus-visible outline classes to all interactive buttons

Closes #498