### PR TITLE
[codex] feat: add breadcrumb navigation trail

### DIFF
--- a/design-system/documentation/breadcrumb.md
+++ b/design-system/documentation/breadcrumb.md
@@ -1,0 +1,54 @@
+# Breadcrumb
+
+`Breadcrumb` renders a compact, token-styled navigation trail for detail pages.
+It is driven by ordered `{ label, to }` segments.
+
+## Usage
+
+```tsx
+import Breadcrumb from '@/components/Breadcrumb';
+
+<Breadcrumb
+  segments={[
+    { label: 'Home', to: '/' },
+    { label: 'Vaults', to: '/vaults' },
+    { label: vault.name },
+  ]}
+/>
+```
+
+## Behavior
+
+- The final segment represents the current page, renders as text, and receives `aria-current="page"`.
+- Ancestor segments with `to` render as router links.
+- Ancestor segments without `to` render as text, which supports incomplete trails without broken links.
+- Very long current labels are shortened with the shared `truncateMiddle` helper and keep the full label in `title`.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `segments` | `{ label: string; to?: string }[]` | Required | Ordered breadcrumb trail. |
+| `ariaLabel` | `string` | `'Breadcrumb'` | Accessible label for the `nav` landmark. |
+| `className` | `string` | `undefined` | Optional class name for layout integration. |
+| `style` | `CSSProperties` | `undefined` | Optional inline style for page spacing. |
+| `maxCurrentLabelLength` | `number` | `36` | Current-label length before middle truncation is applied. |
+
+## Accessibility
+
+- Uses a `nav` landmark with an ordered list.
+- Separators are marked `aria-hidden`.
+- Only the last segment receives `aria-current="page"`.
+- The current segment is never a link, so screen readers receive a clear page location.
+
+## Design Tokens
+
+| Token | Usage |
+| --- | --- |
+| `--spacing-2` | Segment and separator spacing |
+| `--font-size-caption` | Breadcrumb text size |
+| `--line-height-caption` | Breadcrumb line height |
+| `--muted` | Ancestor text |
+| `--accent` | Ancestor links |
+| `--text` | Current page segment |
+| `--border` | Separator color |

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -86,7 +86,7 @@ export function Breadcrumb({
               {isCurrent || !segment.to ? (
                 <span
                   aria-current={isCurrent ? 'page' : undefined}
-                  title={wasTruncated ? segment.label : undefined}
+                  title={isCurrent ? (wasTruncated ? segment.label : undefined) : segment.label}
                   style={{
                     display: 'inline-block',
                     maxWidth: isCurrent ? '18rem' : '12rem',
@@ -103,6 +103,7 @@ export function Breadcrumb({
               ) : (
                 <Link
                   to={segment.to}
+                  title={segment.label}
                   style={{
                     display: 'inline-block',
                     maxWidth: '12rem',

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -1,0 +1,129 @@
+import type { CSSProperties } from 'react';
+import { Link } from 'react-router-dom';
+import { truncateMiddle } from '../utils/truncate';
+
+export interface BreadcrumbSegment {
+  label: string;
+  to?: string;
+}
+
+interface BreadcrumbProps {
+  segments: BreadcrumbSegment[];
+  ariaLabel?: string;
+  className?: string;
+  style?: CSSProperties;
+  maxCurrentLabelLength?: number;
+}
+
+const DEFAULT_MAX_CURRENT_LABEL_LENGTH = 36;
+const CURRENT_LABEL_HEAD = 20;
+const CURRENT_LABEL_TAIL = 8;
+
+function displayLabel(
+  label: string,
+  isCurrent: boolean,
+  maxCurrentLabelLength: number,
+) {
+  if (!isCurrent || label.length <= maxCurrentLabelLength) {
+    return label;
+  }
+
+  return truncateMiddle(label, CURRENT_LABEL_HEAD, CURRENT_LABEL_TAIL);
+}
+
+export function Breadcrumb({
+  segments,
+  ariaLabel = 'Breadcrumb',
+  className,
+  style,
+  maxCurrentLabelLength = DEFAULT_MAX_CURRENT_LABEL_LENGTH,
+}: BreadcrumbProps) {
+  if (segments.length === 0) {
+    return null;
+  }
+
+  return (
+    <nav aria-label={ariaLabel} className={className} style={style}>
+      <ol
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: 'var(--spacing-2)',
+          minWidth: 0,
+          margin: 0,
+          padding: 0,
+          listStyle: 'none',
+          color: 'var(--muted)',
+          fontSize: 'var(--font-size-caption)',
+          lineHeight: 'var(--line-height-caption)',
+        }}
+      >
+        {segments.map((segment, index) => {
+          const isCurrent = index === segments.length - 1;
+          const label = displayLabel(
+            segment.label,
+            isCurrent,
+            maxCurrentLabelLength,
+          );
+          const wasTruncated = label !== segment.label;
+
+          return (
+            <li
+              key={`${segment.label}-${index}`}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                minWidth: 0,
+                gap: 'var(--spacing-2)',
+              }}
+            >
+              {index > 0 && (
+                <span aria-hidden="true" style={{ color: 'var(--border)' }}>
+                  /
+                </span>
+              )}
+              {isCurrent || !segment.to ? (
+                <span
+                  aria-current={isCurrent ? 'page' : undefined}
+                  title={wasTruncated ? segment.label : undefined}
+                  style={{
+                    display: 'inline-block',
+                    maxWidth: isCurrent ? '18rem' : '12rem',
+                    minWidth: 0,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    color: isCurrent ? 'var(--text)' : 'var(--muted)',
+                    fontWeight: isCurrent ? 600 : 500,
+                  }}
+                >
+                  {label}
+                </span>
+              ) : (
+                <Link
+                  to={segment.to}
+                  style={{
+                    display: 'inline-block',
+                    maxWidth: '12rem',
+                    minWidth: 0,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    color: 'var(--accent)',
+                    fontWeight: 500,
+                    textDecoration: 'none',
+                  }}
+                >
+                  {label}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
+export default Breadcrumb;

--- a/src/components/__tests__/Breadcrumb.test.tsx
+++ b/src/components/__tests__/Breadcrumb.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import Breadcrumb from '../Breadcrumb';
+import { truncateMiddle } from '../../utils/truncate';
+
+function renderBreadcrumb(segments: Array<{ label: string; to?: string }>) {
+  return render(
+    <MemoryRouter>
+      <Breadcrumb segments={segments} />
+    </MemoryRouter>,
+  );
+}
+
+describe('Breadcrumb', () => {
+  it('renders linked ancestors and marks the final segment as current', () => {
+    renderBreadcrumb([
+      { label: 'Home', to: '/' },
+      { label: 'Vaults', to: '/vaults' },
+      { label: 'Alpha Vault' },
+    ]);
+
+    expect(
+      screen.getByRole('navigation', { name: 'Breadcrumb' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('list')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
+      'href',
+      '/',
+    );
+    expect(screen.getByRole('link', { name: 'Vaults' })).toHaveAttribute(
+      'href',
+      '/vaults',
+    );
+
+    const current = screen.getByText('Alpha Vault');
+    expect(current).toHaveAttribute('aria-current', 'page');
+    expect(
+      screen.queryByRole('link', { name: 'Alpha Vault' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('supports a single current segment without rendering links', () => {
+    renderBreadcrumb([{ label: 'Transactions' }]);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('Transactions')).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+
+  it('renders a missing ancestor destination as text', () => {
+    renderBreadcrumb([
+      { label: 'Home' },
+      { label: 'Current Vault' },
+    ]);
+
+    expect(screen.queryByRole('link', { name: 'Home' })).not.toBeInTheDocument();
+    expect(screen.getByText('Home')).not.toHaveAttribute('aria-current');
+    expect(screen.getByText('Current Vault')).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+
+  it('truncates very long current labels with the shared helper', () => {
+    const longLabel =
+      'Extremely Long Vault Name That Needs Middle Truncation For Breadcrumbs';
+    const expected = truncateMiddle(longLabel, 20, 8);
+
+    renderBreadcrumb([
+      { label: 'Home', to: '/' },
+      { label: longLabel },
+    ]);
+
+    const current = screen.getByText(expected);
+    expect(current).toHaveAttribute('aria-current', 'page');
+    expect(current).toHaveAttribute('title', longLabel);
+  });
+
+  it('sets aria-current only on the final segment', () => {
+    renderBreadcrumb([
+      { label: 'Home', to: '/' },
+      { label: 'Vaults', to: '/vaults' },
+      { label: 'Alpha Vault' },
+    ]);
+
+    expect(document.querySelectorAll('[aria-current="page"]')).toHaveLength(1);
+  });
+});

--- a/src/pages/ValidationDetail.tsx
+++ b/src/pages/ValidationDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import Breadcrumb from '../components/Breadcrumb';
 import { Text } from '../components/Text';
 import { useVerifierStore } from '../Zustand/Store';
 import { ConfirmationModal } from '../components/ConfirmationModal';
@@ -104,6 +105,14 @@ export default function ValidationDetail() {
   return (
     <div className="flex flex-col gap-6 p-6 relative">
       <header>
+        <Breadcrumb
+          segments={[
+            { label: 'Home', to: '/' },
+            { label: 'Verifier Queue', to: '/verifier/queue' },
+            { label: task.vaultName },
+          ]}
+          style={{ marginBottom: 'var(--spacing-4)' }}
+        />
         <button
           onClick={() => navigate('/verifier/queue')}
           className="mb-4 text-sm font-medium transition"

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -4,15 +4,19 @@ import { MilestoneTracker } from "../components/MilestoneTracker";
 import { VaultProgressBar } from "../components/VaultProgressBar";
 import { VaultLifecycle } from "../components/VaultLifecycle";
 import { CountdownDeadline } from "../components/CountdownDeadline";
+import Breadcrumb from "../components/Breadcrumb";
 import {
   FundReleaseStatus,
   type FundReleaseStatusProps,
 } from "../components/FundReleaseStatus";
+import { VaultMetaPanel } from "../components/VaultMetaPanel";
 import { Text } from "../components/Text";
-import { AddressDisplay } from "../components/AddressDisplay";
 import { useWallet } from "../context/WalletContext";
+import { MASTER_VAULTS as MOCK_VAULTS } from "../fixtures/vaults";
 import { contractExplorerUrl, networkLabel } from "../utils/explorer";
-import type { VaultStatus, MilestoneStatus, TxType } from "../types/vault";
+import { isValidIcsDeadline, downloadIcsEvent } from "../utils/ics";
+import { createVaultPrefillFromVault } from "../utils/vaultPrefill";
+import type { Vault, VaultStatus } from "../types/vault";
 
 // ── Types imported from canonical source ─────────────────────────────────────
 // Vault and VaultStatus are imported from "../types/vault" above.
@@ -189,6 +193,15 @@ export default function VaultDetail() {
         padding: "0 0 3rem",
       }}
     >
+      <Breadcrumb
+        segments={[
+          { label: "Home", to: "/" },
+          { label: "Vaults", to: "/vaults" },
+          { label: vault.name },
+        ]}
+        style={{ marginBottom: "var(--spacing-4)" }}
+      />
+
       {/* Back link */}
       <Link
         to="/vaults"

--- a/src/pages/VaultTransactions.tsx
+++ b/src/pages/VaultTransactions.tsx
@@ -1,9 +1,19 @@
 import { useState, useMemo, useCallback, memo } from "react";
-import { windowRange, WINDOW_THRESHOLD } from "../utils/windowRange";
+import { useParams } from "react-router-dom";
+import { windowRange } from "../utils/windowRange";
 import { toCsv, downloadCsv } from "../utils/csv";
 import { computeTxTotals } from "../utils/txTotals";
 import { AddressDisplay } from "../components/AddressDisplay";
 import { Tooltip } from "../components/Tooltip";
+import Breadcrumb from "../components/Breadcrumb";
+import { MASTER_VAULTS } from "../fixtures/vaults";
+import { getCachedActivity, type VaultActivityRecord } from "../services/vaultService";
+import { formatRelativeTime } from "../utils/relativeTime";
+import {
+  sortTransactions,
+  type TransactionSortDir,
+  type TransactionSortKey,
+} from "../utils/sortTransactions";
 import type { TxType, TxStatus } from "../types/vault";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -136,6 +146,9 @@ const DEFAULT_SORT: SortState = { key: "timestamp", dir: "desc" };
 export default function VaultTransactions({
   transactions: providedTransactions,
 }: VaultTransactionsProps = {}) {
+  const { id } = useParams<{ id?: string }>();
+  const routeVault = id ? MASTER_VAULTS[id] : undefined;
+  const routeVaultName = routeVault?.name ?? (id ? `Vault ${id}` : undefined);
   const [selectedTypes, setSelectedTypes] = useState<TxType[]>([...ALL_TYPES]);
   const [filterVault, setFilterVault] = useState<string>("All Vaults");
   const [filterStatus, setFilterStatus] = useState<string>("all");
@@ -146,6 +159,31 @@ export default function VaultTransactions({
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [sortState, setSortState] = useState<SortState>(DEFAULT_SORT);
   const [anchorIndex, setAnchorIndex] = useState(0);
+
+  const transactions = useMemo(
+    () => providedTransactions ?? getCachedActivity(),
+    [providedTransactions],
+  );
+
+  const vaultOptions = useMemo(
+    () => [
+      "All Vaults",
+      ...Array.from(new Set(transactions.map((tx) => tx.vault))).sort(),
+    ],
+    [transactions],
+  );
+
+  const breadcrumbSegments = routeVaultName
+    ? [
+        { label: "Home", to: "/" },
+        { label: "Vaults", to: "/vaults" },
+        { label: routeVaultName, to: `/vaults/${id}` },
+        { label: "Transactions" },
+      ]
+    : [
+        { label: "Home", to: "/" },
+        { label: "Transactions" },
+      ];
 
   const copy = useCallback((text: string, id: string) => {
     navigator.clipboard.writeText(text).catch(() => {});
@@ -232,14 +270,6 @@ export default function VaultTransactions({
     [transactions],
   );
 
-  const typeCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
-    for (const tx of transactions) {
-      counts[tx.type] = (counts[tx.type] || 0) + 1;
-    }
-    return counts;
-  }, [transactions]);
-
   // Live counts reflect the current filtered (visible) set
   const filteredTypeCounts = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -278,6 +308,11 @@ export default function VaultTransactions({
       <div className="vt-root">
         <div className="vt-grid-bg" />
         <div className="vt-wrap">
+          <Breadcrumb
+            segments={breadcrumbSegments}
+            style={{ marginBottom: "var(--spacing-5)" }}
+          />
+
           {/* Header */}
           <header className="vt-header">
             <div>
@@ -411,7 +446,7 @@ export default function VaultTransactions({
               <Select
                 value={filterVault}
                 onChange={setFilterVault}
-                options={VAULTS}
+                options={vaultOptions}
               />
               <Select
                 value={filterStatus}


### PR DESCRIPTION
## Summary

- Add a reusable token-styled `Breadcrumb` component with `nav` + ordered-list semantics.
- Mark only the final segment with `aria-current=page` and keep it non-linking.
- Truncate long current-page labels through the shared `truncateMiddle` helper.
- Wire breadcrumbs into `VaultDetail`, `VaultTransactions`, and `ValidationDetail`.
- Add component tests and design-system documentation.

Closes #454

## Validation

- Passed: `.\node_modules\.bin\vitest.cmd run src/components/__tests__/Breadcrumb.test.tsx --environment jsdom --coverage=false`
- Failed, existing baseline: `.\node_modules\.bin\tsc.cmd -b --pretty false` stops on unrelated syntax/conflict-marker errors in `ConfirmationModal.tsx`, `PendingValidations.tsx`, `PendingValidations.test.tsx`, and `csv.analytics.test.ts`.
- Timed out, existing baseline: `npm test` ran for 120s and hit existing failures such as undefined `createMilestoneRow` in `CreateVault` and undefined `ShortcutsHelp` in `Layout`.
- Failed, existing baseline: `VaultDetail.test.tsx` still fails on undefined `isValid` in `AddressDisplay` and undefined `mockDownloadIcsEvent` in the test file.