### PR TITLE
feat(design-system): add getTokenValue resolver for component token consumption

### DIFF
--- a/design-system/src/__tests__/token-resolver.test.ts
+++ b/design-system/src/__tests__/token-resolver.test.ts
@@ -1,0 +1,57 @@
+import { getTokenValue } from "../utils/token-loader";
+import { DesignTokens } from "../types/tokens";
+
+const tokens: DesignTokens = {
+  color: {
+    brand: {
+      primary: { $type: "color", $value: "#1d4ed8" },
+      secondary: { $type: "color", $value: "#9333ea" },
+    },
+    feedback: {
+      ok: { $type: "color", $value: "#10b981" },
+      danger: { $type: "color", $value: "#ef4444" },
+    },
+  },
+  spacing: {
+    md: { $type: "dimension", $value: "16px" },
+  },
+  contrast: {
+    pair: { light: 4.5, dark: 7.2 },
+  },
+} as unknown as DesignTokens;
+
+describe("getTokenValue", () => {
+  it("returns the $value of a leaf token at a known path", () => {
+    expect(getTokenValue(tokens, "color.brand.primary")).toBe("#1d4ed8");
+  });
+
+  it("returns undefined when an intermediate sub-property doesn't exist", () => {
+    // The token has no `contrast` field, so walking past $value returns undefined.
+    expect(getTokenValue(tokens, "color.brand.primary.contrast")).toBeUndefined();
+  });
+
+  it("returns the $value of a different category", () => {
+    expect(getTokenValue(tokens, "spacing.md")).toBe("16px");
+  });
+
+  it("returns undefined for a missing intermediate segment", () => {
+    expect(getTokenValue(tokens, "color.unknown.primary")).toBeUndefined();
+    expect(getTokenValue(tokens, "totally.absent")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty path", () => {
+    expect(getTokenValue(tokens, "")).toBeUndefined();
+    expect(getTokenValue(tokens, ".")).toBeUndefined();
+    expect(getTokenValue(tokens, "...")).toBeUndefined();
+  });
+
+  it("does not throw on nullish segments or trailing dots", () => {
+    expect(() => getTokenValue(tokens, "color.brand.primary.")).not.toThrow();
+    expect(getTokenValue(tokens, "color.brand.primary.")).toBe("#1d4ed8");
+  });
+
+  it("returns the leaf object (not $value) when the path lands on a plain object", () => {
+    const result = getTokenValue(tokens, "contrast.pair");
+    expect(result).toEqual({ light: 4.5, dark: 7.2 });
+  });
+});

--- a/design-system/src/index.ts
+++ b/design-system/src/index.ts
@@ -5,5 +5,6 @@
 
 export * from './types/tokens';
 export * from './utils/token-loader';
+export { getTokenValue } from './utils/token-loader';
 export * from './utils/validators';
 export * from './utils/css-variables';

--- a/design-system/src/utils/token-loader.ts
+++ b/design-system/src/utils/token-loader.ts
@@ -40,3 +40,35 @@ export function getAllTokens(): DesignTokens {
   
   return allTokens;
 }
+
+
+/**
+ * Resolve a single token by its dotted path (e.g. "color.brand.primary").
+ * Returns the token's $value, or the value of a sub-property if a sub-path
+ * is provided (e.g. "color.brand.primary.contrast.light" returns the
+ * `contrast.light` numeric field).
+ *
+ * Returns `undefined` if any segment of the path is missing. Use this from
+ * component code to fetch individual tokens without re-walking the full
+ * tree.
+ */
+export function getTokenValue(
+  root: DesignTokens,
+  path: string,
+): unknown {
+  const parts = path.split(".").filter(Boolean);
+  if (parts.length === 0) return undefined;
+  let cursor: unknown = root;
+  for (const part of parts) {
+    if (cursor && typeof cursor === "object" && part in (cursor as Record<string, unknown>)) {
+      cursor = (cursor as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+  // If the final node is a token object with $value, return $value.
+  if (cursor && typeof cursor === "object" && "$value" in (cursor as Record<string, unknown>)) {
+    return (cursor as Record<string, unknown>).$value;
+  }
+  return cursor;
+}


### PR DESCRIPTION
## Summary
Adds a small `getTokenValue(root, path)` helper to `design-system/src/utils/token-loader.ts` that takes a dotted path (e.g. `"color.brand.primary"` or `"spacing.md"`) and returns the token's `$value` (or the leaf object if the path lands on a non-token object). Unknown paths return `undefined` without throwing. The function is re-exported from the design-system barrel so components can do:

```ts
import { getTokenValue } from "@design-system";
const primary = getTokenValue(allTokens, "color.brand.primary");
```

## Why
Components currently have to walk the full `DesignTokens` tree themselves to fetch a single value, which leaks the token shape into every consumer. The new helper centralises the lookup, handles missing segments defensively, and gives component code a stable, type-friendly API for reading tokens.

## Changes
- `design-system/src/utils/token-loader.ts`: add `getTokenValue()` function with full JSDoc.
- `design-system/src/index.ts`: re-export `getTokenValue` from the barrel.
- `design-system/src/__tests__/token-resolver.test.ts`: 7 new tests covering: leaf `$value`, missing intermediate, empty/dotted paths, trailing dot, leaf object (not `$value`), and a sanity check on a different category.

## Test Plan
- [x] `npm test -- src/__tests__/token-resolver` — 7/7 pass (verified locally before opening the PR)
- [x] `npm test` — full suite still passes (no test changes outside the new file)
- [x] No runtime call-site change in this PR; downstream consumers can adopt the resolver when they need it.

## Linked issue
Closes #310

Payout wallet (Stellar): `GBVHELLD2JE235Y2NGTDT3MWI3T65ON6SY4N6FBHYVDAQ5FZC2CP5QXH`
GrantFox OSS campaign — smart escrow payout on merge.